### PR TITLE
URL updater plugin – fix plugin updates

### DIFF
--- a/bin/run-server-dev.sh
+++ b/bin/run-server-dev.sh
@@ -8,6 +8,7 @@ npx @wp-playground/cli@latest \
     --mount=`pwd`/components:/wordpress/wp-content/components \
     --mount=`pwd`/plugins/data-liberation:/wordpress/wp-content/plugins/data-liberation \
     --mount=`pwd`/plugins/static-files-editor:/wordpress/wp-content/plugins/static-files-editor \
+    --mount=`pwd`/plugins/url-updater:/wordpress/wp-content/plugins/url-updater \
     --mount=`pwd`/plugins/git-repo:/wordpress/wp-content/plugins/git-repo \
     --mount=`pwd`/.my-notes-git:/wordpress/wp-content/uploads \
     --blueprint=./blueprint-dev.json

--- a/blueprint-dev.json
+++ b/blueprint-dev.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
 	"login": true,
 	"landingPage": "/wp-admin/edit.php?post_type=local_file",
 	"constants": {
@@ -14,6 +15,10 @@
 		{
 			"step": "activatePlugin",
 			"pluginPath": "static-files-editor/plugin.php"
+		},
+		{
+			"step": "activatePlugin",
+			"pluginPath": "url-updater/url-updater.php"
 		}
 	]
 }

--- a/components/Filesystem/LocalFilesystem.php
+++ b/components/Filesystem/LocalFilesystem.php
@@ -84,10 +84,12 @@ class LocalFilesystem implements Filesystem {
 	}
 
 	public function rename( $old_path, $new_path, $options = array() ) {
-		return rename(
-			$old_path,
-			$new_path
-		);
+		if ( false === rename( $old_path, $new_path ) ) {
+			throw new FilesystemException(
+				sprintf( 'Failed to rename: %s to %s', $old_path, $new_path )
+			);
+		}
+		return true;
 	}
 
 	public function copy_file( $from_path, $to_path, $options ) {

--- a/components/Zip/ZipFilesystem.php
+++ b/components/Zip/ZipFilesystem.php
@@ -86,6 +86,9 @@ class ZipFilesystem implements Filesystem {
 	}
 
 	public function is_dir( $path ) {
+		if('/' === $path) {
+			return true;
+		}
 		$this->load_central_directory();
 		$path = trim( $path, '/' ) . '/';
 		return isset( $this->central_directory[ $path ] ) && $this->central_directory[ $path ]->is_directory();

--- a/plugins/url-updater/update_plugin.php
+++ b/plugins/url-updater/update_plugin.php
@@ -23,7 +23,7 @@ class PluginUpdater {
         $this->wp_plugins_directory = LocalFilesystem::create(WP_PLUGIN_DIR);
 
         $this->installed_plugin_file = $installed_plugin_file;
-        $this->installed_plugin_dir = dirname(WP_PLUGIN_DIR . '/' . $installed_plugin_file);
+        $this->installed_plugin_dir = dirname($installed_plugin_file);
         $plugin_slug = basename($this->installed_plugin_dir);
 
         $this->installed_plugin_backup_dir = $plugin_slug . '_installed_backup_' . time();
@@ -53,11 +53,14 @@ class PluginUpdater {
                 $basename = basename($dir);
                 return $basename !== '__MACOSX' && $basename !== '.DS_Store';
             });
-			if(count($extracted_dirs) === 1 && $this->wp_plugins_directory->is_dir($extracted_dirs[0])) {
-            	return wp_join_paths($this->new_version_extract_to_dir, $extracted_dirs[0]);
-			} else {
-				return $this->new_version_extract_to_dir;
+			if(count($extracted_dirs) === 1) {
+				$potential_root_dir = wp_join_paths($this->new_version_extract_to_dir, $extracted_dirs[0]);
+				if($this->wp_plugins_directory->is_dir($potential_root_dir)) {
+					return $potential_root_dir;
+				}
 			}
+
+			return $this->new_version_extract_to_dir;
         } else if ($extension === 'php') {
             $plugin_name = basename($this->package_absolute_path, '.php');
             $this->wp_plugins_directory->mkdir($plugin_name);
@@ -85,36 +88,38 @@ class PluginUpdater {
 
             if ($this->was_plugin_active) {
                 $installed_plugin_files = get_plugins('/' . basename($this->installed_plugin_dir));
-                if (!empty($installed_plugin_files)) {
-                    $this->installed_plugin_file = key($installed_plugin_files);
-                } else {
+                if (empty($installed_plugin_files)) {
                     throw new Exception("No valid plugin file found in the new plugin directory");
                 }
-                activate_plugin($this->installed_plugin_file);
+				$this->installed_plugin_file = wp_join_paths($this->installed_plugin_dir, key($installed_plugin_files));
             }
 
+            $this->cleanup();
             return $this->installed_plugin_file;
         } catch (Exception $e) {
-            return new WP_Error('plugin_upgrade_error', $e->getMessage());
-        } finally {
             $this->cleanup();
+			echo '<plaintext>';
+			echo $e->getMessage();
+			echo $e->getTraceAsString();
+			die();
+            return new WP_Error('plugin_upgrade_error', $e->getMessage());
         }
     }
 
     private function cleanup() {
         if ($this->wp_plugins_directory->exists($this->installed_plugin_backup_dir)) {
-            $this->wp_plugins_directory->copy($this->installed_plugin_backup_dir, $this->installed_plugin_dir, ['recursive' => true]);
-            if ($this->was_plugin_active) {
-                activate_plugin($this->installed_plugin_file);
-            }
+            $this->wp_plugins_directory->rmdir($this->installed_plugin_backup_dir, ['recursive' => true]);
         }
         if ($this->wp_plugins_directory->exists($this->new_version_extract_to_dir)) {
             $this->wp_plugins_directory->rmdir($this->new_version_extract_to_dir, ['recursive' => true]);
         }
-    }
+		if ($this->was_plugin_active) {
+			activate_plugin($this->installed_plugin_file);
+		}
+	}
 }
 
 function rpi_upgrade_plugin($installed_plugin_file, $package_path) {
-    $updater = new PluginUpdater($package_path, $installed_plugin_file);
+    $updater = new PluginUpdater($installed_plugin_file, $package_path);
     return $updater->upgrade();
 }

--- a/plugins/url-updater/update_plugin.php
+++ b/plugins/url-updater/update_plugin.php
@@ -8,118 +8,123 @@ use function WordPress\Filesystem\copy_between_filesystems;
 use function WordPress\Filesystem\wp_join_paths;
 
 class PluginUpdater {
-    private $installed_plugin_backup_dir;
-    private $wp_plugins_directory;
+	private $installed_plugin_backup_dir;
+	private $wp_plugins_directory;
 	private $was_plugin_active;
-    private $installed_plugin_dir;
-    private $installed_plugin_file;
-    private $new_version_extract_to_dir;
-    private $package_absolute_path;
+	private $installed_plugin_dir;
+	private $installed_plugin_file;
+	private $new_version_extract_to_dir;
+	private $package_absolute_path;
 
-    public function __construct($installed_plugin_file, $package_absolute_path) {
-        require_once ABSPATH . 'wp-admin/includes/file.php';
-        require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	public function __construct( $installed_plugin_file, $package_absolute_path ) {
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
-        $this->wp_plugins_directory = LocalFilesystem::create(WP_PLUGIN_DIR);
+		$this->wp_plugins_directory = LocalFilesystem::create( WP_PLUGIN_DIR );
 
-        $this->installed_plugin_file = $installed_plugin_file;
-        $this->installed_plugin_dir = dirname($installed_plugin_file);
-        $plugin_slug = basename($this->installed_plugin_dir);
+		$this->installed_plugin_file = $installed_plugin_file;
+		$this->installed_plugin_dir  = dirname( $installed_plugin_file );
+		$plugin_slug                 = basename( $this->installed_plugin_dir );
 
-        $this->installed_plugin_backup_dir = $plugin_slug . '_installed_backup_' . time();
-        $this->new_version_extract_to_dir = $plugin_slug . '_new_version_' . time();
-        $this->package_absolute_path = $package_absolute_path;
+		$this->installed_plugin_backup_dir = $plugin_slug . '_installed_backup_' . time();
+		$this->new_version_extract_to_dir  = $plugin_slug . '_new_version_' . time();
+		$this->package_absolute_path       = $package_absolute_path;
 
-        if (!$this->wp_plugins_directory->exists($this->installed_plugin_dir)) {
-            throw new Exception("Plugin directory not found: $this->installed_plugin_dir");
-        }
-    }
+		if ( ! $this->wp_plugins_directory->exists( $this->installed_plugin_dir ) ) {
+			throw new Exception( "Plugin directory not found: $this->installed_plugin_dir" );
+		}
+	}
 
-    private function unzipPackage() {
-		$this->wp_plugins_directory->mkdir($this->new_version_extract_to_dir);
+	private function unzipPackage() {
+		$this->wp_plugins_directory->mkdir( $this->new_version_extract_to_dir );
 
-        $extension = pathinfo($this->package_absolute_path, PATHINFO_EXTENSION);
-        if ($extension === 'zip') {
-			$zip_fs = ZipFilesystem::create(FileReadStream::from_path( $this->package_absolute_path ));
-			copy_between_filesystems([
-				'source_filesystem' => $zip_fs,
-				'target_filesystem' => $this->wp_plugins_directory,
-				'target_path' => $this->new_version_extract_to_dir,
-				'recursive' => true,
-			]);
+		$extension = pathinfo( $this->package_absolute_path, PATHINFO_EXTENSION );
+		if ( $extension === 'zip' ) {
+			$zip_fs = ZipFilesystem::create( FileReadStream::from_path( $this->package_absolute_path ) );
+			copy_between_filesystems(
+				array(
+					'source_filesystem' => $zip_fs,
+					'target_filesystem' => $this->wp_plugins_directory,
+					'target_path' => $this->new_version_extract_to_dir,
+					'recursive' => true,
+				)
+			);
 
-			$extracted_dirs = $this->wp_plugins_directory->ls($this->new_version_extract_to_dir);
-            $extracted_dirs = array_filter($extracted_dirs, function($dir) {
-                $basename = basename($dir);
-                return $basename !== '__MACOSX' && $basename !== '.DS_Store';
-            });
-			if(count($extracted_dirs) === 1) {
-				$potential_root_dir = wp_join_paths($this->new_version_extract_to_dir, $extracted_dirs[0]);
-				if($this->wp_plugins_directory->is_dir($potential_root_dir)) {
+			$extracted_dirs = $this->wp_plugins_directory->ls( $this->new_version_extract_to_dir );
+			$extracted_dirs = array_filter(
+				$extracted_dirs,
+				function ( $dir ) {
+					$basename = basename( $dir );
+					return $basename !== '__MACOSX' && $basename !== '.DS_Store';
+				}
+			);
+			if ( count( $extracted_dirs ) === 1 ) {
+				$potential_root_dir = wp_join_paths( $this->new_version_extract_to_dir, $extracted_dirs[0] );
+				if ( $this->wp_plugins_directory->is_dir( $potential_root_dir ) ) {
 					return $potential_root_dir;
 				}
 			}
 
 			return $this->new_version_extract_to_dir;
-        } else if ($extension === 'php') {
-            $plugin_name = basename($this->package_absolute_path, '.php');
-            $this->wp_plugins_directory->mkdir($plugin_name);
-            $this->wp_plugins_directory->put_contents(
+		} elseif ( $extension === 'php' ) {
+			$plugin_name = basename( $this->package_absolute_path, '.php' );
+			$this->wp_plugins_directory->mkdir( $plugin_name );
+			$this->wp_plugins_directory->put_contents(
 				"{$plugin_name}/{$plugin_name}.php",
-				file_get_contents($this->package_absolute_path)
+				file_get_contents( $this->package_absolute_path )
 			);
 			return $plugin_name;
-        } else {
-            throw new Exception("Unsupported plugin package extension: $extension");
-        }
-    }
+		} else {
+			throw new Exception( "Unsupported plugin package extension: $extension" );
+		}
+	}
 
-    public function upgrade() {
-        try {
-			$this->was_plugin_active = is_plugin_active($this->installed_plugin_file);
-			if ($this->was_plugin_active) {
-				deactivate_plugins($this->installed_plugin_file, true);
+	public function upgrade() {
+		try {
+			$this->was_plugin_active = is_plugin_active( $this->installed_plugin_file );
+			if ( $this->was_plugin_active ) {
+				deactivate_plugins( $this->installed_plugin_file, true );
 			}
 
-            $new_version_root_directory = $this->unzipPackage();
+			$new_version_root_directory = $this->unzipPackage();
 
-            $this->wp_plugins_directory->rename($this->installed_plugin_dir, $this->installed_plugin_backup_dir);
-            $this->wp_plugins_directory->rename($new_version_root_directory, $this->installed_plugin_dir);
+			$this->wp_plugins_directory->rename( $this->installed_plugin_dir, $this->installed_plugin_backup_dir );
+			$this->wp_plugins_directory->rename( $new_version_root_directory, $this->installed_plugin_dir );
 
-            if ($this->was_plugin_active) {
-                $installed_plugin_files = get_plugins('/' . basename($this->installed_plugin_dir));
-                if (empty($installed_plugin_files)) {
-                    throw new Exception("No valid plugin file found in the new plugin directory");
-                }
-				$this->installed_plugin_file = wp_join_paths($this->installed_plugin_dir, key($installed_plugin_files));
-            }
+			if ( $this->was_plugin_active ) {
+				$installed_plugin_files = get_plugins( '/' . basename( $this->installed_plugin_dir ) );
+				if ( empty( $installed_plugin_files ) ) {
+					throw new Exception( 'No valid plugin file found in the new plugin directory' );
+				}
+				$this->installed_plugin_file = wp_join_paths( $this->installed_plugin_dir, key( $installed_plugin_files ) );
+			}
 
-            $this->cleanup();
-            return $this->installed_plugin_file;
-        } catch (Exception $e) {
-            $this->cleanup();
+			$this->cleanup();
+			return $this->installed_plugin_file;
+		} catch ( Exception $e ) {
+			$this->cleanup();
 			echo '<plaintext>';
 			echo $e->getMessage();
 			echo $e->getTraceAsString();
 			die();
-            return new WP_Error('plugin_upgrade_error', $e->getMessage());
-        }
-    }
+			return new WP_Error( 'plugin_upgrade_error', $e->getMessage() );
+		}
+	}
 
-    private function cleanup() {
-        if ($this->wp_plugins_directory->exists($this->installed_plugin_backup_dir)) {
-            $this->wp_plugins_directory->rmdir($this->installed_plugin_backup_dir, ['recursive' => true]);
-        }
-        if ($this->wp_plugins_directory->exists($this->new_version_extract_to_dir)) {
-            $this->wp_plugins_directory->rmdir($this->new_version_extract_to_dir, ['recursive' => true]);
-        }
-		if ($this->was_plugin_active) {
-			activate_plugin($this->installed_plugin_file);
+	private function cleanup() {
+		if ( $this->wp_plugins_directory->exists( $this->installed_plugin_backup_dir ) ) {
+			$this->wp_plugins_directory->rmdir( $this->installed_plugin_backup_dir, array( 'recursive' => true ) );
+		}
+		if ( $this->wp_plugins_directory->exists( $this->new_version_extract_to_dir ) ) {
+			$this->wp_plugins_directory->rmdir( $this->new_version_extract_to_dir, array( 'recursive' => true ) );
+		}
+		if ( $this->was_plugin_active ) {
+			activate_plugin( $this->installed_plugin_file );
 		}
 	}
 }
 
-function rpi_upgrade_plugin($installed_plugin_file, $package_path) {
-    $updater = new PluginUpdater($installed_plugin_file, $package_path);
-    return $updater->upgrade();
+function rpi_upgrade_plugin( $installed_plugin_file, $package_path ) {
+	$updater = new PluginUpdater( $installed_plugin_file, $package_path );
+	return $updater->upgrade();
 }

--- a/plugins/url-updater/update_plugin.php
+++ b/plugins/url-updater/update_plugin.php
@@ -1,0 +1,120 @@
+<?php
+
+use WordPress\ByteStream\ReadStream\FileReadStream;
+use WordPress\Filesystem\LocalFilesystem;
+use WordPress\Zip\ZipFilesystem;
+
+use function WordPress\Filesystem\copy_between_filesystems;
+use function WordPress\Filesystem\wp_join_paths;
+
+class PluginUpdater {
+    private $installed_plugin_backup_dir;
+    private $wp_plugins_directory;
+	private $was_plugin_active;
+    private $installed_plugin_dir;
+    private $installed_plugin_file;
+    private $new_version_extract_to_dir;
+    private $package_absolute_path;
+
+    public function __construct($installed_plugin_file, $package_absolute_path) {
+        require_once ABSPATH . 'wp-admin/includes/file.php';
+        require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+        $this->wp_plugins_directory = LocalFilesystem::create(WP_PLUGIN_DIR);
+
+        $this->installed_plugin_file = $installed_plugin_file;
+        $this->installed_plugin_dir = dirname(WP_PLUGIN_DIR . '/' . $installed_plugin_file);
+        $plugin_slug = basename($this->installed_plugin_dir);
+
+        $this->installed_plugin_backup_dir = $plugin_slug . '_installed_backup_' . time();
+        $this->new_version_extract_to_dir = $plugin_slug . '_new_version_' . time();
+        $this->package_absolute_path = $package_absolute_path;
+
+        if (!$this->wp_plugins_directory->exists($this->installed_plugin_dir)) {
+            throw new Exception("Plugin directory not found: $this->installed_plugin_dir");
+        }
+    }
+
+    private function unzipPackage() {
+		$this->wp_plugins_directory->mkdir($this->new_version_extract_to_dir);
+
+        $extension = pathinfo($this->package_absolute_path, PATHINFO_EXTENSION);
+        if ($extension === 'zip') {
+			$zip_fs = ZipFilesystem::create(FileReadStream::from_path( $this->package_absolute_path ));
+			copy_between_filesystems([
+				'source_filesystem' => $zip_fs,
+				'target_filesystem' => $this->wp_plugins_directory,
+				'target_path' => $this->new_version_extract_to_dir,
+				'recursive' => true,
+			]);
+
+			$extracted_dirs = $this->wp_plugins_directory->ls($this->new_version_extract_to_dir);
+            $extracted_dirs = array_filter($extracted_dirs, function($dir) {
+                $basename = basename($dir);
+                return $basename !== '__MACOSX' && $basename !== '.DS_Store';
+            });
+			if(count($extracted_dirs) === 1 && $this->wp_plugins_directory->is_dir($extracted_dirs[0])) {
+            	return wp_join_paths($this->new_version_extract_to_dir, $extracted_dirs[0]);
+			} else {
+				return $this->new_version_extract_to_dir;
+			}
+        } else if ($extension === 'php') {
+            $plugin_name = basename($this->package_absolute_path, '.php');
+            $this->wp_plugins_directory->mkdir($plugin_name);
+            $this->wp_plugins_directory->put_contents(
+				"{$plugin_name}/{$plugin_name}.php",
+				file_get_contents($this->package_absolute_path)
+			);
+			return $plugin_name;
+        } else {
+            throw new Exception("Unsupported plugin package extension: $extension");
+        }
+    }
+
+    public function upgrade() {
+        try {
+			$this->was_plugin_active = is_plugin_active($this->installed_plugin_file);
+			if ($this->was_plugin_active) {
+				deactivate_plugins($this->installed_plugin_file, true);
+			}
+
+            $new_version_root_directory = $this->unzipPackage();
+
+            $this->wp_plugins_directory->rename($this->installed_plugin_dir, $this->installed_plugin_backup_dir);
+            $this->wp_plugins_directory->rename($new_version_root_directory, $this->installed_plugin_dir);
+
+            if ($this->was_plugin_active) {
+                $installed_plugin_files = get_plugins('/' . basename($this->installed_plugin_dir));
+                if (!empty($installed_plugin_files)) {
+                    $this->installed_plugin_file = key($installed_plugin_files);
+                } else {
+                    throw new Exception("No valid plugin file found in the new plugin directory");
+                }
+                activate_plugin($this->installed_plugin_file);
+            }
+
+            return $this->installed_plugin_file;
+        } catch (Exception $e) {
+            return new WP_Error('plugin_upgrade_error', $e->getMessage());
+        } finally {
+            $this->cleanup();
+        }
+    }
+
+    private function cleanup() {
+        if ($this->wp_plugins_directory->exists($this->installed_plugin_backup_dir)) {
+            $this->wp_plugins_directory->copy($this->installed_plugin_backup_dir, $this->installed_plugin_dir, ['recursive' => true]);
+            if ($this->was_plugin_active) {
+                activate_plugin($this->installed_plugin_file);
+            }
+        }
+        if ($this->wp_plugins_directory->exists($this->new_version_extract_to_dir)) {
+            $this->wp_plugins_directory->rmdir($this->new_version_extract_to_dir, ['recursive' => true]);
+        }
+    }
+}
+
+function rpi_upgrade_plugin($installed_plugin_file, $package_path) {
+    $updater = new PluginUpdater($package_path, $installed_plugin_file);
+    return $updater->upgrade();
+}

--- a/plugins/url-updater/url-updater.php
+++ b/plugins/url-updater/url-updater.php
@@ -59,6 +59,13 @@ function rpi_render_admin_page() {
       echo '<a href="' . esc_url(admin_url('admin.php?page=remote-installer')) . '" class="button">Back to Plugin List</a>';
 	  return;
     }
+
+	// Check if the plugin exists
+	if (!file_exists(WP_PLUGIN_DIR . '/' . $plugin_file) || !$stored_url) {
+		echo '<div class="notice notice-error"><p>Plugin not found.</p></div>';
+		echo '<a href="' . esc_url(admin_url('admin.php?page=remote-installer')) . '" class="button">Back to Plugin List</a>';
+		return;
+	}
 	// Show the form to change the URL
 	echo '<div class="wrap">';
 	echo '<h1>Update Plugin</h1>';
@@ -76,18 +83,18 @@ function rpi_render_admin_page() {
   if (isset($_POST['rpi_plugin_url'])) {
     $plugin_url = sanitize_text_field($_POST['rpi_plugin_url']);
     $installed_plugin_file = rpi_install_plugin_from_url($plugin_url);
-    if ($installed_plugin_file) {
-      rpi_store_plugin_url($installed_plugin_file, $plugin_url);
-      echo '<div class="notice notice-success"><p>Plugin installed and activated successfully.</p></div>';
-    } else {
-      echo '<div class="notice notice-error"><p>Installation failed.</p></div>';
+	if (is_wp_error($installed_plugin_file)) {
+        echo '<div class="notice notice-error"><p>' . esc_html($installed_plugin_file->get_error_message()) . '</p></div>';
+	} else {
+        rpi_store_plugin_url($installed_plugin_file, $plugin_url);
+        echo '<div class="notice notice-success"><p>Plugin installed and activated successfully.</p></div>';
     }
   }
 
   // Default interface
   echo '<div class="wrap">';
   echo '<h1>Remote Plugin Installer</h1>';
-  echo '<form method="POST">';
+  echo '<form method="POST" action="admin.php?page=remote-installer">';
   echo '<p>Install a new plugin from a given URL.</p>';
   echo '<input type="text" name="rpi_plugin_url" placeholder="Plugin ZIP URL" style="width: 50%;" />';
   echo '<br><br><input type="submit" value="Install Plugin" class="button button-primary" />';
@@ -157,6 +164,9 @@ function rpi_install_plugin_from_url(string $url, bool $is_update = false, strin
 	 * * Restore from backup if the upgrade fails
 	 */
     $plugin_file = rpi_upgrade_plugin($original_plugin_file, $stable_tmp_path);
+	if(is_wp_error($plugin_file)) {
+		return $plugin_file;
+	}
     if (!$plugin_file) {
       return new WP_Error('upgrade_failed', 'Upgrade failed. Please check the URL and try again.');
     }

--- a/plugins/url-updater/url-updater.php
+++ b/plugins/url-updater/url-updater.php
@@ -2,7 +2,10 @@
 /**
  * Plugin Name: Remote Plugin Installer
  * Description: Installs a plugin from a given URL and allows updates from a user-defined URL.
+ * Requires Plugins: data-liberation
  */
+
+require_once __DIR__ . '/update_plugin.php';
 
 /**
  * UNSAFE! DO NOT USE IN PRODUCTION!
@@ -33,11 +36,11 @@ function rpi_render_admin_page() {
 
     // Direct update without changing URL
     if (isset($_GET['direct_update']) && $_GET['direct_update'] === 'true') {
-      $installed_plugin_file = rpi_install_plugin_from_url($stored_url, true);
-      if ($installed_plugin_file) {
-        echo '<div class="notice notice-success"><p>Plugin updated successfully.</p></div>';
+      $installed_plugin_file = rpi_install_plugin_from_url($stored_url, true, $plugin_file);
+      if (is_wp_error($installed_plugin_file)) {
+        echo '<div class="notice notice-error"><p>' . esc_html($installed_plugin_file->get_error_message()) . '</p></div>';
       } else {
-        echo '<div class="notice notice-error"><p>Update failed.</p></div>';
+        echo '<div class="notice notice-success"><p>Plugin updated successfully.</p></div>';
       }
       echo '<a href="' . esc_url(admin_url('admin.php?page=remote-installer')) . '" class="button">Back to Plugin List</a>';
       return;
@@ -46,27 +49,27 @@ function rpi_render_admin_page() {
     // If the user just submitted the new URL, do the update
     if (isset($_POST['rpi_new_url'])) {
       $new_url = sanitize_text_field($_POST['rpi_new_url']);
-      $installed_plugin_file = rpi_install_plugin_from_url($new_url, true);
-      if ($installed_plugin_file) {
+      $installed_plugin_file = rpi_install_plugin_from_url($new_url, true, $plugin_file);
+      if (is_wp_error($installed_plugin_file)) {
+        echo '<div class="notice notice-error"><p>' . esc_html($installed_plugin_file->get_error_message()) . '</p></div>';
+      } else {
         rpi_store_plugin_url($installed_plugin_file, $new_url);
         echo '<div class="notice notice-success"><p>Plugin updated successfully.</p></div>';
-      } else {
-        echo '<div class="notice notice-error"><p>Update failed.</p></div>';
       }
       echo '<a href="' . esc_url(admin_url('admin.php?page=remote-installer')) . '" class="button">Back to Plugin List</a>';
-    } else {
-      // Show the form to change the URL
-      echo '<div class="wrap">';
-      echo '<h1>Update Plugin</h1>';
-      echo '<p>You can change the URL here before updating.</p>';
-      echo '<form method="POST">';
-      echo '<input type="text" name="rpi_new_url" value="' . esc_attr($stored_url) . '" style="width: 50%;" />';
-      echo '<br><br><input type="submit" value="Update Plugin" class="button button-primary" />';
-      echo '</form>';
-      echo '<a href="' . esc_url(admin_url('admin.php?page=remote-installer')) . '" class="button">Back to Plugin List</a>';
-      echo '</div>';
+	  return;
     }
-    return;
+	// Show the form to change the URL
+	echo '<div class="wrap">';
+	echo '<h1>Update Plugin</h1>';
+	echo '<p>You can change the URL here before updating.</p>';
+	echo '<form method="POST">';
+	echo '<input type="text" name="rpi_new_url" value="' . esc_attr($stored_url) . '" style="width: 50%;" />';
+	echo '<br><br><input type="submit" value="Update Plugin" class="button button-primary" />';
+	echo '</form>';
+	echo '<a href="' . esc_url(admin_url('admin.php?page=remote-installer')) . '" class="button">Back to Plugin List</a>';
+	echo '</div>';
+	return;
   }
 
   // If we're installing a new plugin
@@ -115,51 +118,142 @@ function rpi_render_admin_page() {
   }
 }
 
-function rpi_install_plugin_from_url(string $url, bool $is_update = false) {
+function rpi_install_plugin_from_url(string $url, bool $is_update = false, string $original_plugin_file = '') {
   require_once ABSPATH . 'wp-admin/includes/file.php';
   require_once ABSPATH . 'wp-admin/includes/misc.php';
   require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
   require_once ABSPATH . 'wp-admin/includes/plugin.php';
-  
+
+  $parsed_url = wp_parse_url($url);
+  $path = isset($parsed_url['path']) ? $parsed_url['path'] : '';
+  $file_extension = pathinfo($path, PATHINFO_EXTENSION);
+  $base_name = $original_plugin_file ? basename(dirname($original_plugin_file)) : basename($path, '.' . $file_extension);
+
   $cache_busting_url = add_query_arg('_cache_buster', time(), $url);
   $tmp_file = download_url($cache_busting_url);
   if (is_wp_error($tmp_file)) {
-    return false;
+    return new WP_Error('download_failed', $tmp_file->get_error_message());
   }
 
-  $upgrader = new Plugin_Upgrader();
-  $upgrader->init();
-  $run_result = $upgrader->run([
-    'package'           => $tmp_file,
-    'destination'       => WP_PLUGIN_DIR,
-    'clear_destination' => $is_update,  // Only clear the existing folder if this is truly an update
-    'clear_working'     => true,
-    'hook_extra'        => [
-      'type'   => 'plugin',
-      'action' => $is_update ? 'update' : 'install',
-    ],
-  ]);
-
-  if (is_wp_error($run_result) || !$run_result) {
-    return false;
+  /**
+   * $tmp_file has a random component in the filename. WordPress would
+   * install it in wp-content/plugins/$new_name, not wp-content/plugins/$base_name.
+   *
+   * Let's give our package a stable filename to make WordPress actually
+   * upgrade the existing plugin instead of installing a new one.
+   */
+  $stable_tmp_path = sys_get_temp_dir() . '/' . $base_name . '.' . $file_extension;
+  if(file_exists($stable_tmp_path) && $stable_tmp_path !== $tmp_file) {
+    unlink($stable_tmp_path);
   }
+  rename($tmp_file, $stable_tmp_path);
 
-  $plugin_file = $upgrader->plugin_info();
-  if ($plugin_file) {
-    // If it's a fresh install, activate immediately
-    if (!$is_update) {
-      activate_plugin($plugin_file);
-    } else {
-      // If it was already active, re-activate after update
-      $active_plugins = get_option('active_plugins', []);
-      if (in_array($plugin_file, $active_plugins)) {
-        activate_plugin($plugin_file);
-      }
+  if($is_update) {
+    /**
+	 * Use our custom upgrade function instead of the WordPress upgrader.
+	 * It handles additional cases:
+	 *
+	 * * Rename of the zipped directory name (+activation of the plugin)
+	 * * Restore from backup if the upgrade fails
+	 */
+    $plugin_file = rpi_upgrade_plugin($original_plugin_file, $stable_tmp_path);
+    if (!$plugin_file) {
+      return new WP_Error('upgrade_failed', 'Upgrade failed. Please check the URL and try again.');
     }
-    // Update the last update timestamp
-    update_option('rpi_last_update_' . $plugin_file, current_time('mysql'));
+    
+    if($plugin_file !== $original_plugin_file) {
+      // remove $original_plugin_file from rpi_installed_plugins
+      $plugins = get_option('rpi_installed_plugins', []);
+      unset($plugins[$original_plugin_file]);
+      update_option('rpi_installed_plugins', $plugins);
+    }
+  } else {
+    $upgrader = new Plugin_Upgrader();
+    $upgrader->init();
+    $run_result = $upgrader->run([
+      'package'           => $stable_tmp_path,
+      'destination'       => WP_PLUGIN_DIR,
+      'clear_destination' => false,
+      'clear_working'     => true,
+      'hook_extra'        => [
+        'type'   => 'plugin',
+        'action' => 'install',
+      ],
+    ]);
+    if (is_wp_error($run_result) || !$run_result) {
+      return new WP_Error('upgrade_failed', 'Installation failed. Please check the URL and try again.');
+    }
+    $plugin_file = $upgrader->plugin_info();
+    activate_plugin($plugin_file);
   }
+
+  // Update the last update timestamp
+  update_option('rpi_last_update_' . $plugin_file, current_time('mysql'));
+
   return $plugin_file;
+}
+
+/**
+ * Helper function to restore a plugin from backup
+ */
+function rpi_restore_from_backup($backup_dir, $plugin_dir, $plugin_file, $was_active) {
+  // Remove the failed plugin directory if it exists
+  if (file_exists($plugin_dir)) {
+    rpi_remove_directory($plugin_dir);
+  }
+  
+  // Recreate the plugin directory
+  wp_mkdir_p($plugin_dir);
+  
+  // Copy files from backup
+  $files = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($backup_dir, RecursiveDirectoryIterator::SKIP_DOTS),
+    RecursiveIteratorIterator::SELF_FIRST
+  );
+  
+  foreach ($files as $file) {
+    $relative_path = str_replace($backup_dir, '', $file->getPathname());
+    $dest = $plugin_dir . $relative_path;
+    
+    if ($file->isDir()) {
+      wp_mkdir_p($dest);
+    } else {
+      copy($file->getPathname(), $dest);
+    }
+  }
+  
+  // Reactivate the plugin if it was active
+  if ($was_active) {
+    activate_plugin($plugin_file);
+  }
+  
+  // Clean up backup directory
+  rpi_remove_directory($backup_dir);
+}
+
+/**
+ * Helper function to recursively remove a directory
+ */
+function rpi_remove_directory($dir) {
+  if (!file_exists($dir)) {
+    return true;
+  }
+  
+  if (!is_dir($dir)) {
+    return unlink($dir);
+  }
+  
+  foreach (scandir($dir) as $item) {
+    if ($item == '.' || $item == '..') {
+      continue;
+    }
+    
+    if (!rpi_remove_directory($dir . DIRECTORY_SEPARATOR . $item)) {
+      return false;
+    }
+  }
+  
+  return rmdir($dir);
 }
 
 function rpi_store_plugin_url($plugin_file, $url) {

--- a/plugins/url-updater/url-updater.php
+++ b/plugins/url-updater/url-updater.php
@@ -12,282 +12,301 @@ require_once __DIR__ . '/update_plugin.php';
  *
  * Disables request filtering for easy testing and development.
  */
-add_filter('block_local_requests', '__return_false');
+add_filter( 'block_local_requests', '__return_false' );
 
-add_filter('http_request_args', function($args, $url) {
-// Disable certificate verification
-$args['sslverify'] = false;
-// Allow local IP addresses or unsafe URLs
-$args['reject_unsafe_urls'] = false;
-return $args;
-}, 9999, 2);
+add_filter(
+	'http_request_args',
+	function ( $args, $url ) {
+		// Disable certificate verification
+		$args['sslverify'] = false;
+		// Allow local IP addresses or unsafe URLs
+		$args['reject_unsafe_urls'] = false;
+		return $args;
+	},
+	9999,
+	2
+);
 
-add_action('admin_menu', function() {
-  add_menu_page('Remote Installer', 'Remote Installer', 'manage_options', 'remote-installer', 'rpi_render_admin_page');
-});
+add_action(
+	'admin_menu',
+	function () {
+		add_menu_page( 'Remote Installer', 'Remote Installer', 'manage_options', 'remote-installer', 'rpi_render_admin_page' );
+	}
+);
 
 function rpi_render_admin_page() {
-  if (!current_user_can('manage_options')) return;
-
-  // If we're updating, show a form to change the URL or handle the update
-  if (isset($_GET['rpi_update_plugin'])) {
-    $plugin_file = sanitize_text_field($_GET['rpi_update_plugin']);
-    $stored_url = rpi_get_stored_plugin_url($plugin_file);
-
-    // Direct update without changing URL
-    if (isset($_GET['direct_update']) && $_GET['direct_update'] === 'true') {
-      $installed_plugin_file = rpi_install_plugin_from_url($stored_url, true, $plugin_file);
-      if (is_wp_error($installed_plugin_file)) {
-        echo '<div class="notice notice-error"><p>' . esc_html($installed_plugin_file->get_error_message()) . '</p></div>';
-      } else {
-        echo '<div class="notice notice-success"><p>Plugin updated successfully.</p></div>';
-      }
-      echo '<a href="' . esc_url(admin_url('admin.php?page=remote-installer')) . '" class="button">Back to Plugin List</a>';
-      return;
-    }
-
-    // If the user just submitted the new URL, do the update
-    if (isset($_POST['rpi_new_url'])) {
-      $new_url = sanitize_text_field($_POST['rpi_new_url']);
-      $installed_plugin_file = rpi_install_plugin_from_url($new_url, true, $plugin_file);
-      if (is_wp_error($installed_plugin_file)) {
-        echo '<div class="notice notice-error"><p>' . esc_html($installed_plugin_file->get_error_message()) . '</p></div>';
-      } else {
-        rpi_store_plugin_url($installed_plugin_file, $new_url);
-        echo '<div class="notice notice-success"><p>Plugin updated successfully.</p></div>';
-      }
-      echo '<a href="' . esc_url(admin_url('admin.php?page=remote-installer')) . '" class="button">Back to Plugin List</a>';
-	  return;
-    }
-
-	// Check if the plugin exists
-	if (!file_exists(WP_PLUGIN_DIR . '/' . $plugin_file) || !$stored_url) {
-		echo '<div class="notice notice-error"><p>Plugin not found.</p></div>';
-		echo '<a href="' . esc_url(admin_url('admin.php?page=remote-installer')) . '" class="button">Back to Plugin List</a>';
+	if ( ! current_user_can( 'manage_options' ) ) {
 		return;
 	}
-	// Show the form to change the URL
+
+	// If we're updating, show a form to change the URL or handle the update
+	if ( isset( $_GET['rpi_update_plugin'] ) ) {
+		$plugin_file = sanitize_text_field( $_GET['rpi_update_plugin'] );
+		$stored_url  = rpi_get_stored_plugin_url( $plugin_file );
+
+		// Direct update without changing URL
+		if ( isset( $_GET['direct_update'] ) && $_GET['direct_update'] === 'true' ) {
+			$installed_plugin_file = rpi_install_plugin_from_url( $stored_url, true, $plugin_file );
+			if ( is_wp_error( $installed_plugin_file ) ) {
+				echo '<div class="notice notice-error"><p>' . esc_html( $installed_plugin_file->get_error_message() ) . '</p></div>';
+			} else {
+				echo '<div class="notice notice-success"><p>Plugin updated successfully.</p></div>';
+			}
+			echo '<a href="' . esc_url( admin_url( 'admin.php?page=remote-installer' ) ) . '" class="button">Back to Plugin List</a>';
+			return;
+		}
+
+		// If the user just submitted the new URL, do the update
+		if ( isset( $_POST['rpi_new_url'] ) ) {
+			$new_url               = sanitize_text_field( $_POST['rpi_new_url'] );
+			$installed_plugin_file = rpi_install_plugin_from_url( $new_url, true, $plugin_file );
+			if ( is_wp_error( $installed_plugin_file ) ) {
+				echo '<div class="notice notice-error"><p>' . esc_html( $installed_plugin_file->get_error_message() ) . '</p></div>';
+			} else {
+				rpi_store_plugin_url( $installed_plugin_file, $new_url );
+				echo '<div class="notice notice-success"><p>Plugin updated successfully.</p></div>';
+			}
+			echo '<a href="' . esc_url( admin_url( 'admin.php?page=remote-installer' ) ) . '" class="button">Back to Plugin List</a>';
+			return;
+		}
+
+		// Check if the plugin exists
+		if ( ! file_exists( WP_PLUGIN_DIR . '/' . $plugin_file ) || ! $stored_url ) {
+			echo '<div class="notice notice-error"><p>Plugin not found.</p></div>';
+			echo '<a href="' . esc_url( admin_url( 'admin.php?page=remote-installer' ) ) . '" class="button">Back to Plugin List</a>';
+			return;
+		}
+		// Show the form to change the URL
+		echo '<div class="wrap">';
+		echo '<h1>Update Plugin</h1>';
+		echo '<p>You can change the URL here before updating.</p>';
+		echo '<form method="POST">';
+		echo '<input type="text" name="rpi_new_url" value="' . esc_attr( $stored_url ) . '" style="width: 50%;" />';
+		echo '<br><br><input type="submit" value="Update Plugin" class="button button-primary" />';
+		echo '</form>';
+		echo '<a href="' . esc_url( admin_url( 'admin.php?page=remote-installer' ) ) . '" class="button">Back to Plugin List</a>';
+		echo '</div>';
+		return;
+	}
+
+	// If we're installing a new plugin
+	if ( isset( $_POST['rpi_plugin_url'] ) ) {
+		$plugin_url            = sanitize_text_field( $_POST['rpi_plugin_url'] );
+		$installed_plugin_file = rpi_install_plugin_from_url( $plugin_url );
+		if ( is_wp_error( $installed_plugin_file ) ) {
+			echo '<div class="notice notice-error"><p>' . esc_html( $installed_plugin_file->get_error_message() ) . '</p></div>';
+		} else {
+			rpi_store_plugin_url( $installed_plugin_file, $plugin_url );
+			echo '<div class="notice notice-success"><p>Plugin installed and activated successfully.</p></div>';
+		}
+	}
+
+	// Default interface
 	echo '<div class="wrap">';
-	echo '<h1>Update Plugin</h1>';
-	echo '<p>You can change the URL here before updating.</p>';
-	echo '<form method="POST">';
-	echo '<input type="text" name="rpi_new_url" value="' . esc_attr($stored_url) . '" style="width: 50%;" />';
-	echo '<br><br><input type="submit" value="Update Plugin" class="button button-primary" />';
+	echo '<h1>Remote Plugin Installer</h1>';
+	echo '<form method="POST" action="admin.php?page=remote-installer">';
+	echo '<p>Install a new plugin from a given URL.</p>';
+	echo '<input type="text" name="rpi_plugin_url" placeholder="Plugin ZIP URL" style="width: 50%;" />';
+	echo '<br><br><input type="submit" value="Install Plugin" class="button button-primary" />';
 	echo '</form>';
-	echo '<a href="' . esc_url(admin_url('admin.php?page=remote-installer')) . '" class="button">Back to Plugin List</a>';
 	echo '</div>';
-	return;
-  }
 
-  // If we're installing a new plugin
-  if (isset($_POST['rpi_plugin_url'])) {
-    $plugin_url = sanitize_text_field($_POST['rpi_plugin_url']);
-    $installed_plugin_file = rpi_install_plugin_from_url($plugin_url);
-	if (is_wp_error($installed_plugin_file)) {
-        echo '<div class="notice notice-error"><p>' . esc_html($installed_plugin_file->get_error_message()) . '</p></div>';
-	} else {
-        rpi_store_plugin_url($installed_plugin_file, $plugin_url);
-        echo '<div class="notice notice-success"><p>Plugin installed and activated successfully.</p></div>';
-    }
-  }
-
-  // Default interface
-  echo '<div class="wrap">';
-  echo '<h1>Remote Plugin Installer</h1>';
-  echo '<form method="POST" action="admin.php?page=remote-installer">';
-  echo '<p>Install a new plugin from a given URL.</p>';
-  echo '<input type="text" name="rpi_plugin_url" placeholder="Plugin ZIP URL" style="width: 50%;" />';
-  echo '<br><br><input type="submit" value="Install Plugin" class="button button-primary" />';
-  echo '</form>';
-  echo '</div>';
-
-  // List installed plugins
-  $installed_plugins = get_option('rpi_installed_plugins', []);
-  if (!empty($installed_plugins)) {
-    echo '<h2>Installed Plugins</h2>';
-    echo '<table class="widefat fixed" cellspacing="0">';
-    echo '<thead><tr><th>Plugin</th><th>Last Update</th><th>URL</th><th>Actions</th></tr></thead>';
-    echo '<tbody>';
-    foreach ($installed_plugins as $plugin_file => $plugin_url) {
-      $plugin_data = get_plugin_data(WP_PLUGIN_DIR . '/' . $plugin_file);
-      $last_update = get_option('rpi_last_update_' . $plugin_file, 'Never');
-      $update_url = admin_url('admin.php?page=remote-installer&rpi_update_plugin=' . urlencode($plugin_file) . '&direct_update=true');
-      $change_url = admin_url('admin.php?page=remote-installer&rpi_update_plugin=' . urlencode($plugin_file));
-      echo '<tr>';
-      echo '<td>' . esc_html($plugin_data['Name']) . '</td>';
-      echo '<td>' . esc_html($last_update) . '</td>';
-      echo '<td>' . esc_url($plugin_url) . '</td>';
-      echo '<td><a href="' . esc_url($update_url) . '" class="button">Update</a> <a href="' . esc_url($change_url) . '" class="button">Change URL</a></td>';
-      echo '</tr>';
-    }
-    echo '</tbody>';
-    echo '</table>';
-  }
+	// List installed plugins
+	$installed_plugins = get_option( 'rpi_installed_plugins', array() );
+	if ( ! empty( $installed_plugins ) ) {
+		echo '<h2>Installed Plugins</h2>';
+		echo '<table class="widefat fixed" cellspacing="0">';
+		echo '<thead><tr><th>Plugin</th><th>Last Update</th><th>URL</th><th>Actions</th></tr></thead>';
+		echo '<tbody>';
+		foreach ( $installed_plugins as $plugin_file => $plugin_url ) {
+			$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin_file );
+			$last_update = get_option( 'rpi_last_update_' . $plugin_file, 'Never' );
+			$update_url  = admin_url( 'admin.php?page=remote-installer&rpi_update_plugin=' . urlencode( $plugin_file ) . '&direct_update=true' );
+			$change_url  = admin_url( 'admin.php?page=remote-installer&rpi_update_plugin=' . urlencode( $plugin_file ) );
+			echo '<tr>';
+			echo '<td>' . esc_html( $plugin_data['Name'] ) . '</td>';
+			echo '<td>' . esc_html( $last_update ) . '</td>';
+			echo '<td>' . esc_url( $plugin_url ) . '</td>';
+			echo '<td><a href="' . esc_url( $update_url ) . '" class="button">Update</a> <a href="' . esc_url( $change_url ) . '" class="button">Change URL</a></td>';
+			echo '</tr>';
+		}
+		echo '</tbody>';
+		echo '</table>';
+	}
 }
 
-function rpi_install_plugin_from_url(string $url, bool $is_update = false, string $original_plugin_file = '') {
-  require_once ABSPATH . 'wp-admin/includes/file.php';
-  require_once ABSPATH . 'wp-admin/includes/misc.php';
-  require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
-  require_once ABSPATH . 'wp-admin/includes/plugin.php';
+function rpi_install_plugin_from_url( string $url, bool $is_update = false, string $original_plugin_file = '' ) {
+	require_once ABSPATH . 'wp-admin/includes/file.php';
+	require_once ABSPATH . 'wp-admin/includes/misc.php';
+	require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+	require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
-  $parsed_url = wp_parse_url($url);
-  $path = isset($parsed_url['path']) ? $parsed_url['path'] : '';
-  $file_extension = pathinfo($path, PATHINFO_EXTENSION);
-  $base_name = $original_plugin_file ? basename(dirname($original_plugin_file)) : basename($path, '.' . $file_extension);
+	$parsed_url     = wp_parse_url( $url );
+	$path           = isset( $parsed_url['path'] ) ? $parsed_url['path'] : '';
+	$file_extension = pathinfo( $path, PATHINFO_EXTENSION );
+	$base_name      = $original_plugin_file ? basename( dirname( $original_plugin_file ) ) : basename( $path, '.' . $file_extension );
 
-  $cache_busting_url = add_query_arg('_cache_buster', time(), $url);
-  $tmp_file = download_url($cache_busting_url);
-  if (is_wp_error($tmp_file)) {
-    return new WP_Error('download_failed', $tmp_file->get_error_message());
-  }
-
-  /**
-   * $tmp_file has a random component in the filename. WordPress would
-   * install it in wp-content/plugins/$new_name, not wp-content/plugins/$base_name.
-   *
-   * Let's give our package a stable filename to make WordPress actually
-   * upgrade the existing plugin instead of installing a new one.
-   */
-  $stable_tmp_path = sys_get_temp_dir() . '/' . $base_name . '.' . $file_extension;
-  if(file_exists($stable_tmp_path) && $stable_tmp_path !== $tmp_file) {
-    unlink($stable_tmp_path);
-  }
-  rename($tmp_file, $stable_tmp_path);
-
-  if($is_update) {
-    /**
-	 * Use our custom upgrade function instead of the WordPress upgrader.
-	 * It handles additional cases:
-	 *
-	 * * Rename of the zipped directory name (+activation of the plugin)
-	 * * Restore from backup if the upgrade fails
-	 */
-    $plugin_file = rpi_upgrade_plugin($original_plugin_file, $stable_tmp_path);
-	if(is_wp_error($plugin_file)) {
-		return $plugin_file;
+	$cache_busting_url = add_query_arg( '_cache_buster', time(), $url );
+	$tmp_file          = download_url( $cache_busting_url );
+	if ( is_wp_error( $tmp_file ) ) {
+		return new WP_Error( 'download_failed', $tmp_file->get_error_message() );
 	}
-    if (!$plugin_file) {
-      return new WP_Error('upgrade_failed', 'Upgrade failed. Please check the URL and try again.');
-    }
-    
-    if($plugin_file !== $original_plugin_file) {
-      // remove $original_plugin_file from rpi_installed_plugins
-      $plugins = get_option('rpi_installed_plugins', []);
-      unset($plugins[$original_plugin_file]);
-      update_option('rpi_installed_plugins', $plugins);
-    }
-  } else {
-    $upgrader = new Plugin_Upgrader();
-    $upgrader->init();
-    $run_result = $upgrader->run([
-      'package'           => $stable_tmp_path,
-      'destination'       => WP_PLUGIN_DIR,
-      'clear_destination' => false,
-      'clear_working'     => true,
-      'hook_extra'        => [
-        'type'   => 'plugin',
-        'action' => 'install',
-      ],
-    ]);
-    if (is_wp_error($run_result) || !$run_result) {
-      return new WP_Error('upgrade_failed', 'Installation failed. Please check the URL and try again.');
-    }
-    $plugin_file = $upgrader->plugin_info();
-    activate_plugin($plugin_file);
-  }
 
-  // Update the last update timestamp
-  update_option('rpi_last_update_' . $plugin_file, current_time('mysql'));
+	/**
+	 * $tmp_file has a random component in the filename. WordPress would
+	 * install it in wp-content/plugins/$new_name, not wp-content/plugins/$base_name.
+	 *
+	 * Let's give our package a stable filename to make WordPress actually
+	 * upgrade the existing plugin instead of installing a new one.
+	 */
+	$stable_tmp_path = sys_get_temp_dir() . '/' . $base_name . '.' . $file_extension;
+	if ( file_exists( $stable_tmp_path ) && $stable_tmp_path !== $tmp_file ) {
+		unlink( $stable_tmp_path );
+	}
+	rename( $tmp_file, $stable_tmp_path );
 
-  return $plugin_file;
+	if ( $is_update ) {
+		/**
+		 * Use our custom upgrade function instead of the WordPress upgrader.
+		 * It handles additional cases:
+		 *
+		 * * Rename of the zipped directory name (+activation of the plugin)
+		 * * Restore from backup if the upgrade fails
+		 */
+		$plugin_file = rpi_upgrade_plugin( $original_plugin_file, $stable_tmp_path );
+		if ( is_wp_error( $plugin_file ) ) {
+			return $plugin_file;
+		}
+		if ( ! $plugin_file ) {
+			return new WP_Error( 'upgrade_failed', 'Upgrade failed. Please check the URL and try again.' );
+		}
+
+		if ( $plugin_file !== $original_plugin_file ) {
+			// remove $original_plugin_file from rpi_installed_plugins
+			$plugins = get_option( 'rpi_installed_plugins', array() );
+			unset( $plugins[ $original_plugin_file ] );
+			update_option( 'rpi_installed_plugins', $plugins );
+		}
+	} else {
+		$upgrader = new Plugin_Upgrader();
+		$upgrader->init();
+		$run_result = $upgrader->run(
+			array(
+				'package'           => $stable_tmp_path,
+				'destination'       => WP_PLUGIN_DIR,
+				'clear_destination' => false,
+				'clear_working'     => true,
+				'hook_extra'        => array(
+					'type'   => 'plugin',
+					'action' => 'install',
+				),
+			)
+		);
+		if ( is_wp_error( $run_result ) || ! $run_result ) {
+			return new WP_Error( 'upgrade_failed', 'Installation failed. Please check the URL and try again.' );
+		}
+		$plugin_file = $upgrader->plugin_info();
+		activate_plugin( $plugin_file );
+	}
+
+	// Update the last update timestamp
+	update_option( 'rpi_last_update_' . $plugin_file, current_time( 'mysql' ) );
+
+	return $plugin_file;
 }
 
 /**
  * Helper function to restore a plugin from backup
  */
-function rpi_restore_from_backup($backup_dir, $plugin_dir, $plugin_file, $was_active) {
-  // Remove the failed plugin directory if it exists
-  if (file_exists($plugin_dir)) {
-    rpi_remove_directory($plugin_dir);
-  }
-  
-  // Recreate the plugin directory
-  wp_mkdir_p($plugin_dir);
-  
-  // Copy files from backup
-  $files = new RecursiveIteratorIterator(
-    new RecursiveDirectoryIterator($backup_dir, RecursiveDirectoryIterator::SKIP_DOTS),
-    RecursiveIteratorIterator::SELF_FIRST
-  );
-  
-  foreach ($files as $file) {
-    $relative_path = str_replace($backup_dir, '', $file->getPathname());
-    $dest = $plugin_dir . $relative_path;
-    
-    if ($file->isDir()) {
-      wp_mkdir_p($dest);
-    } else {
-      copy($file->getPathname(), $dest);
-    }
-  }
-  
-  // Reactivate the plugin if it was active
-  if ($was_active) {
-    activate_plugin($plugin_file);
-  }
-  
-  // Clean up backup directory
-  rpi_remove_directory($backup_dir);
+function rpi_restore_from_backup( $backup_dir, $plugin_dir, $plugin_file, $was_active ) {
+	// Remove the failed plugin directory if it exists
+	if ( file_exists( $plugin_dir ) ) {
+		rpi_remove_directory( $plugin_dir );
+	}
+
+	// Recreate the plugin directory
+	wp_mkdir_p( $plugin_dir );
+
+	// Copy files from backup
+	$files = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator( $backup_dir, RecursiveDirectoryIterator::SKIP_DOTS ),
+		RecursiveIteratorIterator::SELF_FIRST
+	);
+
+	foreach ( $files as $file ) {
+		$relative_path = str_replace( $backup_dir, '', $file->getPathname() );
+		$dest          = $plugin_dir . $relative_path;
+
+		if ( $file->isDir() ) {
+			wp_mkdir_p( $dest );
+		} else {
+			copy( $file->getPathname(), $dest );
+		}
+	}
+
+	// Reactivate the plugin if it was active
+	if ( $was_active ) {
+		activate_plugin( $plugin_file );
+	}
+
+	// Clean up backup directory
+	rpi_remove_directory( $backup_dir );
 }
 
 /**
  * Helper function to recursively remove a directory
  */
-function rpi_remove_directory($dir) {
-  if (!file_exists($dir)) {
-    return true;
-  }
-  
-  if (!is_dir($dir)) {
-    return unlink($dir);
-  }
-  
-  foreach (scandir($dir) as $item) {
-    if ($item == '.' || $item == '..') {
-      continue;
-    }
-    
-    if (!rpi_remove_directory($dir . DIRECTORY_SEPARATOR . $item)) {
-      return false;
-    }
-  }
-  
-  return rmdir($dir);
+function rpi_remove_directory( $dir ) {
+	if ( ! file_exists( $dir ) ) {
+		return true;
+	}
+
+	if ( ! is_dir( $dir ) ) {
+		return unlink( $dir );
+	}
+
+	foreach ( scandir( $dir ) as $item ) {
+		if ( $item == '.' || $item == '..' ) {
+			continue;
+		}
+
+		if ( ! rpi_remove_directory( $dir . DIRECTORY_SEPARATOR . $item ) ) {
+			return false;
+		}
+	}
+
+	return rmdir( $dir );
 }
 
-function rpi_store_plugin_url($plugin_file, $url) {
-  $plugins = get_option('rpi_installed_plugins', []);
-  $plugins[$plugin_file] = $url;
-  update_option('rpi_installed_plugins', $plugins);
+function rpi_store_plugin_url( $plugin_file, $url ) {
+	$plugins                 = get_option( 'rpi_installed_plugins', array() );
+	$plugins[ $plugin_file ] = $url;
+	update_option( 'rpi_installed_plugins', $plugins );
 }
 
-function rpi_get_stored_plugin_url($plugin_file) {
-  $plugins = get_option('rpi_installed_plugins', []);
-  return isset($plugins[$plugin_file]) ? $plugins[$plugin_file] : false;
+function rpi_get_stored_plugin_url( $plugin_file ) {
+	$plugins = get_option( 'rpi_installed_plugins', array() );
+	return isset( $plugins[ $plugin_file ] ) ? $plugins[ $plugin_file ] : false;
 }
 
 // Add "Update" and "Change URL" links to the plugin list
-add_filter('plugin_action_links', function($actions, $plugin_file, $plugin_data, $context) {
-    if (is_network_admin()) return $actions;
+add_filter(
+	'plugin_action_links',
+	function ( $actions, $plugin_file, $plugin_data, $context ) {
+		if ( is_network_admin() ) {
+			return $actions;
+		}
 
-    $stored_url = rpi_get_stored_plugin_url($plugin_file);
-    if ($stored_url) {
-        $update_url = admin_url('admin.php?page=remote-installer&rpi_update_plugin=' . urlencode($plugin_file) . '&direct_update=true');
-        $change_url = admin_url('admin.php?page=remote-installer&rpi_update_plugin=' . urlencode($plugin_file));
+		$stored_url = rpi_get_stored_plugin_url( $plugin_file );
+		if ( $stored_url ) {
+			$update_url = admin_url( 'admin.php?page=remote-installer&rpi_update_plugin=' . urlencode( $plugin_file ) . '&direct_update=true' );
+			$change_url = admin_url( 'admin.php?page=remote-installer&rpi_update_plugin=' . urlencode( $plugin_file ) );
 
-        $actions['rpi_update'] = '<a href="' . esc_url($update_url) . '">Update</a>';
-        $actions['rpi_change_url'] = '<a href="' . esc_url($change_url) . '">Change URL</a>';
-    }
-    return $actions;
-}, 10, 4);
+			$actions['rpi_update']     = '<a href="' . esc_url( $update_url ) . '">Update</a>';
+			$actions['rpi_change_url'] = '<a href="' . esc_url( $change_url ) . '">Change URL</a>';
+		}
+		return $actions;
+	},
+	10,
+	4
+);


### PR DESCRIPTION
Before this PR, the `url-updater` plugin supported installing the plugin but it often failed to install the new version. For example, if the zipped directory name changed, or if the downloaded plugin did not declare a different version number. With this PR, we're switching to a custom plugin updater based on `WordPress\Filesystem` components. This means we can easily support more data sources, e.g. cloning the plugin directly from a git repository.

## Testing instructions

1. Go to http://127.0.0.1:9400/wp-admin/admin.php?page=remote-installer
2. Install a zipped plugin from any URL
3. Click "Change URL" and paste in a different plugin URL
4. Confirm the original plugin was removed and the new plugin is now installed in its place