### PR TITLE
XMLProcessor: Support namespaces

### DIFF
--- a/components/DataLiberation/EntityReader/EPubEntityReader.php
+++ b/components/DataLiberation/EntityReader/EPubEntityReader.php
@@ -167,7 +167,7 @@ class EPubEntityReader implements EntityReader {
 			}
 			if ( $xml->matches_breadcrumbs( array( 'metadata', '*' ) ) ) {
 				$parsed['metadata'][] = array(
-					'tag'        => $xml->get_local_tag_name(),
+					'tag'        => $xml->get_tag_local_name(),
 					'attributes' => $parsed_entry,
 				);
 			} elseif ( $xml->matches_breadcrumbs( array( 'manifest', 'item' ) ) ) {

--- a/components/DataLiberation/EntityReader/EPubEntityReader.php
+++ b/components/DataLiberation/EntityReader/EPubEntityReader.php
@@ -141,7 +141,7 @@ class EPubEntityReader implements EntityReader {
 			return false;
 		}
 
-		$full_path = $xml->get_attribute_by_qualified_name( 'full-path' );
+		$full_path = $xml->get_attribute( 'full-path' );
 		if ( ! $full_path ) {
 			return false;
 		}
@@ -163,11 +163,11 @@ class EPubEntityReader implements EntityReader {
 			$parsed_entry = array();
 			$keys         = $xml->get_attribute_qualified_names_with_prefix( '' );
 			foreach ( $keys as $key ) {
-				$parsed_entry[ $key ] = $xml->get_attribute_by_qualified_name( $key );
+				$parsed_entry[ $key ] = $xml->get_attribute( $key );
 			}
 			if ( $xml->matches_breadcrumbs( array( 'metadata', '*' ) ) ) {
 				$parsed['metadata'][] = array(
-					'tag'        => $xml->get_qualified_tag(),
+					'tag'        => $xml->get_local_tag_name(),
 					'attributes' => $parsed_entry,
 				);
 			} elseif ( $xml->matches_breadcrumbs( array( 'manifest', 'item' ) ) ) {

--- a/components/DataLiberation/EntityReader/EPubEntityReader.php
+++ b/components/DataLiberation/EntityReader/EPubEntityReader.php
@@ -141,7 +141,7 @@ class EPubEntityReader implements EntityReader {
 			return false;
 		}
 
-		$full_path = $xml->get_attribute( 'full-path' );
+		$full_path = $xml->get_attribute_by_qualified_name( 'full-path' );
 		if ( ! $full_path ) {
 			return false;
 		}
@@ -161,13 +161,13 @@ class EPubEntityReader implements EntityReader {
 		);
 		while ( $xml->next_tag() ) {
 			$parsed_entry = array();
-			$keys         = $xml->get_attribute_names_with_prefix( '' );
+			$keys         = $xml->get_attribute_qualified_names_with_prefix( '' );
 			foreach ( $keys as $key ) {
-				$parsed_entry[ $key ] = $xml->get_attribute( $key );
+				$parsed_entry[ $key ] = $xml->get_attribute_by_qualified_name( $key );
 			}
 			if ( $xml->matches_breadcrumbs( array( 'metadata', '*' ) ) ) {
 				$parsed['metadata'][] = array(
-					'tag'        => $xml->get_tag(),
+					'tag'        => $xml->get_qualified_tag(),
 					'attributes' => $parsed_entry,
 				);
 			} elseif ( $xml->matches_breadcrumbs( array( 'manifest', 'item' ) ) ) {

--- a/components/DataLiberation/EntityReader/WXREntityReader.php
+++ b/components/DataLiberation/EntityReader/WXREntityReader.php
@@ -659,7 +659,7 @@ class WXREntityReader implements EntityReader {
 				$this->last_xml_cursor_outside_of_entity      = $this->xml->get_reentrancy_cursor();
 			}
 
-			$tag = $this->xml->get_tag();
+			$tag = $this->xml->get_qualified_tag();
 			/**
 			 * Custom adjustment: the Accessibility WXR file uses a non-standard
 			 * wp:wp_author tag.
@@ -732,16 +732,16 @@ class WXREntityReader implements EntityReader {
 			 */
 			if ( $this->xml->is_tag_opener() ) {
 				$this->last_opener_attributes = array();
-				$names                        = $this->xml->get_attribute_names_with_prefix( '' );
+				$names                        = $this->xml->get_attribute_qualified_names_with_prefix( '' );
 				foreach ( $names as $name ) {
-					$this->last_opener_attributes[ $name ] = $this->xml->get_attribute( $name );
+					$this->last_opener_attributes[ $name ] = $this->xml->get_attribute_by_qualified_name( $name );
 				}
 				$this->text_buffer = '';
 
 				$is_site_option_opener = (
 					count( $this->xml->get_breadcrumbs() ) === 3 &&
 					$this->xml->matches_breadcrumbs( array( 'rss', 'channel', '*' ) ) &&
-					array_key_exists( $this->xml->get_tag(), static::KNOWN_SITE_OPTIONS )
+					array_key_exists( $this->xml->get_qualified_tag(), static::KNOWN_SITE_OPTIONS )
 				);
 				if ( $is_site_option_opener ) {
 					$this->last_xml_byte_offset_outside_of_entity = $this->xml->get_token_byte_offset_in_the_input_stream();
@@ -848,13 +848,13 @@ class WXREntityReader implements EntityReader {
 	 * @return bool Whether a site_option entity was emitted.
 	 */
 	private function parse_site_option() {
-		if ( ! array_key_exists( $this->xml->get_tag(), static::KNOWN_SITE_OPTIONS ) ) {
+		if ( ! array_key_exists( $this->xml->get_qualified_tag(), static::KNOWN_SITE_OPTIONS ) ) {
 			return false;
 		}
 
 		$this->entity_type = 'site_option';
 		$this->entity_data = array(
-			'option_name'  => static::KNOWN_SITE_OPTIONS[ $this->xml->get_tag() ],
+			'option_name'  => static::KNOWN_SITE_OPTIONS[ $this->xml->get_qualified_tag() ],
 			'option_value' => $this->text_buffer,
 		);
 		$this->emit_entity();

--- a/components/DataLiberation/EntityReader/WXREntityReader.php
+++ b/components/DataLiberation/EntityReader/WXREntityReader.php
@@ -659,7 +659,7 @@ class WXREntityReader implements EntityReader {
 				$this->last_xml_cursor_outside_of_entity      = $this->xml->get_reentrancy_cursor();
 			}
 
-			$tag = $this->xml->get_qualified_tag();
+			$tag = $this->xml->get_local_tag_name();
 			/**
 			 * Custom adjustment: the Accessibility WXR file uses a non-standard
 			 * wp:wp_author tag.
@@ -734,14 +734,14 @@ class WXREntityReader implements EntityReader {
 				$this->last_opener_attributes = array();
 				$names                        = $this->xml->get_attribute_qualified_names_with_prefix( '' );
 				foreach ( $names as $name ) {
-					$this->last_opener_attributes[ $name ] = $this->xml->get_attribute_by_qualified_name( $name );
+					$this->last_opener_attributes[ $name ] = $this->xml->get_attribute( $name );
 				}
 				$this->text_buffer = '';
 
 				$is_site_option_opener = (
 					count( $this->xml->get_breadcrumbs() ) === 3 &&
 					$this->xml->matches_breadcrumbs( array( 'rss', 'channel', '*' ) ) &&
-					array_key_exists( $this->xml->get_qualified_tag(), static::KNOWN_SITE_OPTIONS )
+					array_key_exists( $this->xml->get_local_tag_name(), static::KNOWN_SITE_OPTIONS )
 				);
 				if ( $is_site_option_opener ) {
 					$this->last_xml_byte_offset_outside_of_entity = $this->xml->get_token_byte_offset_in_the_input_stream();
@@ -848,13 +848,13 @@ class WXREntityReader implements EntityReader {
 	 * @return bool Whether a site_option entity was emitted.
 	 */
 	private function parse_site_option() {
-		if ( ! array_key_exists( $this->xml->get_qualified_tag(), static::KNOWN_SITE_OPTIONS ) ) {
+		if ( ! array_key_exists( $this->xml->get_local_tag_name(), static::KNOWN_SITE_OPTIONS ) ) {
 			return false;
 		}
 
 		$this->entity_type = 'site_option';
 		$this->entity_data = array(
-			'option_name'  => static::KNOWN_SITE_OPTIONS[ $this->xml->get_qualified_tag() ],
+			'option_name'  => static::KNOWN_SITE_OPTIONS[ $this->xml->get_local_tag_name() ],
 			'option_value' => $this->text_buffer,
 		);
 		$this->emit_entity();

--- a/components/DataLiberation/EntityReader/WXREntityReader.php
+++ b/components/DataLiberation/EntityReader/WXREntityReader.php
@@ -659,7 +659,7 @@ class WXREntityReader implements EntityReader {
 				$this->last_xml_cursor_outside_of_entity      = $this->xml->get_reentrancy_cursor();
 			}
 
-			$tag = $this->xml->get_local_tag_name();
+			$tag = $this->xml->get_tag_local_name();
 			/**
 			 * Custom adjustment: the Accessibility WXR file uses a non-standard
 			 * wp:wp_author tag.
@@ -741,7 +741,7 @@ class WXREntityReader implements EntityReader {
 				$is_site_option_opener = (
 					count( $this->xml->get_breadcrumbs() ) === 3 &&
 					$this->xml->matches_breadcrumbs( array( 'rss', 'channel', '*' ) ) &&
-					array_key_exists( $this->xml->get_local_tag_name(), static::KNOWN_SITE_OPTIONS )
+					array_key_exists( $this->xml->get_tag_local_name(), static::KNOWN_SITE_OPTIONS )
 				);
 				if ( $is_site_option_opener ) {
 					$this->last_xml_byte_offset_outside_of_entity = $this->xml->get_token_byte_offset_in_the_input_stream();
@@ -848,13 +848,13 @@ class WXREntityReader implements EntityReader {
 	 * @return bool Whether a site_option entity was emitted.
 	 */
 	private function parse_site_option() {
-		if ( ! array_key_exists( $this->xml->get_local_tag_name(), static::KNOWN_SITE_OPTIONS ) ) {
+		if ( ! array_key_exists( $this->xml->get_tag_local_name(), static::KNOWN_SITE_OPTIONS ) ) {
 			return false;
 		}
 
 		$this->entity_type = 'site_option';
 		$this->entity_data = array(
-			'option_name'  => static::KNOWN_SITE_OPTIONS[ $this->xml->get_local_tag_name() ],
+			'option_name'  => static::KNOWN_SITE_OPTIONS[ $this->xml->get_tag_local_name() ],
 			'option_value' => $this->text_buffer,
 		);
 		$this->emit_entity();

--- a/components/DataLiberation/EntityReader/WXREntityReader.php
+++ b/components/DataLiberation/EntityReader/WXREntityReader.php
@@ -243,6 +243,14 @@ class WXREntityReader implements EntityReader {
 	 */
 	private $is_finished = false;
 
+	const NAMESPACES = array(
+		'excerpt' => 'http://wordpress.org/export/1.2/excerpt/',
+		'content' => 'http://purl.org/rss/1.0/modules/content/',
+		'wfw'     => 'http://wellformedweb.org/CommentAPI/',
+		'dc'      => 'http://purl.org/dc/elements/1.1/',
+		'wp'      => 'http://wordpress.org/export/1.2/',
+	);
+
 	/**
 	 * Mapping of WXR tags representing site options to their WordPress options names.
 	 * These tags are only matched if they are children of the <channel> element.
@@ -251,8 +259,8 @@ class WXREntityReader implements EntityReader {
 	 * @var array
 	 */
 	const KNOWN_SITE_OPTIONS = array(
-		'wp:base_blog_url' => 'home',
-		'wp:base_site_url' => 'siteurl',
+		'{http://wordpress.org/export/1.2/}base_blog_url' => 'home',
+		'{http://wordpress.org/export/1.2/}base_site_url' => 'siteurl',
 		'title'            => 'blogname',
 	);
 
@@ -263,39 +271,39 @@ class WXREntityReader implements EntityReader {
 	 * @var array
 	 */
 	const KNOWN_ENITIES = array(
-		'wp:comment'     => array(
+		'{http://wordpress.org/export/1.2/}comment'     => array(
 			'type'   => 'comment',
 			'fields' => array(
-				'wp:comment_id'           => 'comment_id',
-				'wp:comment_author'       => 'comment_author',
-				'wp:comment_author_email' => 'comment_author_email',
-				'wp:comment_author_url'   => 'comment_author_url',
-				'wp:comment_author_IP'    => 'comment_author_IP',
-				'wp:comment_date'         => 'comment_date',
-				'wp:comment_date_gmt'     => 'comment_date_gmt',
-				'wp:comment_content'      => 'comment_content',
-				'wp:comment_approved'     => 'comment_approved',
-				'wp:comment_type'         => 'comment_type',
-				'wp:comment_parent'       => 'comment_parent',
-				'wp:comment_user_id'      => 'comment_user_id',
+				'{http://wordpress.org/export/1.2/}comment_id'           => 'comment_id',
+				'{http://wordpress.org/export/1.2/}comment_author'       => 'comment_author',
+				'{http://wordpress.org/export/1.2/}comment_author_email' => 'comment_author_email',
+				'{http://wordpress.org/export/1.2/}comment_author_url'   => 'comment_author_url',
+				'{http://wordpress.org/export/1.2/}comment_author_IP'    => 'comment_author_IP',
+				'{http://wordpress.org/export/1.2/}comment_date'         => 'comment_date',
+				'{http://wordpress.org/export/1.2/}comment_date_gmt'     => 'comment_date_gmt',
+				'{http://wordpress.org/export/1.2/}comment_content'      => 'comment_content',
+				'{http://wordpress.org/export/1.2/}comment_approved'     => 'comment_approved',
+				'{http://wordpress.org/export/1.2/}comment_type'         => 'comment_type',
+				'{http://wordpress.org/export/1.2/}comment_parent'       => 'comment_parent',
+				'{http://wordpress.org/export/1.2/}comment_user_id'      => 'comment_user_id',
 			),
 		),
-		'wp:commentmeta' => array(
+		'{http://wordpress.org/export/1.2/}commentmeta' => array(
 			'type'   => 'comment_meta',
 			'fields' => array(
-				'wp:meta_key'   => 'meta_key',
-				'wp:meta_value' => 'meta_value',
+				'{http://wordpress.org/export/1.2/}meta_key'   => 'meta_key',
+				'{http://wordpress.org/export/1.2/}meta_value' => 'meta_value',
 			),
 		),
-		'wp:author'      => array(
+		'{http://wordpress.org/export/1.2/}author'      => array(
 			'type'   => 'user',
 			'fields' => array(
-				'wp:author_id'           => 'ID',
-				'wp:author_login'        => 'user_login',
-				'wp:author_email'        => 'user_email',
-				'wp:author_display_name' => 'display_name',
-				'wp:author_first_name'   => 'first_name',
-				'wp:author_last_name'    => 'last_name',
+				'{http://wordpress.org/export/1.2/}author_id'           => 'ID',
+				'{http://wordpress.org/export/1.2/}author_login'        => 'user_login',
+				'{http://wordpress.org/export/1.2/}author_email'        => 'user_email',
+				'{http://wordpress.org/export/1.2/}author_display_name' => 'display_name',
+				'{http://wordpress.org/export/1.2/}author_first_name'   => 'first_name',
+				'{http://wordpress.org/export/1.2/}author_last_name'    => 'last_name',
 			),
 		),
 		'item'           => array(
@@ -306,59 +314,59 @@ class WXREntityReader implements EntityReader {
 				'guid'                 => 'guid',
 				'description'          => 'post_excerpt',
 				'pubDate'              => 'post_published_at',
-				'dc:creator'           => 'post_author',
-				'content:encoded'      => 'post_content',
-				'excerpt:encoded'      => 'post_excerpt',
-				'wp:post_id'           => 'post_id',
-				'wp:status'            => 'post_status',
-				'wp:post_date'         => 'post_date',
-				'wp:post_date_gmt'     => 'post_date_gmt',
-				'wp:post_modified'     => 'post_modified',
-				'wp:post_modified_gmt' => 'post_modified_gmt',
-				'wp:comment_status'    => 'comment_status',
-				'wp:ping_status'       => 'ping_status',
-				'wp:post_name'         => 'post_name',
-				'wp:post_parent'       => 'post_parent',
-				'wp:menu_order'        => 'menu_order',
-				'wp:post_type'         => 'post_type',
-				'wp:post_password'     => 'post_password',
-				'wp:is_sticky'         => 'is_sticky',
-				'wp:attachment_url'    => 'attachment_url',
+				'{http://purl.org/dc/elements/1.1/}creator'           => 'post_author',
+				'{http://purl.org/rss/1.0/modules/content/}encoded'   => 'post_content',
+				'{http://wordpress.org/export/1.2/excerpt/}encoded'  => 'post_excerpt',
+				'{http://wordpress.org/export/1.2/}post_id'           => 'post_id',
+				'{http://wordpress.org/export/1.2/}status'            => 'post_status',
+				'{http://wordpress.org/export/1.2/}post_date'         => 'post_date',
+				'{http://wordpress.org/export/1.2/}post_date_gmt'     => 'post_date_gmt',
+				'{http://wordpress.org/export/1.2/}post_modified'     => 'post_modified',
+				'{http://wordpress.org/export/1.2/}post_modified_gmt' => 'post_modified_gmt',
+				'{http://wordpress.org/export/1.2/}comment_status'    => 'comment_status',
+				'{http://wordpress.org/export/1.2/}ping_status'       => 'ping_status',
+				'{http://wordpress.org/export/1.2/}post_name'         => 'post_name',
+				'{http://wordpress.org/export/1.2/}post_parent'       => 'post_parent',
+				'{http://wordpress.org/export/1.2/}menu_order'        => 'menu_order',
+				'{http://wordpress.org/export/1.2/}post_type'         => 'post_type',
+				'{http://wordpress.org/export/1.2/}post_password'     => 'post_password',
+				'{http://wordpress.org/export/1.2/}is_sticky'         => 'is_sticky',
+				'{http://wordpress.org/export/1.2/}attachment_url'    => 'attachment_url',
 			),
 		),
-		'wp:postmeta'    => array(
+		'{http://wordpress.org/export/1.2/}postmeta'    => array(
 			'type'   => 'post_meta',
 			'fields' => array(
-				'wp:meta_key'   => 'meta_key',
-				'wp:meta_value' => 'meta_value',
+				'{http://wordpress.org/export/1.2/}meta_key'   => 'meta_key',
+				'{http://wordpress.org/export/1.2/}meta_value' => 'meta_value',
 			),
 		),
-		'wp:term'        => array(
+		'{http://wordpress.org/export/1.2/}term'        => array(
 			'type'   => 'term',
 			'fields' => array(
-				'wp:term_id'       => 'term_id',
-				'wp:term_taxonomy' => 'taxonomy',
-				'wp:term_slug'     => 'slug',
-				'wp:term_parent'   => 'parent',
-				'wp:term_name'     => 'name',
+				'{http://wordpress.org/export/1.2/}term_id'       => 'term_id',
+				'{http://wordpress.org/export/1.2/}term_taxonomy' => 'taxonomy',
+				'{http://wordpress.org/export/1.2/}term_slug'     => 'slug',
+				'{http://wordpress.org/export/1.2/}term_parent'   => 'parent',
+				'{http://wordpress.org/export/1.2/}term_name'     => 'name',
 			),
 		),
-		'wp:tag'         => array(
+		'{http://wordpress.org/export/1.2/}tag'         => array(
 			'type'   => 'tag',
 			'fields' => array(
-				'wp:term_id'         => 'term_id',
-				'wp:tag_slug'        => 'slug',
-				'wp:tag_name'        => 'name',
-				'wp:tag_description' => 'description',
+				'{http://wordpress.org/export/1.2/}term_id'         => 'term_id',
+				'{http://wordpress.org/export/1.2/}tag_slug'        => 'slug',
+				'{http://wordpress.org/export/1.2/}tag_name'        => 'name',
+				'{http://wordpress.org/export/1.2/}tag_description' => 'description',
 			),
 		),
-		'wp:category'    => array(
+		'{http://wordpress.org/export/1.2/}category'    => array(
 			'type'   => 'category',
 			'fields' => array(
-				'wp:category_nicename'    => 'slug',
-				'wp:category_parent'      => 'parent',
-				'wp:cat_name'             => 'name',
-				'wp:category_description' => 'description',
+				'{http://wordpress.org/export/1.2/}category_nicename'    => 'slug',
+				'{http://wordpress.org/export/1.2/}category_parent'      => 'parent',
+				'{http://wordpress.org/export/1.2/}cat_name'             => 'name',
+				'{http://wordpress.org/export/1.2/}category_description' => 'description',
 			),
 		),
 	);
@@ -629,8 +637,8 @@ class WXREntityReader implements EntityReader {
 			// Don't process anything outside the <rss> <channel> hierarchy.
 			if (
 				count( $breadcrumbs ) < 2 ||
-				$breadcrumbs[0] !== 'rss' ||
-				$breadcrumbs[1] !== 'channel'
+				$breadcrumbs[0] !== ['', 'rss'] ||
+				$breadcrumbs[1] !== ['', 'channel']
 			) {
 				continue;
 			}
@@ -659,7 +667,8 @@ class WXREntityReader implements EntityReader {
 				$this->last_xml_cursor_outside_of_entity      = $this->xml->get_reentrancy_cursor();
 			}
 
-			$tag = $this->xml->get_tag_local_name();
+			$tag_with_namespace = $this->xml->get_tag_name_with_namespace();
+
 			/**
 			 * Custom adjustment: the Accessibility WXR file uses a non-standard
 			 * wp:wp_author tag.
@@ -668,8 +677,8 @@ class WXREntityReader implements EntityReader {
 			 *        the regular WXR importer would ignore them? Perhaps a warning
 			 *        and an upstream PR would be a better solution.
 			 */
-			if ( $tag === 'wp:wp_author' ) {
-				$tag = 'wp:author';
+			if ( $tag_with_namespace === '{http://wordpress.org/export/1.2/}wp_author' ) {
+				$tag_with_namespace = '{http://wordpress.org/export/1.2/}author';
 			}
 
 			/**
@@ -677,7 +686,7 @@ class WXREntityReader implements EntityReader {
 			 * finished, emit it, and start processing the new entity the next
 			 * time this function is called.
 			 */
-			if ( array_key_exists( $tag, static::KNOWN_ENITIES ) ) {
+			if ( array_key_exists( $tag_with_namespace, static::KNOWN_ENITIES ) ) {
 				if ( $this->entity_type && ! $this->entity_finished ) {
 					$this->emit_entity();
 
@@ -687,7 +696,7 @@ class WXREntityReader implements EntityReader {
 				// Only tag openers indicate a new entity. Closers just mean
 				// the previous entity is finished.
 				if ( $this->xml->is_tag_opener() ) {
-					$this->set_entity_tag( $tag );
+					$this->set_entity_tag( $tag_with_namespace );
 					$this->last_xml_byte_offset_outside_of_entity = $this->xml->get_token_byte_offset_in_the_input_stream();
 					$this->last_xml_cursor_outside_of_entity      = $this->xml->get_reentrancy_cursor();
 				}
@@ -732,18 +741,19 @@ class WXREntityReader implements EntityReader {
 			 */
 			if ( $this->xml->is_tag_opener() ) {
 				$this->last_opener_attributes = array();
-				$names                        = $this->xml->get_attribute_qualified_names_with_prefix( '' );
-				foreach ( $names as $name ) {
-					$this->last_opener_attributes[ $name ] = $this->xml->get_attribute( $name );
+				// Get non-namespaced attributes.
+				$names                        = $this->xml->get_attribute_names_with_prefix( '', '' );
+				foreach ( $names as list($namespace, $name) ) {
+					$this->last_opener_attributes[ $name ] = $this->xml->get_attribute( $namespace, $name );
 				}
 				$this->text_buffer = '';
 
 				$is_site_option_opener = (
 					count( $this->xml->get_breadcrumbs() ) === 3 &&
 					$this->xml->matches_breadcrumbs( array( 'rss', 'channel', '*' ) ) &&
-					array_key_exists( $this->xml->get_tag_local_name(), static::KNOWN_SITE_OPTIONS )
+					array_key_exists( $this->xml->get_tag_name_with_namespace(), static::KNOWN_SITE_OPTIONS )
 				);
-				if ( $is_site_option_opener ) {
+				if ( $is_site_option_opener ) {		
 					$this->last_xml_byte_offset_outside_of_entity = $this->xml->get_token_byte_offset_in_the_input_stream();
 				}
 				continue;
@@ -759,7 +769,7 @@ class WXREntityReader implements EntityReader {
 
 			if (
 				! $this->entity_finished &&
-				$this->xml->get_breadcrumbs() === array( 'rss', 'channel' )
+				$this->xml->get_breadcrumbs() === array( array( '', 'rss' ), array( '', 'channel' ) )
 			) {
 				// Look for site options in children of the <channel> tag.
 				if ( $this->parse_site_option() ) {
@@ -790,7 +800,7 @@ class WXREntityReader implements EntityReader {
 			 */
 			if (
 				$this->entity_type === 'post' &&
-				$tag === 'category' &&
+				$tag_with_namespace === '{http://wordpress.org/export/1.2/}category' &&
 				array_key_exists( 'domain', $this->last_opener_attributes ) &&
 				array_key_exists( 'nicename', $this->last_opener_attributes )
 			) {
@@ -812,11 +822,11 @@ class WXREntityReader implements EntityReader {
 			 * The WXR format is extensible so this reader could potentially
 			 * support registering custom handlers for unknown tags in the future.
 			 */
-			if ( ! isset( static::KNOWN_ENITIES[ $this->entity_tag ]['fields'][ $tag ] ) ) {
+			if ( ! isset( static::KNOWN_ENITIES[ $this->entity_tag ]['fields'][ $tag_with_namespace ] ) ) {
 				continue;
 			}
 
-			$key                       = static::KNOWN_ENITIES[ $this->entity_tag ]['fields'][ $tag ];
+			$key                       = static::KNOWN_ENITIES[ $this->entity_tag ]['fields'][ $tag_with_namespace ];
 			$this->entity_data[ $key ] = $this->text_buffer;
 			$this->text_buffer         = '';
 		} while ( $this->xml->next_token() );
@@ -848,13 +858,13 @@ class WXREntityReader implements EntityReader {
 	 * @return bool Whether a site_option entity was emitted.
 	 */
 	private function parse_site_option() {
-		if ( ! array_key_exists( $this->xml->get_tag_local_name(), static::KNOWN_SITE_OPTIONS ) ) {
+		if ( ! array_key_exists( $this->xml->get_tag_name_with_namespace(), static::KNOWN_SITE_OPTIONS ) ) {
 			return false;
 		}
 
 		$this->entity_type = 'site_option';
 		$this->entity_data = array(
-			'option_name'  => static::KNOWN_SITE_OPTIONS[ $this->xml->get_tag_local_name() ],
+			'option_name'  => static::KNOWN_SITE_OPTIONS[ $this->xml->get_tag_name_with_namespace() ],
 			'option_value' => $this->text_buffer,
 		);
 		$this->emit_entity();
@@ -924,10 +934,10 @@ class WXREntityReader implements EntityReader {
 	 * @since WP_VERSION
 	 *
 	 */
-	private function set_entity_tag( string $tag ) {
-		$this->entity_tag = $tag;
-		if ( array_key_exists( $tag, static::KNOWN_ENITIES ) ) {
-			$this->entity_type = static::KNOWN_ENITIES[ $tag ]['type'];
+	private function set_entity_tag( string $tag_with_namespace ) {
+		$this->entity_tag = $tag_with_namespace;
+		if ( array_key_exists( $tag_with_namespace, static::KNOWN_ENITIES ) ) {
+			$this->entity_type = static::KNOWN_ENITIES[ $tag_with_namespace ]['type'];
 		}
 	}
 

--- a/components/XML/Tests/XMLProcessorTest.php
+++ b/components/XML/Tests/XMLProcessorTest.php
@@ -15,9 +15,9 @@ use WordPress\XML\XMLProcessor;
  * @coversDefaultClass XMLProcessor
  */
 class XMLProcessorTest extends TestCase {
-	const XML_SIMPLE = '<wp:content id="first"><wp:text id="second">Text</wp:text></wp:content>';
-	const XML_WITH_CLASSES = '<wp:content wp:post-type="main with-border" id="first"><wp:text wp:post-type="not-main bold with-border" id="second">Text</wp:text></wp:content>';
-	const XML_MALFORMED = '<wp:content><wp:text wp:post-type="d-md-none" Notifications</wp:text><wp:text wp:post-type="d-none d-md-inline">Back to notifications</wp:text></wp:content>';
+	const XML_SIMPLE = '<wp:content xmlns:wp="w.org" id="first"><wp:text id="second">Text</wp:text></wp:content>';
+	const XML_WITH_CLASSES = '<wp:content xmlns:wp="w.org" wp:post-type="main with-border" id="first"><wp:text wp:post-type="not-main bold with-border" id="second">Text</wp:text></wp:content>';
+	const XML_MALFORMED = '<wp:content xmlns:wp="w.org"><wp:text wp:post-type="d-md-none" Notifications</wp:text><wp:text wp:post-type="d-none d-md-inline">Back to notifications</wp:text></wp:content>';
 
 	public function beforeEach() {
 		$GLOBALS['_doing_it_wrong_messages'] = array();
@@ -26,36 +26,36 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_local_tag_name
+	 * @covers XMLProcessor::get_tag_local_name
 	 */
 	public function test_get_tag_returns_null_before_finding_tags() {
 		$processor = XMLProcessor::create_from_string( '<wp:content>Test</wp:content>' );
 
-		$this->assertNull( $processor->get_local_tag_name(), 'Calling get_tag() without selecting a tag did not return null' );
+		$this->assertNull( $processor->get_tag_local_name(), 'Calling get_tag() without selecting a tag did not return null' );
 	}
 
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_local_tag_name
+	 * @covers XMLProcessor::get_tag_local_name
 	 */
 	public function test_get_tag_returns_null_when_not_in_open_tag() {
-		$processor = XMLProcessor::create_from_string( '<wp:content>Test</wp:content>' );
+		$processor = XMLProcessor::create_from_string( '<wp:content xmlns:wp="w.org">Test</wp:content>' );
 
-		$this->assertFalse( $processor->next_tag( 'p' ), 'Querying a non-existing tag did not return false' );
-		$this->assertNull( $processor->get_local_tag_name(), 'Accessing a non-existing tag did not return null' );
+		$this->assertFalse( $processor->next_tag( array( '', 'p') ), 'Querying a non-existing tag did not return false' );
+		$this->assertNull( $processor->get_tag_local_name(), 'Accessing a non-existing tag did not return null' );
 	}
 
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_local_tag_name
+	 * @covers XMLProcessor::get_tag_local_name
 	 */
 	public function test_get_tag_returns_open_tag_name() {
-		$processor = XMLProcessor::create_from_string( '<wp:content>Test</wp:content>' );
+		$processor = XMLProcessor::create_from_string( '<content>Test</content>' );
 
-		$this->assertTrue( $processor->next_tag( 'wp:content' ), 'Querying an existing tag did not return true' );
-		$this->assertSame( 'wp:content', $processor->get_local_tag_name(), 'Accessing an existing tag name did not return "div"' );
+		$this->assertTrue( $processor->next_tag( 'content' ), 'Querying an existing tag did not return true' );
+		$this->assertSame( 'content', $processor->get_tag_local_name(), 'Accessing an existing tag name did not return "div"' );
 	}
 
 	/**
@@ -110,10 +110,10 @@ class XMLProcessorTest extends TestCase {
 	 * @covers XMLProcessor::get_attribute
 	 */
 	public function test_get_attribute_returns_null_when_not_in_open_tag() {
-		$processor = XMLProcessor::create_from_string( '<wp:content wp:post-type="test">Test</wp:content>' );
+		$processor = XMLProcessor::create_from_string( '<wp:content xmlns:wp="w.org" wp:post-type="test">Test</wp:content>' );
 
 		$this->assertFalse( $processor->next_tag( 'p' ), 'Querying a non-existing tag did not return false' );
-		$this->assertNull( $processor->get_attribute( 'wp:post-type' ),
+		$this->assertNull( $processor->get_attribute( '', 'wp:post-type' ),
 			'Accessing an attribute of a non-existing tag did not return null' );
 	}
 
@@ -123,12 +123,12 @@ class XMLProcessorTest extends TestCase {
 	 * @covers XMLProcessor::get_attribute
 	 */
 	public function test_get_attribute_returns_null_when_in_closing_tag() {
-		$processor = XMLProcessor::create_from_string( '<wp:content wp:post-type="test">Test</wp:content>' );
+		$processor = XMLProcessor::create_from_string( '<wp:content xmlns:wp="w.org" wp:post-type="test">Test</wp:content>' );
 
-		$this->assertTrue( $processor->next_tag( 'wp:content' ), 'Querying an existing tag did not return true' );
+		$this->assertTrue( $processor->next_tag( array( 'w.org', 'content' ) ), 'Querying an existing tag did not return true' );
 		$this->assertTrue( $processor->next_token(), 'Querying an existing closing tag did not return true' );
 		$this->assertTrue( $processor->next_token(), 'Querying an existing closing tag did not return true' );
-		$this->assertNull( $processor->get_attribute( 'wp:post-type' ), 'Accessing an attribute of a closing tag did not return null' );
+		$this->assertNull( $processor->get_attribute( 'w.org', 'post-type' ), 'Accessing an attribute of a closing tag did not return null' );
 	}
 
 	/**
@@ -137,10 +137,10 @@ class XMLProcessorTest extends TestCase {
 	 * @covers XMLProcessor::get_attribute
 	 */
 	public function test_get_attribute_returns_null_when_attribute_missing() {
-		$processor = XMLProcessor::create_from_string( '<wp:content wp:post-type="test">Test</wp:content>' );
+		$processor = XMLProcessor::create_from_string( '<wp:content xmlns:wp="w.org" wp:post-type="test">Test</wp:content>' );
 
-		$this->assertTrue( $processor->next_tag( 'wp:content' ), 'Querying an existing tag did not return true' );
-		$this->assertNull( $processor->get_attribute( 'test-id' ), 'Accessing a non-existing attribute did not return null' );
+		$this->assertTrue( $processor->next_tag( array( 'w.org', 'content' ) ), 'Querying an existing tag did not return true' );
+		$this->assertNull( $processor->get_attribute( '', 'test-id' ), 'Accessing a non-existing attribute did not return null' );
 	}
 
 	/**
@@ -150,9 +150,9 @@ class XMLProcessorTest extends TestCase {
 	 * @covers XMLProcessor::get_attribute
 	 */
 	public function test_attributes_are_rejected_in_tag_closers() {
-		$processor = XMLProcessor::create_from_string( '<wp:content>Test</wp:content wp:post-type="test">' );
+		$processor = XMLProcessor::create_from_string( '<content>Test</content post-type="test">' );
 
-		$this->assertTrue( $processor->next_tag( 'wp:content' ), 'Querying an existing tag did not return true' );
+		$this->assertTrue( $processor->next_tag( 'content' ), 'Querying an existing tag did not return true' );
 		$this->assertTrue( $processor->next_token(), 'Querying a text node did not return true.' );
 		$this->assertFalse( $processor->next_token(), 'Querying an existing but invalid closing tag did not return false.' );
 	}
@@ -163,10 +163,10 @@ class XMLProcessorTest extends TestCase {
 	 * @covers XMLProcessor::get_attribute
 	 */
 	public function test_get_attribute_returns_attribute_value() {
-		$processor = XMLProcessor::create_from_string( '<wp:content wp:post-type="test">Test</wp:content>' );
+		$processor = XMLProcessor::create_from_string( '<wp:content wp:post-type="test" xmlns:wp="w.org">Test</wp:content>' );
 
-		$this->assertTrue( $processor->next_tag( 'wp:content' ), 'Querying an existing tag did not return true' );
-		$this->assertSame( 'test', $processor->get_attribute( 'wp:post-type' ),
+		$this->assertTrue( $processor->next_tag( array( 'breadcrumbs' => array( array( 'w.org', 'content' ) ) ) ), 'Querying an existing tag did not return true' );
+		$this->assertSame( 'test', $processor->get_attribute( 'w.org', 'post-type' ),
 			'Accessing a wp:post-type="test" attribute value did not return "test"' );
 	}
 
@@ -201,10 +201,10 @@ class XMLProcessorTest extends TestCase {
 	 * @covers XMLProcessor::get_attribute
 	 */
 	public function test_malformed_attribute_value_containing_ampersand_is_treated_as_plaintext() {
-		$processor = XMLProcessor::create_from_string( '<wp:content enabled="WordPress & WordPress">Test</wp:content>' );
+		$processor = XMLProcessor::create_from_string( '<wp:content xmlns:wp="w.org" enabled="WordPress & WordPress">Test</wp:content>' );
 
 		$this->assertTrue( $processor->next_tag(), 'Querying a tag did not return true' );
-		$this->assertEquals( 'WordPress & WordPress', $processor->get_attribute( 'enabled' ) );
+		$this->assertEquals( 'WordPress & WordPress', $processor->get_attribute( '', 'enabled' ) );
 	}
 
 	/**
@@ -214,10 +214,10 @@ class XMLProcessorTest extends TestCase {
 	 * @covers XMLProcessor::get_attribute
 	 */
 	public function test_malformed_attribute_value_containing_entity_without_semicolon_is_treated_as_plaintext() {
-		$processor = XMLProcessor::create_from_string( '<wp:content enabled="&#x94">Test</wp:content>' );
+		$processor = XMLProcessor::create_from_string( '<wp:content xmlns:wp="w.org" enabled="&#x94">Test</wp:content>' );
 
 		$this->assertTrue( $processor->next_tag(), 'Querying a tag did not return true' );
-		$this->assertEquals( '&#x94', $processor->get_attribute( 'enabled' ) );
+		$this->assertEquals( '&#x94', $processor->get_attribute( '', 'enabled' ) );
 	}
 
 	/**
@@ -262,7 +262,7 @@ class XMLProcessorTest extends TestCase {
 	 * @covers XMLProcessor::get_attribute
 	 */
 	public function test_get_modifiable_text_returns_a_decoded_value() {
-		$processor = XMLProcessor::create_from_string( '<root>&#x201C;&#x1f604;&#x201D;</root>' );
+		$processor = XMLProcessor::create_from_string( '<root xmlns:wp="w.org">&#x201C;&#x1f604;&#x201D;</root>' );
 
 		$processor->next_tag( 'root' );
 		$processor->next_token();
@@ -285,7 +285,7 @@ class XMLProcessorTest extends TestCase {
 		$this->assertTrue( $processor->next_tag( 'root' ), 'Querying a tag did not return true' );
 		$this->assertEquals(
 			'“😄”',
-			$processor->get_attribute( 'encoded-data' ),
+			$processor->get_attribute( '', 'encoded-data' ),
 			'Reading an encoded attribute did not decode it.'
 		);
 	}
@@ -298,17 +298,17 @@ class XMLProcessorTest extends TestCase {
 	 * @param  string  $attribute_name  Name of data-enabled attribute with case variations.
 	 */
 	public function test_get_attribute_is_case_sensitive() {
-		$processor = XMLProcessor::create_from_string( '<wp:content DATA-enabled="true">Test</wp:content>' );
+		$processor = XMLProcessor::create_from_string( '<wp:content xmlns:wp="w.org" DATA-enabled="true">Test</wp:content>' );
 		$processor->next_tag();
 
 		$this->assertEquals(
 			'true',
-			$processor->get_attribute( 'DATA-enabled' ),
+			$processor->get_attribute( '', 'DATA-enabled' ),
 			'Accessing an attribute by a same-cased name did return not its value'
 		);
 
 		$this->assertNull(
-			$processor->get_attribute( 'data-enabled' ),
+			$processor->get_attribute( '', 'data-enabled' ),
 			'Accessing an attribute by a differently-cased name did return its value'
 		);
 	}
@@ -322,14 +322,14 @@ class XMLProcessorTest extends TestCase {
 	public function test_remove_attribute_is_case_sensitive() {
 		$processor = XMLProcessor::create_from_string( '<wp:content DATA-enabled="true">Test</wp:content>' );
 		$processor->next_tag();
-		$processor->remove_attribute( 'data-enabled' );
+		$processor->remove_attribute( '', 'data-enabled' );
 
 		$this->assertSame( '<wp:content DATA-enabled="true">Test</wp:content>', $processor->get_updated_xml(),
 			'A case-sensitive remove_attribute call did remove the attribute' );
 
-		$processor->remove_attribute( 'DATA-enabled' );
+		$processor->remove_attribute( '', 'DATA-enabled' );
 
-		$this->assertSame( '<wp:content >Test</wp:content>', $processor->get_updated_xml(),
+		$this->assertSame( '<wp:content DATA-enabled="true">Test</wp:content>', $processor->get_updated_xml(),
 			'A case-sensitive remove_attribute call did not remove the attribute' );
 	}
 
@@ -339,11 +339,11 @@ class XMLProcessorTest extends TestCase {
 	 * @covers XMLProcessor::set_attribute
 	 */
 	public function test_set_attribute_is_case_sensitive() {
-		$processor = XMLProcessor::create_from_string( '<wp:content DATA-enabled="true">Test</wp:content>' );
+		$processor = XMLProcessor::create_from_string( '<wp:content xmlns:wp="w.org" DATA-enabled="true">Test</wp:content>' );
 		$processor->next_tag();
-		$processor->set_attribute( 'data-enabled', 'abc' );
+		$processor->set_attribute( '', 'data-enabled', 'abc' );
 
-		$this->assertSame( '<wp:content data-enabled="abc" DATA-enabled="true">Test</wp:content>', $processor->get_updated_xml(),
+		$this->assertSame( '<wp:content data-enabled="abc" xmlns:wp="w.org" DATA-enabled="true">Test</wp:content>', $processor->get_updated_xml(),
 			'A case-insensitive set_attribute call did not update the existing attribute' );
 	}
 
@@ -355,7 +355,7 @@ class XMLProcessorTest extends TestCase {
 	public function test_get_attribute_names_with_prefix_returns_null_before_finding_tags() {
 		$processor = XMLProcessor::create_from_string( '<wp:content data-foo="bar">Test</wp:content>' );
 		$this->assertNull(
-			$processor->get_attribute_qualified_names_with_prefix( 'data-' ),
+			$processor->get_attribute_names_with_prefix( '', 'data-' ),
 			'Accessing attributes by their prefix did not return null when no tag was selected'
 		);
 	}
@@ -366,9 +366,9 @@ class XMLProcessorTest extends TestCase {
 	 * @covers XMLProcessor::get_attribute_qualified_names_with_prefix
 	 */
 	public function test_get_attribute_names_with_prefix_returns_null_when_not_in_open_tag() {
-		$processor = XMLProcessor::create_from_string( '<wp:content data-foo="bar">Test</wp:content>' );
-		$processor->next_tag( 'p' );
-		$this->assertNull( $processor->get_attribute_qualified_names_with_prefix( 'data-' ),
+		$processor = XMLProcessor::create_from_string( '<wp:content xmlns:wp="w.org" data-foo="bar">Test</wp:content>' );
+		$processor->next_tag( 'w.org', 'content' );
+		$this->assertNull( $processor->get_attribute_names_with_prefix( '', 'data-' ),
 			'Accessing attributes of a non-existing tag did not return null' );
 	}
 
@@ -378,11 +378,11 @@ class XMLProcessorTest extends TestCase {
 	 * @covers XMLProcessor::get_attribute_qualified_names_with_prefix
 	 */
 	public function test_get_attribute_names_with_prefix_returns_null_when_in_closing_tag() {
-		$processor = XMLProcessor::create_from_string( '<wp:content data-foo="bar">Test</wp:content>' );
-		$processor->next_tag( 'wp:content' );
+		$processor = XMLProcessor::create_from_string( '<wp:content xmlns:wp="w.org" data-foo="bar">Test</wp:content>' );
+		$processor->next_tag( 'w.org', 'content' );
 		$processor->next_tag( array( 'tag_closers' => 'visit' ) );
 
-		$this->assertNull( $processor->get_attribute_qualified_names_with_prefix( 'data-' ),
+		$this->assertNull( $processor->get_attribute_names_with_prefix( '', 'data-' ),
 			'Accessing attributes of a closing tag did not return null' );
 	}
 
@@ -395,7 +395,7 @@ class XMLProcessorTest extends TestCase {
 		$processor = XMLProcessor::create_from_string( '<wp:content>Test</wp:content>' );
 		$processor->next_tag( 'wp:content' );
 
-		$this->assertSame( array(), $processor->get_attribute_qualified_names_with_prefix( 'data-' ),
+		$this->assertSame( array(), $processor->get_attribute_names_with_prefix( '', 'data-' ),
 			'Accessing the attributes on a tag without any did not return an empty array' );
 	}
 
@@ -405,12 +405,12 @@ class XMLProcessorTest extends TestCase {
 	 * @covers XMLProcessor::get_attribute_qualified_names_with_prefix
 	 */
 	public function test_get_attribute_names_with_prefix_returns_matching_attribute_names_in_original_case() {
-		$processor = XMLProcessor::create_from_string( '<wp:content DATA-enabled="yes" wp:post-type="test" data-test-ID="14">Test</wp:content>' );
+		$processor = XMLProcessor::create_from_string( '<content DATA-enabled="yes" post-type="test" data-test-ID="14">Test</content>' );
 		$processor->next_tag();
 
 		$this->assertSame(
-			array( 'data-test-ID' ),
-			$processor->get_attribute_qualified_names_with_prefix( 'data-' ),
+			array( array( '', 'data-test-ID' ) ),
+			$processor->get_attribute_names_with_prefix( '', 'data-' ),
 			'Accessing attributes by their prefix did not return their lowercase names'
 		);
 	}
@@ -421,18 +421,18 @@ class XMLProcessorTest extends TestCase {
 	 * @covers XMLProcessor::get_attribute_qualified_names_with_prefix
 	 */
 	public function test_get_attribute_names_with_prefix_returns_attribute_added_by_set_attribute() {
-		$processor = XMLProcessor::create_from_string( '<wp:content data-foo="bar">Test</wp:content>' );
+		$processor = XMLProcessor::create_from_string( '<content data-foo="bar">Test</content>' );
 		$processor->next_tag();
-		$processor->set_attribute( 'data-test-id', '14' );
+		$processor->set_attribute( '', 'data-test-id', '14' );
 
 		$this->assertSame(
-			'<wp:content data-test-id="14" data-foo="bar">Test</wp:content>',
+			'<content data-test-id="14" data-foo="bar">Test</content>',
 			$processor->get_updated_xml(),
 			"Updated XML doesn't include attribute added via set_attribute"
 		);
 		$this->assertSame(
-			array( 'data-test-id', 'data-foo' ),
-			$processor->get_attribute_qualified_names_with_prefix( 'data-' ),
+			array( array( '', 'data-test-id' ), array( '', 'data-foo' ) ),
+			$processor->get_attribute_names_with_prefix( '', 'data-' ),
 			"Accessing attribute names doesn't find attribute added via set_attribute"
 		);
 	}
@@ -443,12 +443,13 @@ class XMLProcessorTest extends TestCase {
 	 * @covers XMLProcessor::__toString
 	 */
 	public function test_to_string_returns_updated_xml() {
-		$processor = XMLProcessor::create_from_string( '<line id="remove" /><wp:content enabled="yes" wp:post-type="test">Test</wp:content><wp:text id="span-id"></wp:text>' );
+		$processor = XMLProcessor::create_from_string( '<root xmlns:wp="w.org"><line id="remove" /><wp:content enabled="yes" wp:post-type="test">Test</wp:content><wp:text id="span-id"></wp:text></root>' );
 		$processor->next_tag();
-		$processor->remove_attribute( 'id' );
+		$processor->next_tag();
+		$processor->remove_attribute( '', 'id' );
 
 		$processor->next_tag();
-		$processor->set_attribute( 'id', 'wp:content-id-1' );
+		$processor->set_attribute( '', 'id', 'wp:content-id-1' );
 
 		$this->assertSame(
 			$processor->get_updated_xml(),
@@ -463,32 +464,32 @@ class XMLProcessorTest extends TestCase {
 	 * @covers XMLProcessor::get_updated_xml
 	 */
 	public function test_get_updated_xml_applies_the_updates_so_far_and_keeps_the_processor_on_the_current_tag() {
-		$processor = XMLProcessor::create_from_string( '<line id="remove" /><wp:content enabled="yes" wp:post-type="test">Test</wp:content><wp:text id="span-id"></wp:text>' );
+		$processor = XMLProcessor::create_from_string( '<line id="remove" /><content enabled="yes" post-type="test">Test</content><text id="span-id"></text>' );
 		$processor->next_tag();
-		$processor->remove_attribute( 'id' );
+		$processor->remove_attribute( '', 'id' );
 
 		$processor->next_tag();
-		$processor->set_attribute( 'id', 'wp:content-id-1' );
+		$processor->set_attribute( '', 'id', 'content-id-1' );
 
 		$this->assertSame(
-			'<line  /><wp:content id="wp:content-id-1" enabled="yes" wp:post-type="test">Test</wp:content><wp:text id="span-id"></wp:text>',
+			'<line  /><content id="content-id-1" enabled="yes" post-type="test">Test</content><text id="span-id"></text>',
 			$processor->get_updated_xml(),
 			'Calling get_updated_xml after updating the attributes of the second tag returned different XML than expected'
 		);
 
-		$processor->set_attribute( 'id', 'wp:content-id-2' );
+		$processor->set_attribute( '', 'id', 'content-id-2' );
 
 		$this->assertSame(
-			'<line  /><wp:content id="wp:content-id-2" enabled="yes" wp:post-type="test">Test</wp:content><wp:text id="span-id"></wp:text>',
+			'<line  /><content id="content-id-2" enabled="yes" post-type="test">Test</content><text id="span-id"></text>',
 			$processor->get_updated_xml(),
 			'Calling get_updated_xml after updating the attributes of the second tag for the second time returned different XML than expected'
 		);
 
 		$processor->next_tag();
-		$processor->remove_attribute( 'id' );
+		$processor->remove_attribute( '', 'id' );
 
 		$this->assertSame(
-			'<line  /><wp:content id="wp:content-id-2" enabled="yes" wp:post-type="test">Test</wp:content><wp:text ></wp:text>',
+			'<line  /><content id="content-id-2" enabled="yes" post-type="test">Test</content><text ></text>',
 			$processor->get_updated_xml(),
 			'Calling get_updated_xml after removing the id attribute of the third tag returned different XML than expected'
 		);
@@ -517,17 +518,17 @@ class XMLProcessorTest extends TestCase {
 	 * @expectedIncorrectUsage XMLProcessor::parse_next_attribute
 	 */
 	public function test_get_updated_xml_applies_updates_to_content_after_seeking_to_before_parsed_bytes() {
-		$processor = XMLProcessor::create_from_string( '<wp:content><photo hidden></wp:content>' );
+		$processor = XMLProcessor::create_from_string( '<wp:content xmlns:wp="w.org"><photo hidden></wp:content>' );
 
 		$processor->next_tag();
-		$processor->set_attribute( 'wonky', 'true' );
+		$processor->set_attribute( '', 'wonky', 'true' );
 		$processor->next_tag();
 		$processor->set_bookmark( 'here' );
 
 		$processor->next_tag( array( 'tag_closers' => 'visit' ) );
 		$processor->seek( 'here' );
 
-		$this->assertSame( '<wp:content wonky="true"><photo hidden></wp:content>', $processor->get_updated_xml() );
+		$this->assertSame( '<wp:content wonky="true" xmlns:wp="w.org"><photo hidden></wp:content>', $processor->get_updated_xml() );
 	}
 
 	public function test_declare_element_as_pcdata() {
@@ -545,7 +546,7 @@ class XMLProcessorTest extends TestCase {
 			But! It is all treated as text.
 		';
 		$processor = XMLProcessor::create_from_string(
-			"<root><my-pcdata>$text</my-pcdata></root>"
+			"<root xmlns:wp=\"w.org\"><my-pcdata>$text</my-pcdata></root>"
 		);
 		$processor->declare_element_as_pcdata( 'my-pcdata' );
 		$processor->next_tag( 'my-pcdata' );
@@ -622,34 +623,34 @@ class XMLProcessorTest extends TestCase {
 	public static function data_xml_nth_token_substring() {
 		return array(
 			// Tags.
-			'DIV start tag'                 => array( '<wp:content>', 1, '<wp:content>' ),
+			'DIV start tag'                 => array( '<content>', 1, '<content>' ),
 			'DIV start tag with attributes' => array(
-				'<wp:content wp:post-type="x" disabled="yes">',
+				'<content post-type="x" disabled="yes">',
 				1,
-				'<wp:content wp:post-type="x" disabled="yes">',
+				'<content post-type="x" disabled="yes">',
 			),
-			'Nested DIV'                    => array( '<wp:content><wp:content b="yes">', 2, '<wp:content b="yes">' ),
-			'Sibling DIV'                   => array( '<wp:content></wp:content><wp:content b="yes">', 3, '<wp:content b="yes">' ),
-			'DIV before text'               => array( '<wp:content> text', 1, '<wp:content>' ),
-			'DIV after comment'             => array( '<root><!-- comment --><wp:content>', 3, '<wp:content>' ),
-			'DIV before comment'            => array( '<wp:content><!-- c --> ', 1, '<wp:content>' ),
-			'Start "self-closing" tag'      => array( '<wp:content />', 1, '<wp:content />' ),
+			'Nested DIV'                    => array( '<content><content b="yes">', 2, '<content b="yes">' ),
+			'Sibling DIV'                   => array( '<content></content><content b="yes">', 3, '<content b="yes">' ),
+			'DIV before text'               => array( '<content> text', 1, '<content>' ),
+			'DIV after comment'             => array( '<root><!-- comment --><content>', 3, '<content>' ),
+			'DIV before comment'            => array( '<content><!-- c --> ', 1, '<content>' ),
+			'Start "self-closing" tag'      => array( '<content />', 1, '<content />' ),
 			'Void tag'                      => array( '<photo src="img.png">', 1, '<photo src="img.png">' ),
 			'Void tag w/self-closing flag'  => array( '<photo src="img.png" />', 1, '<photo src="img.png" />' ),
-			'Void tag inside DIV'           => array( '<wp:content><photo src="img.png"></wp:content>', 2, '<photo src="img.png">' ),
+			'Void tag inside DIV'           => array( '<content><photo src="img.png"></content>', 2, '<photo src="img.png">' ),
 
 			// Text.
 			'Text'                          => array( 'Just text</data>', 1, 'Just text' ),
-			'Text in DIV'                   => array( '<wp:content>Text<wp:content>', 2, 'Text' ),
-			'Text before DIV'               => array( 'Text<wp:content>', 1, 'Text' ),
+			'Text in DIV'                   => array( '<content>Text<content>', 2, 'Text' ),
+			'Text before DIV'               => array( 'Text<content>', 1, 'Text' ),
 			'Text after comment'            => array( '<!-- comment -->Text<!-- c -->', 2, 'Text' ),
 			'Text before comment'           => array( 'Text<!-- c --> ', 1, 'Text' ),
 
 			// Comments.
 			'Comment'                       => array( '<!-- comment -->', 1, '<!-- comment -->' ),
-			'Comment in DIV'                => array( '<wp:content><!-- comment --><wp:content>', 2, '<!-- comment -->' ),
-			'Comment before DIV'            => array( '<!-- comment --><wp:content>', 1, '<!-- comment -->' ),
-			'Comment after DIV'             => array( '<wp:content></wp:content><!-- comment -->', 3, '<!-- comment -->' ),
+			'Comment in DIV'                => array( '<content ><!-- comment --><content>', 2, '<!-- comment -->' ),
+			'Comment before DIV'            => array( '<!-- comment --><content>', 1, '<!-- comment -->' ),
+			'Comment after DIV'             => array( '<content ></content><!-- comment -->', 3, '<!-- comment -->' ),
 			'Comment after comment'         => array( '<!-- comment --><!-- comment -->', 2, '<!-- comment -->' ),
 			'Comment before comment'        => array( '<!-- comment --><!-- c --> ', 1, '<!-- comment -->' ),
 			'Empty comment'                 => array( '<!---->', 1, '<!---->' ),
@@ -685,7 +686,7 @@ class XMLProcessorTest extends TestCase {
 	 */
 	public function test_normalizes_carriage_returns_in_text_nodes() {
 		$processor = XMLProcessor::create_from_string(
-			"<wp:content>We are\rnormalizing\r\n\nthe\n\r\r\r\ncarriage returns</wp:content>"
+			"<content>We are\rnormalizing\r\n\nthe\n\r\r\r\ncarriage returns</content>"
 		);
 		$processor->next_tag();
 		$processor->next_token();
@@ -703,7 +704,7 @@ class XMLProcessorTest extends TestCase {
 	 */
 	public function test_normalizes_carriage_returns_in_cdata() {
 		$processor = XMLProcessor::create_from_string(
-			"<wp:content><![CDATA[We are\rnormalizing\r\n\nthe\n\r\r\r\ncarriage returns]]>"
+			"<content><![CDATA[We are\rnormalizing\r\n\nthe\n\r\r\r\ncarriage returns]]>"
 		);
 		$processor->next_tag();
 		$processor->next_token();
@@ -722,10 +723,10 @@ class XMLProcessorTest extends TestCase {
 	 * @covers XMLProcessor::is_tag_closer
 	 */
 	public function test_next_tag_should_not_stop_on_closers() {
-		$processor = XMLProcessor::create_from_string( '<wp:content><photo /></wp:content>' );
+		$processor = XMLProcessor::create_from_string( '<wp:content xmlns:wp="w.org"><photo /></wp:content>' );
 
-		$this->assertTrue( $processor->next_tag( array( 'breadcrumbs' => array( 'wp:content' ) ) ), 'Did not find desired tag opener' );
-		$this->assertFalse( $processor->next_tag( array( 'breadcrumbs' => array( 'wp:content' ) ) ),
+		$this->assertTrue( $processor->next_tag( array( 'breadcrumbs' => array( array( 'w.org', 'content' ) ) ) ), 'Did not find desired tag opener' );
+		$this->assertFalse( $processor->next_tag( array( 'breadcrumbs' => array( array( 'w.org', 'content' ) ) ) ),
 			'Visited an unwanted tag, a tag closer' );
 	}
 
@@ -738,11 +739,11 @@ class XMLProcessorTest extends TestCase {
 	 * @covers XMLProcessor::get_updated_xml
 	 */
 	public function test_internal_pointer_returns_to_original_spot_after_inserting_content_before_cursor() {
-		$tags = XMLProcessor::create_from_string( '<root><wp:content>outside</wp:content><section><wp:content><photo>inside</wp:content></section></root>' );
+		$tags = XMLProcessor::create_from_string( '<root xmlns:wp="w.org"><wp:content>outside</wp:content><section><wp:content><photo>inside</wp:content></section></root>' );
 
 		$tags->next_tag();
 		$tags->next_tag();
-		$tags->set_attribute( 'wp:post-type', 'foo' );
+		$tags->set_attribute( '', 'wp:post-type', 'foo' );
 		$tags->next_tag( 'section' );
 
 		// Return to this spot after moving ahead.
@@ -751,9 +752,9 @@ class XMLProcessorTest extends TestCase {
 		// Move ahead.
 		$tags->next_tag( 'photo' );
 		$tags->seek( 'here' );
-		$this->assertSame( '<root><wp:content wp:post-type="foo">outside</wp:content><section><wp:content><photo>inside</wp:content></section></root>',
+		$this->assertSame( '<root xmlns:wp="w.org"><wp:content wp:post-type="foo">outside</wp:content><section><wp:content><photo>inside</wp:content></section></root>',
 			$tags->get_updated_xml() );
-		$this->assertSame( 'section', $tags->get_local_tag_name() );
+		$this->assertSame( 'section', $tags->get_tag_local_name() );
 		$this->assertFalse( $tags->is_tag_closer() );
 	}
 
@@ -768,7 +769,7 @@ class XMLProcessorTest extends TestCase {
 		$this->assertFalse( $processor->next_tag( 'p' ), 'Querying a non-existing tag did not return false' );
 		$this->assertFalse( $processor->next_tag( 'wp:content' ), 'Querying a non-existing tag did not return false' );
 
-		$processor->set_attribute( 'id', 'primary' );
+		$processor->set_attribute( '', 'id', 'primary' );
 
 		$this->assertSame(
 			self::XML_SIMPLE,
@@ -786,18 +787,18 @@ class XMLProcessorTest extends TestCase {
 	 * @covers XMLProcessor::remove_class
 	 */
 	public function test_attribute_ops_on_tag_closer_do_not_change_the_markup() {
-		$processor = XMLProcessor::create_from_string( '<wp:content id="3"></wp:content>' );
+		$processor = XMLProcessor::create_from_string( '<wp:content xmlns:wp="w.org" id="3"></wp:content>' );
 		$processor->next_token();
 		$this->assertFalse( $processor->is_tag_closer(), 'Skipped tag opener' );
 
 		$processor->next_token();
 		$this->assertTrue( $processor->is_tag_closer(), 'Skipped tag closer' );
-		$this->assertFalse( $processor->set_attribute( 'id', 'test' ),
+		$this->assertFalse( $processor->set_attribute( '', 'id', 'test' ),
 			"Allowed setting an attribute on a tag closer when it shouldn't have" );
-		$this->assertFalse( $processor->remove_attribute( 'invalid-id' ),
+		$this->assertFalse( $processor->remove_attribute( '', 'invalid-id' ),
 			"Allowed removing an attribute on a tag closer when it shouldn't have" );
 		$this->assertSame(
-			'<wp:content id="3"></wp:content>',
+			'<wp:content xmlns:wp="w.org" id="3"></wp:content>',
 			$processor->get_updated_xml(),
 			'Calling get_updated_xml after updating a non-existing tag returned an XML that was different from the original XML'
 		);
@@ -812,16 +813,16 @@ class XMLProcessorTest extends TestCase {
 	public function test_set_attribute_with_a_non_existing_attribute_adds_a_new_attribute_to_the_markup() {
 		$processor = XMLProcessor::create_from_string( self::XML_SIMPLE );
 		$processor->next_tag();
-		$processor->set_attribute( 'test-attribute', 'test-value' );
+		$processor->set_attribute( '', 'test-attribute', 'test-value' );
 
 		$this->assertSame(
-			'<wp:content test-attribute="test-value" id="first"><wp:text id="second">Text</wp:text></wp:content>',
+			'<wp:content test-attribute="test-value" xmlns:wp="w.org" id="first"><wp:text id="second">Text</wp:text></wp:content>',
 			$processor->get_updated_xml(),
 			'Updated XML does not include attribute added via set_attribute()'
 		);
 		$this->assertSame(
 			'test-value',
-			$processor->get_attribute( 'test-attribute' ),
+			$processor->get_attribute( '', 'test-attribute' ),
 			'get_attribute() (called after get_updated_xml()) did not return attribute added via set_attribute()'
 		);
 	}
@@ -834,15 +835,15 @@ class XMLProcessorTest extends TestCase {
 	public function test_get_attribute_returns_updated_values_before_they_are_applied() {
 		$processor = XMLProcessor::create_from_string( self::XML_SIMPLE );
 		$processor->next_tag();
-		$processor->set_attribute( 'test-attribute', 'test-value' );
+		$processor->set_attribute( '', 'test-attribute', 'test-value' );
 
 		$this->assertSame(
 			'test-value',
-			$processor->get_attribute( 'test-attribute' ),
+			$processor->get_attribute( '', 'test-attribute' ),
 			'get_attribute() (called before get_updated_xml()) did not return attribute added via set_attribute()'
 		);
 		$this->assertSame(
-			'<wp:content test-attribute="test-value" id="first"><wp:text id="second">Text</wp:text></wp:content>',
+			'<wp:content test-attribute="test-value" xmlns:wp="w.org" id="first"><wp:text id="second">Text</wp:text></wp:content>',
 			$processor->get_updated_xml(),
 			'Updated XML does not include attribute added via set_attribute()'
 		);
@@ -856,15 +857,15 @@ class XMLProcessorTest extends TestCase {
 	public function test_get_attribute_returns_updated_values_before_they_are_applied_with_different_name_casing() {
 		$processor = XMLProcessor::create_from_string( self::XML_SIMPLE );
 		$processor->next_tag();
-		$processor->set_attribute( 'test-ATTribute', 'test-value' );
+		$processor->set_attribute( '', 'test-ATTribute', 'test-value' );
 
 		$this->assertSame(
 			'test-value',
-			$processor->get_attribute( 'test-ATTribute' ),
+			$processor->get_attribute( '', 'test-ATTribute' ),
 			'get_attribute() (called before get_updated_xml()) did not return attribute added via set_attribute()'
 		);
 		$this->assertSame(
-			'<wp:content test-ATTribute="test-value" id="first"><wp:text id="second">Text</wp:text></wp:content>',
+			'<wp:content test-ATTribute="test-value" xmlns:wp="w.org" id="first"><wp:text id="second">Text</wp:text></wp:content>',
 			$processor->get_updated_xml(),
 			'Updated XML does not include attribute added via set_attribute()'
 		);
@@ -879,14 +880,14 @@ class XMLProcessorTest extends TestCase {
 	public function test_get_attribute_reflects_removed_attribute_before_it_is_applied() {
 		$processor = XMLProcessor::create_from_string( self::XML_SIMPLE );
 		$processor->next_tag();
-		$processor->remove_attribute( 'id' );
+		$processor->remove_attribute( '', 'id' );
 
 		$this->assertNull(
-			$processor->get_attribute( 'id' ),
+			$processor->get_attribute( '', 'id' ),
 			'get_attribute() (called before get_updated_xml()) returned attribute that was removed by remove_attribute()'
 		);
 		$this->assertSame(
-			'<wp:content ><wp:text id="second">Text</wp:text></wp:content>',
+			'<wp:content xmlns:wp="w.org" ><wp:text id="second">Text</wp:text></wp:content>',
 			$processor->get_updated_xml(),
 			'Updated XML includes attribute that was removed by remove_attribute()'
 		);
@@ -900,11 +901,11 @@ class XMLProcessorTest extends TestCase {
 	public function test_get_attribute_reflects_adding_and_then_removing_an_attribute_before_those_updates_are_applied() {
 		$processor = XMLProcessor::create_from_string( self::XML_SIMPLE );
 		$processor->next_tag();
-		$processor->set_attribute( 'test-attribute', 'test-value' );
-		$processor->remove_attribute( 'test-attribute' );
+		$processor->set_attribute( '', 'test-attribute', 'test-value' );
+		$processor->remove_attribute( '', 'test-attribute' );
 
 		$this->assertNull(
-			$processor->get_attribute( 'test-attribute' ),
+			$processor->get_attribute( '', 'test-attribute' ),
 			'get_attribute() (called before get_updated_xml()) returned attribute that was added via set_attribute() and then removed by remove_attribute()'
 		);
 		$this->assertSame(
@@ -922,15 +923,15 @@ class XMLProcessorTest extends TestCase {
 	public function test_get_attribute_reflects_setting_and_then_removing_an_existing_attribute_before_those_updates_are_applied() {
 		$processor = XMLProcessor::create_from_string( self::XML_SIMPLE );
 		$processor->next_tag();
-		$processor->set_attribute( 'id', 'test-value' );
-		$processor->remove_attribute( 'id' );
+		$processor->set_attribute( '', 'id', 'test-value' );
+		$processor->remove_attribute( '', 'id' );
 
 		$this->assertNull(
-			$processor->get_attribute( 'id' ),
+			$processor->get_attribute( '', 'id' ),
 			'get_attribute() (called before get_updated_xml()) returned attribute that was overwritten by set_attribute() and then removed by remove_attribute()'
 		);
 		$this->assertSame(
-			'<wp:content ><wp:text id="second">Text</wp:text></wp:content>',
+			'<wp:content xmlns:wp="w.org" ><wp:text id="second">Text</wp:text></wp:content>',
 			$processor->get_updated_xml(),
 			'Updated XML includes attribute that was overwritten by set_attribute() and then removed by remove_attribute()'
 		);
@@ -944,9 +945,9 @@ class XMLProcessorTest extends TestCase {
 	public function test_set_attribute_with_an_existing_attribute_name_updates_its_value_in_the_markup() {
 		$processor = XMLProcessor::create_from_string( self::XML_SIMPLE );
 		$processor->next_tag();
-		$processor->set_attribute( 'id', 'new-id' );
+		$processor->set_attribute( '', 'id', 'new-id' );
 		$this->assertSame(
-			'<wp:content id="new-id"><wp:text id="second">Text</wp:text></wp:content>',
+			'<wp:content xmlns:wp="w.org" id="new-id"><wp:text id="second">Text</wp:text></wp:content>',
 			$processor->get_updated_xml(),
 			'Existing attribute was not updated'
 		);
@@ -961,13 +962,13 @@ class XMLProcessorTest extends TestCase {
 	 * @covers XMLProcessor::set_attribute
 	 */
 	public function test_set_attribute_with_case_variants_updates_only_the_original_first_copy() {
-		$processor = XMLProcessor::create_from_string( '<wp:content data-enabled="5">' );
+		$processor = XMLProcessor::create_from_string( '<wp:content xmlns:wp="w.org" data-enabled="5">' );
 		$processor->next_tag();
-		$processor->set_attribute( 'data-enabled', 'canary1' );
-		$processor->set_attribute( 'data-enabled', 'canary2' );
-		$processor->set_attribute( 'data-enabled', 'canary3' );
+		$processor->set_attribute( '', 'data-enabled', 'canary1' );
+		$processor->set_attribute( '', 'data-enabled', 'canary2' );
+		$processor->set_attribute( '', 'data-enabled', 'canary3' );
 
-		$this->assertSame( '<wp:content data-enabled="canary3">', strtolower( $processor->get_updated_xml() ) );
+		$this->assertSame( '<wp:content xmlns:wp="w.org" data-enabled="canary3">', strtolower( $processor->get_updated_xml() ) );
 	}
 
 	/**
@@ -979,11 +980,11 @@ class XMLProcessorTest extends TestCase {
 	public function test_next_tag_and_set_attribute_in_a_loop_update_all_tags_in_the_markup() {
 		$processor = XMLProcessor::create_from_string( self::XML_SIMPLE );
 		while ( $processor->next_tag() ) {
-			$processor->set_attribute( 'data-foo', 'bar' );
+			$processor->set_attribute( '', 'data-foo', 'bar' );
 		}
 
 		$this->assertSame(
-			'<wp:content data-foo="bar" id="first"><wp:text data-foo="bar" id="second">Text</wp:text></wp:content>',
+			'<wp:content data-foo="bar" xmlns:wp="w.org" id="first"><wp:text data-foo="bar" id="second">Text</wp:text></wp:content>',
 			$processor->get_updated_xml(),
 			'Not all tags were updated when looping with next_tag() and set_attribute()'
 		);
@@ -997,10 +998,10 @@ class XMLProcessorTest extends TestCase {
 	public function test_remove_attribute_with_an_existing_attribute_name_removes_it_from_the_markup() {
 		$processor = XMLProcessor::create_from_string( self::XML_SIMPLE );
 		$processor->next_tag();
-		$processor->remove_attribute( 'id' );
+		$processor->remove_attribute( '', 'id' );
 
 		$this->assertSame(
-			'<wp:content ><wp:text id="second">Text</wp:text></wp:content>',
+			'<wp:content xmlns:wp="w.org" ><wp:text id="second">Text</wp:text></wp:content>',
 			$processor->get_updated_xml(),
 			'Attribute was not removed'
 		);
@@ -1014,7 +1015,7 @@ class XMLProcessorTest extends TestCase {
 	public function test_remove_attribute_with_a_non_existing_attribute_name_does_not_change_the_markup() {
 		$processor = XMLProcessor::create_from_string( self::XML_SIMPLE );
 		$processor->next_tag();
-		$processor->remove_attribute( 'no-such-attribute' );
+		$processor->remove_attribute( '', 'no-such-attribute' );
 
 		$this->assertSame(
 			self::XML_SIMPLE,
@@ -1030,24 +1031,24 @@ class XMLProcessorTest extends TestCase {
 	 */
 	public function test_correctly_parses_xml_attributes_wrapped_in_single_quotation_marks() {
 		$processor = XMLProcessor::create_from_string(
-			'<wp:content id=\'first\'><wp:text id=\'second\'>Text</wp:text></wp:content>'
+			'<wp:content xmlns:wp="w.org" id=\'first\'><wp:text id=\'second\'>Text</wp:text></wp:content>'
 		);
 		$processor->next_tag(
 			array(
-				'breadcrumbs' => array( 'wp:content' ),
+				'breadcrumbs' => array( array( 'w.org', 'content' ) ),
 				'id'          => 'first',
 			)
 		);
-		$processor->remove_attribute( 'id' );
+		$processor->remove_attribute( '', 'id' );
 		$processor->next_tag(
 			array(
-				'breadcrumbs' => array( 'wp:text' ),
+				'breadcrumbs' => array( array( 'w.org', 'text' ) ),
 				'id'          => 'second',
 			)
 		);
-		$processor->set_attribute( 'id', 'single-quote' );
+		$processor->set_attribute( '', 'id', 'single-quote' );
 		$this->assertSame(
-			'<wp:content ><wp:text id="single-quote">Text</wp:text></wp:content>',
+			'<wp:content xmlns:wp="w.org" ><wp:text id="single-quote">Text</wp:text></wp:content>',
 			$processor->get_updated_xml(),
 			'Did not remove single-quoted attribute'
 		);
@@ -1066,7 +1067,7 @@ class XMLProcessorTest extends TestCase {
 		);
 		$processor->next_tag( 'input' );
 		$this->assertFalse(
-			$processor->set_attribute( 'checked', false ),
+			$processor->set_attribute( '', 'checked', false ),
 			'Accepted a boolean attribute name.'
 		);
 	}
@@ -1081,7 +1082,7 @@ class XMLProcessorTest extends TestCase {
 		$xml_input = '<form action="/action_page.php"><input type="checkbox" name="vehicle" value="Bike"><label for="vehicle">I have a bike</label></form>';
 		$processor = XMLProcessor::create_from_string( $xml_input );
 		$processor->next_tag( 'input' );
-		$processor->set_attribute( 'checked', false );
+		$processor->set_attribute( '', 'checked', false );
 		$this->assertSame(
 			$xml_input,
 			$processor->get_updated_xml(),
@@ -1106,7 +1107,7 @@ class XMLProcessorTest extends TestCase {
 
 		$this->assertFalse(
 			$processor->next_tag(),
-			"Should not have found any tag, but found {$processor->get_local_tag_name()}."
+			"Should not have found any tag, but found {$processor->get_tag_local_name()}."
 		);
 
 		$this->assertTrue(
@@ -1144,7 +1145,7 @@ class XMLProcessorTest extends TestCase {
 
 		$this->assertFalse(
 			$processor->next_tag(),
-			"Should not have found any tag, but found {$processor->get_local_tag_name()}."
+			"Should not have found any tag, but found {$processor->get_tag_local_name()}."
 		);
 
 		$this->assertFalse(
@@ -1189,7 +1190,7 @@ class XMLProcessorTest extends TestCase {
 		$processor->next_tag();
 		$this->assertFalse(
 			$processor->next_tag(),
-			"Shouldn't have found any tags but found {$processor->get_local_tag_name()}."
+			"Shouldn't have found any tags but found {$processor->get_tag_local_name()}."
 		);
 
 		$this->assertTrue(
@@ -1205,19 +1206,19 @@ class XMLProcessorTest extends TestCase {
 	 */
 	public static function data_incomplete_syntax_elements() {
 		return array(
-			'Incomplete tag name'                         => array( '<root><swit' ),
-			'Incomplete tag (no attributes)'              => array( '<root><wp:content' ),
-			'Incomplete tag (attributes)'                 => array( '<root><wp:content inert="yes" title="test"' ),
-			'Incomplete attribute (before =)'             => array( '<root><button disabled' ),
-			'Incomplete attribute (before ")'             => array( '<root><button disabled=' ),
-			'Incomplete attribute (before closing quote)' => array( '<root><button disabled="value started' ),
-			'Incomplete attribute (single quoted)'        => array( "<root><li wp:post-type='just-another class" ),
-			'Incomplete attribute (double quoted)'        => array( '<root><iframe src="https://www.example.com/embed/abcdef' ),
-			'Incomplete comment (normative)'              => array( '<root><!-- without end' ),
-			'Incomplete comment (missing --)'             => array( '<root><!-- without end --' ),
-			'Incomplete CDATA'                            => array( '<root><![CDATA[something inside of here needs to get out' ),
-			'Partial CDATA'                               => array( '<root><![CDA' ),
-			'Partially closed CDATA]'                     => array( '<root><![CDATA[cannot escape]' ),
+			'Incomplete tag name'                         => array( '<root xmlns:wp="w.org"><swit' ),
+			'Incomplete tag (no attributes)'              => array( '<root xmlns:wp="w.org"><wp:content' ),
+			'Incomplete tag (attributes)'                 => array( '<root xmlns:wp="w.org"><wp:content inert="yes" title="test"' ),
+			'Incomplete attribute (before =)'             => array( '<root xmlns:wp="w.org"><button disabled' ),
+			'Incomplete attribute (before ")'             => array( '<root xmlns:wp="w.org"><button disabled=' ),
+			'Incomplete attribute (before closing quote)' => array( '<root xmlns:wp="w.org"><button disabled="value started' ),
+			'Incomplete attribute (single quoted)'        => array( "<root xmlns:wp=\"w.org\"><li wp:post-type='just-another class" ),
+			'Incomplete attribute (double quoted)'        => array( '<root xmlns:wp="w.org"><iframe src="https://www.example.com/embed/abcdef' ),
+			'Incomplete comment (normative)'              => array( '<root xmlns:wp="w.org"><!-- without end' ),
+			'Incomplete comment (missing --)'             => array( '<root xmlns:wp="w.org"><!-- without end --' ),
+			'Incomplete CDATA'                            => array( '<root xmlns:wp="w.org"><![CDATA[something inside of here needs to get out' ),
+			'Partial CDATA'                               => array( '<root xmlns:wp="w.org"><![CDA' ),
+			'Partially closed CDATA]'                     => array( '<root xmlns:wp="w.org"><![CDATA[cannot escape]' ),
 		);
 	}
 
@@ -1314,7 +1315,7 @@ class XMLProcessorTest extends TestCase {
 	 * @ticket 61365
 	 */
 	public function test_single_text_node_with_taglike_text() {
-		$processor = XMLProcessor::create_from_string( '<root>This is a text node< /A>' );
+		$processor = XMLProcessor::create_from_string( '<root xmlns:wp="w.org">This is a text node< /A>' );
 		$this->assertTrue( $processor->next_token(), 'A root node was not found.' );
 		$this->assertTrue( $processor->next_token(), 'A valid text node was not found.' );
 		$this->assertEquals( 'This is a text node', $processor->get_modifiable_text(),
@@ -1328,7 +1329,7 @@ class XMLProcessorTest extends TestCase {
 	 * @ticket 61365
 	 */
 	public function test_parses_CDATA() {
-		$processor = XMLProcessor::create_from_string( '<root><![CDATA[This is a CDATA text node.]]></root>' );
+		$processor = XMLProcessor::create_from_string( '<root xmlns:wp="w.org"><![CDATA[This is a CDATA text node.]]></root>' );
 		$processor->next_tag();
 		$this->assertTrue( $processor->next_token(), 'The first text node was not found.' );
 		$this->assertEquals(
@@ -1342,7 +1343,7 @@ class XMLProcessorTest extends TestCase {
 	 * @ticket 61365
 	 */
 	public function test_yields_CDATA_a_separate_text_node() {
-		$processor = XMLProcessor::create_from_string( '<root>This is the first text node <![CDATA[ and this is a second text node ]]> and this is the third text node.</root>' );
+		$processor = XMLProcessor::create_from_string( '<root xmlns:wp="w.org">This is the first text node <![CDATA[ and this is a second text node ]]> and this is the third text node.</root>' );
 
 		$processor->next_token();
 		$this->assertTrue( $processor->next_token(), 'The first text node was not found.' );
@@ -1379,8 +1380,8 @@ class XMLProcessorTest extends TestCase {
 			$processor->get_token_type(),
 			'The XML declaration was not correctly identified.'
 		);
-		$this->assertEquals( '1.0', $processor->get_attribute( 'version' ), 'The version attribute was not correctly captured.' );
-		$this->assertEquals( 'UTF-8', $processor->get_attribute( 'encoding' ), 'The encoding attribute was not correctly captured.' );
+		$this->assertEquals( '1.0', $processor->get_attribute( '', 'version' ), 'The version attribute was not correctly captured.' );
+		$this->assertEquals( 'UTF-8', $processor->get_attribute( '', 'encoding' ), 'The encoding attribute was not correctly captured.' );
 	}
 
 	/**
@@ -1395,8 +1396,8 @@ class XMLProcessorTest extends TestCase {
 			$processor->get_token_type(),
 			'The XML declaration was not correctly identified.'
 		);
-		$this->assertEquals( '1.0', $processor->get_attribute( 'version' ), 'The version attribute was not correctly captured.' );
-		$this->assertEquals( 'UTF-8', $processor->get_attribute( 'encoding' ), 'The encoding attribute was not correctly captured.' );
+		$this->assertEquals( '1.0', $processor->get_attribute( '', 'version' ), 'The version attribute was not correctly captured.' );
+		$this->assertEquals( 'UTF-8', $processor->get_attribute( '', 'encoding' ), 'The encoding attribute was not correctly captured.' );
 	}
 
 	/**
@@ -1428,7 +1429,7 @@ class XMLProcessorTest extends TestCase {
 	 * @ticket 61365
 	 */
 	public function test_applies_updates_before_proceeding() {
-		$xml = '<root><wp:content><photo/></wp:content><wp:content><photo/></wp:content></root>';
+		$xml = '<root xmlns:wp="w.org"><wp:content><photo/></wp:content><wp:content><photo/></wp:content></root>';
 
 		$subclass = new class( $xml ) extends XMLProcessor {
 			public function __construct( $xml ) {
@@ -1456,15 +1457,15 @@ class XMLProcessorTest extends TestCase {
 		$subclass->next_tag();
 		$this->assertSame(
 			'p',
-			$subclass->get_local_tag_name(),
+			$subclass->get_tag_local_name(),
 			'Should have matched inserted XML as next tag.'
 		);
 
 		$subclass->next_tag( 'photo' );
-		$subclass->set_attribute( 'alt', 'mountain' );
+		$subclass->set_attribute( '', 'alt', 'mountain' );
 
 		$this->assertSame(
-			'<root><wp:content><photo/><p>snow-capped</p></wp:content><wp:content><photo alt="mountain"/></wp:content></root>',
+			'<root xmlns:wp="w.org"><wp:content><photo/><p>snow-capped</p></wp:content><wp:content><photo alt="mountain"/></wp:content></root>',
 			$subclass->get_updated_xml(),
 			'Should have properly applied the update from in front of the cursor.'
 		);
@@ -1479,7 +1480,7 @@ class XMLProcessorTest extends TestCase {
 	 */
 	public function test_get_breadcrumbs() {
 		$processor = XMLProcessor::create_from_string(
-			'<wp:content>
+			'<wp:content xmlns:wp="w.org">
 				<wp:text>
 					<photo />
 				</wp:text>
@@ -1487,21 +1488,21 @@ class XMLProcessorTest extends TestCase {
 		);
 		$processor->next_tag();
 		$this->assertEquals(
-			array( 'wp:content' ),
+			array( array( 'w.org', 'content' ) ),
 			$processor->get_breadcrumbs(),
 			'get_breadcrumbs() did not return the expected breadcrumbs'
 		);
 
 		$processor->next_tag();
 		$this->assertEquals(
-			array( 'wp:content', 'wp:text' ),
+			array( array( 'w.org', 'content' ), array( 'w.org', 'text' ) ),
 			$processor->get_breadcrumbs(),
 			'get_breadcrumbs() did not return the expected breadcrumbs'
 		);
 
 		$processor->next_tag();
 		$this->assertEquals(
-			array( 'wp:content', 'wp:text', 'photo' ),
+			array( array( 'w.org', 'content' ), array( 'w.org', 'text' ), array( '', 'photo' ) ),
 			$processor->get_breadcrumbs(),
 			'get_breadcrumbs() did not return the expected breadcrumbs'
 		);
@@ -1516,16 +1517,16 @@ class XMLProcessorTest extends TestCase {
 	 */
 	public function test_matches_breadcrumbs() {
 		// Initialize the XMLProcessor with the given XML string
-		$processor = XMLProcessor::create_from_string( '<root><wp:post><content><image /></content></wp:post></root>' );
+		$processor = XMLProcessor::create_from_string( '<root xmlns:wp="w.org"><wp:post><content><image /></content></wp:post></root>' );
 
 		// Move to the next element with tag name 'img'
-		$processor->next_tag( 'image' );
+		$this->assertTrue( $processor->next_tag( 'image' ) );
 
 		// Assert that the breadcrumbs match the expected sequences
-		$this->assertTrue( $processor->matches_breadcrumbs( array( 'content', 'image' ) ) );
-		$this->assertTrue( $processor->matches_breadcrumbs( array( 'wp:post', 'content', 'image' ) ) );
-		$this->assertFalse( $processor->matches_breadcrumbs( array( 'wp:post', 'image' ) ) );
-		$this->assertTrue( $processor->matches_breadcrumbs( array( 'wp:post', '*', 'image' ) ) );
+		$this->assertTrue( $processor->matches_breadcrumbs( array( array( '', 'content' ), 'image' ) ) );
+		$this->assertTrue( $processor->matches_breadcrumbs( array( array( 'w.org', 'post' ), 'content', 'image' ) ) );
+		$this->assertFalse( $processor->matches_breadcrumbs( array( array( 'w.org', 'post' ), 'image' ) ) );
+		$this->assertTrue( $processor->matches_breadcrumbs( array( array( 'w.org', 'post' ), '*', 'image' ) ) );
 	}
 
 	/**
@@ -1535,7 +1536,7 @@ class XMLProcessorTest extends TestCase {
 	 */
 	public function test_next_tag_by_breadcrumbs() {
 		// Initialize the XMLProcessor with the given XML string
-		$processor = XMLProcessor::create_from_string( '<root><wp:post><content><image /></content></wp:post></root>' );
+		$processor = XMLProcessor::create_from_string( '<root xmlns:wp="w.org"><wp:post><content><image /></content></wp:post></root>' );
 
 		// Move to the next element with tag name 'img'
 		$processor->next_tag(
@@ -1544,7 +1545,7 @@ class XMLProcessorTest extends TestCase {
 			)
 		);
 
-		$this->assertEquals( 'image', $processor->get_local_tag_name(), 'Did not find the expected tag' );
+		$this->assertEquals( 'image', $processor->get_tag_local_name(), 'Did not find the expected tag' );
 	}
 
 	/**
@@ -1554,7 +1555,7 @@ class XMLProcessorTest extends TestCase {
 	 */
 	public function test_get_current_depth() {
 		// Initialize the XMLProcessor with the given XML string
-		$processor = XMLProcessor::create_from_string( '<?xml version="1.0" ?><root><wp:text><post /></wp:text><image /></root>' );
+		$processor = XMLProcessor::create_from_string( '<?xml version="1.0" ?><root xmlns:wp="w.org"><wp:text><post /></wp:text><image /></root>' );
 
 		// Assert that the initial depth is 0
 		$this->assertEquals( 0, $processor->get_current_depth() );
@@ -1586,7 +1587,7 @@ class XMLProcessorTest extends TestCase {
 	 * @expectedIncorrectUsage XMLProcessor::step_in_misc
 	 */
 	public function test_no_text_allowed_after_root_element() {
-		$processor = XMLProcessor::create_from_string( '<root></root>text' );
+		$processor = XMLProcessor::create_from_string( '<root xmlns:wp="w.org"></root>text' );
 		$this->assertTrue( $processor->next_tag(), 'Did not find a tag.' );
 		$this->assertFalse( $processor->next_tag(), 'Found a non-existent tag.' );
 		$this->assertEquals(
@@ -1600,7 +1601,7 @@ class XMLProcessorTest extends TestCase {
 	 * @ticket 61365
 	 */
 	public function test_whitespace_text_allowed_after_root_element() {
-		$processor = XMLProcessor::create_from_string( '<root></root>   ' );
+		$processor = XMLProcessor::create_from_string( '<root xmlns:wp="w.org"></root>   ' );
 		$this->assertTrue( $processor->next_tag(), 'Did not find a tag.' );
 		$this->assertFalse( $processor->next_tag(), 'Found a non-existent tag.' );
 		$this->assertNull( $processor->get_last_error(), 'Ran into a parse error after the root element' );
@@ -1610,7 +1611,7 @@ class XMLProcessorTest extends TestCase {
 	 * @ticket 61365
 	 */
 	public function test_processing_directives_allowed_after_root_element() {
-		$processor = XMLProcessor::create_from_string( '<root></root><?xml processing directive! ?>' );
+		$processor = XMLProcessor::create_from_string( '<root xmlns:wp="w.org"></root><?xml processing directive! ?>' );
 		$this->assertTrue( $processor->next_tag(), 'Did not find a tag.' );
 		$this->assertFalse( $processor->next_tag(), 'Found a non-existent tag.' );
 		$this->assertNull( $processor->get_last_error(), 'Ran into a parse error after the root element' );
@@ -1620,10 +1621,10 @@ class XMLProcessorTest extends TestCase {
 	 * @ticket 61365
 	 */
 	public function test_mixed_misc_grammar_allowed_after_root_element() {
-		$processor = XMLProcessor::create_from_string( '<root></root>   <?xml hey ?> <!-- comment --> <?xml another pi ?> <!-- more comments! -->' );
+		$processor = XMLProcessor::create_from_string( '<root xmlns:wp="w.org"></root>   <?xml hey ?> <!-- comment --> <?xml another pi ?> <!-- more comments! -->' );
 
 		$processor->next_tag();
-		$this->assertEquals( 'root', $processor->get_local_tag_name(), 'Did not find a tag.' );
+		$this->assertEquals( 'root', $processor->get_tag_local_name(), 'Did not find a tag.' );
 
 		$processor->next_tag();
 		$this->assertNull( $processor->get_last_error(), 'Did not run into a parse error after the root element' );
@@ -1635,7 +1636,7 @@ class XMLProcessorTest extends TestCase {
 	 * @expectedIncorrectUsage XMLProcessor::step_in_misc
 	 */
 	public function test_elements_not_allowed_after_root_element() {
-		$processor = XMLProcessor::create_from_string( '<root></root><another-root>' );
+		$processor = XMLProcessor::create_from_string( '<root xmlns:wp="w.org"></root><another-root>' );
 		$this->assertTrue( $processor->next_tag(), 'Did not find a tag.' );
 		$this->assertFalse( $processor->next_tag(), 'Fount an illegal tag.' );
 		$this->assertEquals(
@@ -1651,7 +1652,7 @@ class XMLProcessorTest extends TestCase {
 	 * @return void
 	 */
 	public function test_comments_allowed_after_root_element() {
-		$processor = XMLProcessor::create_from_string( '<root></root><!-- comment -->' );
+		$processor = XMLProcessor::create_from_string( '<root xmlns:wp="w.org"></root><!-- comment -->' );
 		$this->assertTrue( $processor->next_tag(), 'Did not find a tag.' );
 		$this->assertFalse( $processor->next_tag(), 'Found an element node after the root element' );
 		$this->assertNull( $processor->get_last_error(), 'Ran into a parse error after the root element' );
@@ -1664,7 +1665,7 @@ class XMLProcessorTest extends TestCase {
 	 * @return void
 	 */
 	public function test_cdata_not_allowed_after_root_element() {
-		$processor = XMLProcessor::create_from_string( '<root></root><![CDATA[ cdata ]]>' );
+		$processor = XMLProcessor::create_from_string( '<root xmlns:wp="w.org"></root><![CDATA[ cdata ]]>' );
 		$this->assertTrue( $processor->next_tag(), 'Did not find a tag.' );
 		$this->assertFalse( $processor->next_tag(), 'Did not reject a comment node after the root element' );
 		$this->assertEquals(
@@ -1713,7 +1714,7 @@ class XMLProcessorTest extends TestCase {
 	 */
 	public function test_text_nodes_are_not_exposed_until_their_full_content_is_available() {
 		$processor = XMLProcessor::create_for_streaming(
-			'<root>text'
+			'<root xmlns:wp="w.org">text'
 		);
 		$this->assertTrue( $processor->next_tag(), 'Did not find a tag.' );
 		$this->assertFalse( $processor->next_token(), 'Found a text node before it was fully available.' );
@@ -1731,7 +1732,7 @@ class XMLProcessorTest extends TestCase {
 	 */
 	public function test_escaped_cdata() {
 		$processor = XMLProcessor::create_from_string(
-			'<root>The CDATA section looks as follows: <![CDATA[<![CDATA[Your content goes here]]]]><![CDATA[>]]></root>'
+			'<root xmlns:wp="w.org">The CDATA section looks as follows: <![CDATA[<![CDATA[Your content goes here]]]]><![CDATA[>]]></root>'
 		);
 		$this->assertTrue( $processor->next_token(), 'Did not find a tag.' );
 		$this->assertTrue( $processor->next_token(), 'Did not find a text node.' );
@@ -1750,7 +1751,7 @@ class XMLProcessorTest extends TestCase {
 	 */
 	public function test_pause_and_resume() {
 		$xml       = <<<XML
-			<root>
+			<root xmlns:wp="w.org">
 				<first_child>Hello there</first_child>
 				<second_child>I am a second child</second_child>
 			</root>
@@ -1758,7 +1759,7 @@ XML;
 		$processor = XMLProcessor::create_for_streaming( $xml );
 		$processor->next_tag();
 		$processor->next_tag();
-		$this->assertEquals( 'first_child', $processor->get_local_tag_name(), 'Did not find a tag.' );
+		$this->assertEquals( 'first_child', $processor->get_tag_local_name(), 'Did not find a tag.' );
 
 		$entity_offset = $processor->get_token_byte_offset_in_the_input_stream();
 		$cursor        = $processor->get_reentrancy_cursor();
@@ -1768,7 +1769,7 @@ XML;
 			$cursor
 		);
 		$resumed->next_tag();
-		$this->assertEquals( 'first_child', $resumed->get_local_tag_name(), 'Did not find a tag.' );
+		$this->assertEquals( 'first_child', $resumed->get_tag_local_name(), 'Did not find a tag.' );
 		$resumed->next_token();
 		$this->assertEquals( 'Hello there', $resumed->get_modifiable_text(), 'Did not find the expected text.' );
 	}
@@ -1780,13 +1781,13 @@ XML;
 	 */
 	public function test_doctype_parsing() {
 		$processor = XMLProcessor::create_from_string(
-			'<!DOCTYPE html><root>Content</root>'
+			'<!DOCTYPE html><root xmlns:wp="w.org">Content</root>'
 		);
 
 		$this->assertTrue( $processor->next_token(), 'Did not find DOCTYPE node' );
 		$this->assertEquals( '#doctype', $processor->get_token_type(), 'Did not find DOCTYPE node' );
 		$this->assertTrue( $processor->next_token(), 'Did not find root tag' );
-		$this->assertEquals( 'root', $processor->get_local_tag_name(), 'Did not find root tag' );
+		$this->assertEquals( 'root', $processor->get_tag_local_name(), 'Did not find root tag' );
 	}
 
 	/**
@@ -1796,7 +1797,7 @@ XML;
 	 */
 	public function test_xhtml_doctype_parsing() {
 		$processor = XMLProcessor::create_from_string(
-			'<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"><root>Content</root>'
+			'<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"><root xmlns:wp="w.org">Content</root>'
 		);
 
 		$this->assertTrue( $processor->next_token(), 'Did not find DOCTYPE node' );
@@ -1806,7 +1807,7 @@ XML;
 		$this->assertEquals( 'http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd', $processor->get_system_literal(),
 			'Did not find system literal' );
 		$this->assertTrue( $processor->next_token(), 'Did not find root tag' );
-		$this->assertEquals( 'root', $processor->get_local_tag_name(), 'Did not find root tag' );
+		$this->assertEquals( 'root', $processor->get_tag_local_name(), 'Did not find root tag' );
 	}
 
 	/**
@@ -1816,7 +1817,7 @@ XML;
 	 */
 	public function test_system_doctype_parsing() {
 		$processor = XMLProcessor::create_from_string(
-			'<!DOCTYPE html SYSTEM "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"><root>Content</root>'
+			'<!DOCTYPE html SYSTEM "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"><root xmlns:wp="w.org">Content</root>'
 		);
 
 		$this->assertTrue( $processor->next_token(), 'Did not find DOCTYPE node' );
@@ -1826,7 +1827,7 @@ XML;
 		$this->assertEquals( 'http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd', $processor->get_system_literal(),
 			'Did not find system literal' );
 		$this->assertTrue( $processor->next_token(), 'Did not find root tag' );
-		$this->assertEquals( 'root', $processor->get_local_tag_name(), 'Did not find root tag' );
+		$this->assertEquals( 'root', $processor->get_tag_local_name(), 'Did not find root tag' );
 	}
 
 	/**
@@ -1836,7 +1837,7 @@ XML;
 	 */
 	public function test_invalid_doctype_parsing() {
 		$processor = XMLProcessor::create_from_string(
-			'<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"><root>Content</root>'
+			'<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"><root xmlns:wp="w.org">Content</root>'
 		);
 
 		$this->assertFalse( $processor->next_token(), 'Did not reject complex DOCTYPE' );
@@ -1845,7 +1846,7 @@ XML;
 
 	public function test_doctype_in_tag_content_is_syntax_error() {
 		$processor = XMLProcessor::create_from_string(
-			'<root>Content<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"></root>'
+			'<root xmlns:wp="w.org">Content<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"></root>'
 		);
 
 		$processor->next_token();

--- a/components/XML/Tests/XMLProcessorTest.php
+++ b/components/XML/Tests/XMLProcessorTest.php
@@ -26,36 +26,36 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_qualified_tag
+	 * @covers XMLProcessor::get_local_tag_name
 	 */
 	public function test_get_tag_returns_null_before_finding_tags() {
 		$processor = XMLProcessor::create_from_string( '<wp:content>Test</wp:content>' );
 
-		$this->assertNull( $processor->get_qualified_tag(), 'Calling get_tag() without selecting a tag did not return null' );
+		$this->assertNull( $processor->get_local_tag_name(), 'Calling get_tag() without selecting a tag did not return null' );
 	}
 
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_qualified_tag
+	 * @covers XMLProcessor::get_local_tag_name
 	 */
 	public function test_get_tag_returns_null_when_not_in_open_tag() {
 		$processor = XMLProcessor::create_from_string( '<wp:content>Test</wp:content>' );
 
 		$this->assertFalse( $processor->next_tag( 'p' ), 'Querying a non-existing tag did not return false' );
-		$this->assertNull( $processor->get_qualified_tag(), 'Accessing a non-existing tag did not return null' );
+		$this->assertNull( $processor->get_local_tag_name(), 'Accessing a non-existing tag did not return null' );
 	}
 
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_qualified_tag
+	 * @covers XMLProcessor::get_local_tag_name
 	 */
 	public function test_get_tag_returns_open_tag_name() {
 		$processor = XMLProcessor::create_from_string( '<wp:content>Test</wp:content>' );
 
 		$this->assertTrue( $processor->next_tag( 'wp:content' ), 'Querying an existing tag did not return true' );
-		$this->assertSame( 'wp:content', $processor->get_qualified_tag(), 'Accessing an existing tag name did not return "div"' );
+		$this->assertSame( 'wp:content', $processor->get_local_tag_name(), 'Accessing an existing tag name did not return "div"' );
 	}
 
 	/**
@@ -107,20 +107,20 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute_by_qualified_name
+	 * @covers XMLProcessor::get_attribute
 	 */
 	public function test_get_attribute_returns_null_when_not_in_open_tag() {
 		$processor = XMLProcessor::create_from_string( '<wp:content wp:post-type="test">Test</wp:content>' );
 
 		$this->assertFalse( $processor->next_tag( 'p' ), 'Querying a non-existing tag did not return false' );
-		$this->assertNull( $processor->get_attribute_by_qualified_name( 'wp:post-type' ),
+		$this->assertNull( $processor->get_attribute( 'wp:post-type' ),
 			'Accessing an attribute of a non-existing tag did not return null' );
 	}
 
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute_by_qualified_name
+	 * @covers XMLProcessor::get_attribute
 	 */
 	public function test_get_attribute_returns_null_when_in_closing_tag() {
 		$processor = XMLProcessor::create_from_string( '<wp:content wp:post-type="test">Test</wp:content>' );
@@ -128,26 +128,26 @@ class XMLProcessorTest extends TestCase {
 		$this->assertTrue( $processor->next_tag( 'wp:content' ), 'Querying an existing tag did not return true' );
 		$this->assertTrue( $processor->next_token(), 'Querying an existing closing tag did not return true' );
 		$this->assertTrue( $processor->next_token(), 'Querying an existing closing tag did not return true' );
-		$this->assertNull( $processor->get_attribute_by_qualified_name( 'wp:post-type' ), 'Accessing an attribute of a closing tag did not return null' );
+		$this->assertNull( $processor->get_attribute( 'wp:post-type' ), 'Accessing an attribute of a closing tag did not return null' );
 	}
 
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute_by_qualified_name
+	 * @covers XMLProcessor::get_attribute
 	 */
 	public function test_get_attribute_returns_null_when_attribute_missing() {
 		$processor = XMLProcessor::create_from_string( '<wp:content wp:post-type="test">Test</wp:content>' );
 
 		$this->assertTrue( $processor->next_tag( 'wp:content' ), 'Querying an existing tag did not return true' );
-		$this->assertNull( $processor->get_attribute_by_qualified_name( 'test-id' ), 'Accessing a non-existing attribute did not return null' );
+		$this->assertNull( $processor->get_attribute( 'test-id' ), 'Accessing a non-existing attribute did not return null' );
 	}
 
 	/**
 	 * @ticket 61365
 	 *
 	 * @expectedIncorrectUsage XMLProcessor::base_class_next_token
-	 * @covers XMLProcessor::get_attribute_by_qualified_name
+	 * @covers XMLProcessor::get_attribute
 	 */
 	public function test_attributes_are_rejected_in_tag_closers() {
 		$processor = XMLProcessor::create_from_string( '<wp:content>Test</wp:content wp:post-type="test">' );
@@ -160,13 +160,13 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute_by_qualified_name
+	 * @covers XMLProcessor::get_attribute
 	 */
 	public function test_get_attribute_returns_attribute_value() {
 		$processor = XMLProcessor::create_from_string( '<wp:content wp:post-type="test">Test</wp:content>' );
 
 		$this->assertTrue( $processor->next_tag( 'wp:content' ), 'Querying an existing tag did not return true' );
-		$this->assertSame( 'test', $processor->get_attribute_by_qualified_name( 'wp:post-type' ),
+		$this->assertSame( 'test', $processor->get_attribute( 'wp:post-type' ),
 			'Accessing a wp:post-type="test" attribute value did not return "test"' );
 	}
 
@@ -174,7 +174,7 @@ class XMLProcessorTest extends TestCase {
 	 * @ticket 61365
 	 * @expectedIncorrectUsage XMLProcessor::parse_next_attribute
 	 *
-	 * @covers XMLProcessor::get_attribute_by_qualified_name
+	 * @covers XMLProcessor::get_attribute
 	 */
 	public function test_parsing_stops_on_malformed_attribute_value_no_value() {
 		$processor = XMLProcessor::create_from_string( '<wp:content enabled wp:post-type="test">Test</wp:content>' );
@@ -186,7 +186,7 @@ class XMLProcessorTest extends TestCase {
 	 * @ticket 61365
 	 * @expectedIncorrectUsage XMLProcessor::parse_next_attribute
 	 *
-	 * @covers XMLProcessor::get_attribute_by_qualified_name
+	 * @covers XMLProcessor::get_attribute
 	 */
 	public function test_parsing_stops_on_malformed_attribute_value_no_quotes() {
 		$processor = XMLProcessor::create_from_string( '<wp:content enabled=1 wp:post-type="test">Test</wp:content>' );
@@ -198,33 +198,33 @@ class XMLProcessorTest extends TestCase {
 	 * @ticket 61365
 	 * @expectedIncorrectUsage XMLProcessor::get_attribute
 	 *
-	 * @covers XMLProcessor::get_attribute_by_qualified_name
+	 * @covers XMLProcessor::get_attribute
 	 */
 	public function test_malformed_attribute_value_containing_ampersand_is_treated_as_plaintext() {
 		$processor = XMLProcessor::create_from_string( '<wp:content enabled="WordPress & WordPress">Test</wp:content>' );
 
 		$this->assertTrue( $processor->next_tag(), 'Querying a tag did not return true' );
-		$this->assertEquals( 'WordPress & WordPress', $processor->get_attribute_by_qualified_name( 'enabled' ) );
+		$this->assertEquals( 'WordPress & WordPress', $processor->get_attribute( 'enabled' ) );
 	}
 
 	/**
 	 * @ticket 61365
 	 * @expectedIncorrectUsage XMLProcessor::get_attribute
 	 *
-	 * @covers XMLProcessor::get_attribute_by_qualified_name
+	 * @covers XMLProcessor::get_attribute
 	 */
 	public function test_malformed_attribute_value_containing_entity_without_semicolon_is_treated_as_plaintext() {
 		$processor = XMLProcessor::create_from_string( '<wp:content enabled="&#x94">Test</wp:content>' );
 
 		$this->assertTrue( $processor->next_tag(), 'Querying a tag did not return true' );
-		$this->assertEquals( '&#x94', $processor->get_attribute_by_qualified_name( 'enabled' ) );
+		$this->assertEquals( '&#x94', $processor->get_attribute( 'enabled' ) );
 	}
 
 	/**
 	 * @ticket 61365
 	 * @expectedIncorrectUsage XMLProcessor::parse_next_attribute
 	 *
-	 * @covers XMLProcessor::get_attribute_by_qualified_name
+	 * @covers XMLProcessor::get_attribute
 	 */
 	public function test_parsing_stops_on_malformed_attribute_value_contains_lt_character() {
 		$processor = XMLProcessor::create_from_string( '<wp:content enabled="I love <3 this">Test</wp:content>' );
@@ -236,7 +236,7 @@ class XMLProcessorTest extends TestCase {
 	 * @ticket 61365
 	 * @expectedIncorrectUsage XMLProcessor::parse_next_attribute
 	 *
-	 * @covers XMLProcessor::get_attribute_by_qualified_name
+	 * @covers XMLProcessor::get_attribute
 	 */
 	public function test_parsing_stops_on_malformed_tags_duplicate_attributes() {
 		$processor = XMLProcessor::create_from_string( '<wp:content id="update-me" id="ignored-id"><wp:text id="second">Text</wp:text></wp:content>' );
@@ -248,7 +248,7 @@ class XMLProcessorTest extends TestCase {
 	 * @ticket 61365
 	 * @expectedIncorrectUsage XMLProcessor::parse_next_attribute
 	 *
-	 * @covers XMLProcessor::get_attribute_by_qualified_name
+	 * @covers XMLProcessor::get_attribute
 	 */
 	public function test_parsing_stops_on_malformed_attribute_name_contains_slash() {
 		$processor = XMLProcessor::create_from_string( '<wp:content a/b="test">Test</wp:content>' );
@@ -259,7 +259,7 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute_by_qualified_name
+	 * @covers XMLProcessor::get_attribute
 	 */
 	public function test_get_modifiable_text_returns_a_decoded_value() {
 		$processor = XMLProcessor::create_from_string( '<root>&#x201C;&#x1f604;&#x201D;</root>' );
@@ -277,7 +277,7 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute_by_qualified_name
+	 * @covers XMLProcessor::get_attribute
 	 */
 	public function test_get_attribute_returns_a_decoded_value() {
 		$processor = XMLProcessor::create_from_string( '<root encoded-data="&#x201C;&#x1f604;&#x201D;"></root>' );
@@ -285,7 +285,7 @@ class XMLProcessorTest extends TestCase {
 		$this->assertTrue( $processor->next_tag( 'root' ), 'Querying a tag did not return true' );
 		$this->assertEquals(
 			'“😄”',
-			$processor->get_attribute_by_qualified_name( 'encoded-data' ),
+			$processor->get_attribute( 'encoded-data' ),
 			'Reading an encoded attribute did not decode it.'
 		);
 	}
@@ -293,7 +293,7 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute_by_qualified_name
+	 * @covers XMLProcessor::get_attribute
 	 *
 	 * @param  string  $attribute_name  Name of data-enabled attribute with case variations.
 	 */
@@ -303,12 +303,12 @@ class XMLProcessorTest extends TestCase {
 
 		$this->assertEquals(
 			'true',
-			$processor->get_attribute_by_qualified_name( 'DATA-enabled' ),
+			$processor->get_attribute( 'DATA-enabled' ),
 			'Accessing an attribute by a same-cased name did return not its value'
 		);
 
 		$this->assertNull(
-			$processor->get_attribute_by_qualified_name( 'data-enabled' ),
+			$processor->get_attribute( 'data-enabled' ),
 			'Accessing an attribute by a differently-cased name did return its value'
 		);
 	}
@@ -753,7 +753,7 @@ class XMLProcessorTest extends TestCase {
 		$tags->seek( 'here' );
 		$this->assertSame( '<root><wp:content wp:post-type="foo">outside</wp:content><section><wp:content><photo>inside</wp:content></section></root>',
 			$tags->get_updated_xml() );
-		$this->assertSame( 'section', $tags->get_qualified_tag() );
+		$this->assertSame( 'section', $tags->get_local_tag_name() );
 		$this->assertFalse( $tags->is_tag_closer() );
 	}
 
@@ -821,7 +821,7 @@ class XMLProcessorTest extends TestCase {
 		);
 		$this->assertSame(
 			'test-value',
-			$processor->get_attribute_by_qualified_name( 'test-attribute' ),
+			$processor->get_attribute( 'test-attribute' ),
 			'get_attribute() (called after get_updated_xml()) did not return attribute added via set_attribute()'
 		);
 	}
@@ -829,7 +829,7 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute_by_qualified_name
+	 * @covers XMLProcessor::get_attribute
 	 */
 	public function test_get_attribute_returns_updated_values_before_they_are_applied() {
 		$processor = XMLProcessor::create_from_string( self::XML_SIMPLE );
@@ -838,7 +838,7 @@ class XMLProcessorTest extends TestCase {
 
 		$this->assertSame(
 			'test-value',
-			$processor->get_attribute_by_qualified_name( 'test-attribute' ),
+			$processor->get_attribute( 'test-attribute' ),
 			'get_attribute() (called before get_updated_xml()) did not return attribute added via set_attribute()'
 		);
 		$this->assertSame(
@@ -851,7 +851,7 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute_by_qualified_name
+	 * @covers XMLProcessor::get_attribute
 	 */
 	public function test_get_attribute_returns_updated_values_before_they_are_applied_with_different_name_casing() {
 		$processor = XMLProcessor::create_from_string( self::XML_SIMPLE );
@@ -860,7 +860,7 @@ class XMLProcessorTest extends TestCase {
 
 		$this->assertSame(
 			'test-value',
-			$processor->get_attribute_by_qualified_name( 'test-ATTribute' ),
+			$processor->get_attribute( 'test-ATTribute' ),
 			'get_attribute() (called before get_updated_xml()) did not return attribute added via set_attribute()'
 		);
 		$this->assertSame(
@@ -874,7 +874,7 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute_by_qualified_name
+	 * @covers XMLProcessor::get_attribute
 	 */
 	public function test_get_attribute_reflects_removed_attribute_before_it_is_applied() {
 		$processor = XMLProcessor::create_from_string( self::XML_SIMPLE );
@@ -882,7 +882,7 @@ class XMLProcessorTest extends TestCase {
 		$processor->remove_attribute( 'id' );
 
 		$this->assertNull(
-			$processor->get_attribute_by_qualified_name( 'id' ),
+			$processor->get_attribute( 'id' ),
 			'get_attribute() (called before get_updated_xml()) returned attribute that was removed by remove_attribute()'
 		);
 		$this->assertSame(
@@ -895,7 +895,7 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute_by_qualified_name
+	 * @covers XMLProcessor::get_attribute
 	 */
 	public function test_get_attribute_reflects_adding_and_then_removing_an_attribute_before_those_updates_are_applied() {
 		$processor = XMLProcessor::create_from_string( self::XML_SIMPLE );
@@ -904,7 +904,7 @@ class XMLProcessorTest extends TestCase {
 		$processor->remove_attribute( 'test-attribute' );
 
 		$this->assertNull(
-			$processor->get_attribute_by_qualified_name( 'test-attribute' ),
+			$processor->get_attribute( 'test-attribute' ),
 			'get_attribute() (called before get_updated_xml()) returned attribute that was added via set_attribute() and then removed by remove_attribute()'
 		);
 		$this->assertSame(
@@ -917,7 +917,7 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute_by_qualified_name
+	 * @covers XMLProcessor::get_attribute
 	 */
 	public function test_get_attribute_reflects_setting_and_then_removing_an_existing_attribute_before_those_updates_are_applied() {
 		$processor = XMLProcessor::create_from_string( self::XML_SIMPLE );
@@ -926,7 +926,7 @@ class XMLProcessorTest extends TestCase {
 		$processor->remove_attribute( 'id' );
 
 		$this->assertNull(
-			$processor->get_attribute_by_qualified_name( 'id' ),
+			$processor->get_attribute( 'id' ),
 			'get_attribute() (called before get_updated_xml()) returned attribute that was overwritten by set_attribute() and then removed by remove_attribute()'
 		);
 		$this->assertSame(
@@ -1106,7 +1106,7 @@ class XMLProcessorTest extends TestCase {
 
 		$this->assertFalse(
 			$processor->next_tag(),
-			"Should not have found any tag, but found {$processor->get_qualified_tag()}."
+			"Should not have found any tag, but found {$processor->get_local_tag_name()}."
 		);
 
 		$this->assertTrue(
@@ -1144,7 +1144,7 @@ class XMLProcessorTest extends TestCase {
 
 		$this->assertFalse(
 			$processor->next_tag(),
-			"Should not have found any tag, but found {$processor->get_qualified_tag()}."
+			"Should not have found any tag, but found {$processor->get_local_tag_name()}."
 		);
 
 		$this->assertFalse(
@@ -1189,7 +1189,7 @@ class XMLProcessorTest extends TestCase {
 		$processor->next_tag();
 		$this->assertFalse(
 			$processor->next_tag(),
-			"Shouldn't have found any tags but found {$processor->get_qualified_tag()}."
+			"Shouldn't have found any tags but found {$processor->get_local_tag_name()}."
 		);
 
 		$this->assertTrue(
@@ -1379,8 +1379,8 @@ class XMLProcessorTest extends TestCase {
 			$processor->get_token_type(),
 			'The XML declaration was not correctly identified.'
 		);
-		$this->assertEquals( '1.0', $processor->get_attribute_by_qualified_name( 'version' ), 'The version attribute was not correctly captured.' );
-		$this->assertEquals( 'UTF-8', $processor->get_attribute_by_qualified_name( 'encoding' ), 'The encoding attribute was not correctly captured.' );
+		$this->assertEquals( '1.0', $processor->get_attribute( 'version' ), 'The version attribute was not correctly captured.' );
+		$this->assertEquals( 'UTF-8', $processor->get_attribute( 'encoding' ), 'The encoding attribute was not correctly captured.' );
 	}
 
 	/**
@@ -1395,8 +1395,8 @@ class XMLProcessorTest extends TestCase {
 			$processor->get_token_type(),
 			'The XML declaration was not correctly identified.'
 		);
-		$this->assertEquals( '1.0', $processor->get_attribute_by_qualified_name( 'version' ), 'The version attribute was not correctly captured.' );
-		$this->assertEquals( 'UTF-8', $processor->get_attribute_by_qualified_name( 'encoding' ), 'The encoding attribute was not correctly captured.' );
+		$this->assertEquals( '1.0', $processor->get_attribute( 'version' ), 'The version attribute was not correctly captured.' );
+		$this->assertEquals( 'UTF-8', $processor->get_attribute( 'encoding' ), 'The encoding attribute was not correctly captured.' );
 	}
 
 	/**
@@ -1456,7 +1456,7 @@ class XMLProcessorTest extends TestCase {
 		$subclass->next_tag();
 		$this->assertSame(
 			'p',
-			$subclass->get_qualified_tag(),
+			$subclass->get_local_tag_name(),
 			'Should have matched inserted XML as next tag.'
 		);
 
@@ -1544,7 +1544,7 @@ class XMLProcessorTest extends TestCase {
 			)
 		);
 
-		$this->assertEquals( 'image', $processor->get_qualified_tag(), 'Did not find the expected tag' );
+		$this->assertEquals( 'image', $processor->get_local_tag_name(), 'Did not find the expected tag' );
 	}
 
 	/**
@@ -1623,7 +1623,7 @@ class XMLProcessorTest extends TestCase {
 		$processor = XMLProcessor::create_from_string( '<root></root>   <?xml hey ?> <!-- comment --> <?xml another pi ?> <!-- more comments! -->' );
 
 		$processor->next_tag();
-		$this->assertEquals( 'root', $processor->get_qualified_tag(), 'Did not find a tag.' );
+		$this->assertEquals( 'root', $processor->get_local_tag_name(), 'Did not find a tag.' );
 
 		$processor->next_tag();
 		$this->assertNull( $processor->get_last_error(), 'Did not run into a parse error after the root element' );
@@ -1758,7 +1758,7 @@ XML;
 		$processor = XMLProcessor::create_for_streaming( $xml );
 		$processor->next_tag();
 		$processor->next_tag();
-		$this->assertEquals( 'first_child', $processor->get_qualified_tag(), 'Did not find a tag.' );
+		$this->assertEquals( 'first_child', $processor->get_local_tag_name(), 'Did not find a tag.' );
 
 		$entity_offset = $processor->get_token_byte_offset_in_the_input_stream();
 		$cursor        = $processor->get_reentrancy_cursor();
@@ -1768,7 +1768,7 @@ XML;
 			$cursor
 		);
 		$resumed->next_tag();
-		$this->assertEquals( 'first_child', $resumed->get_qualified_tag(), 'Did not find a tag.' );
+		$this->assertEquals( 'first_child', $resumed->get_local_tag_name(), 'Did not find a tag.' );
 		$resumed->next_token();
 		$this->assertEquals( 'Hello there', $resumed->get_modifiable_text(), 'Did not find the expected text.' );
 	}
@@ -1786,7 +1786,7 @@ XML;
 		$this->assertTrue( $processor->next_token(), 'Did not find DOCTYPE node' );
 		$this->assertEquals( '#doctype', $processor->get_token_type(), 'Did not find DOCTYPE node' );
 		$this->assertTrue( $processor->next_token(), 'Did not find root tag' );
-		$this->assertEquals( 'root', $processor->get_qualified_tag(), 'Did not find root tag' );
+		$this->assertEquals( 'root', $processor->get_local_tag_name(), 'Did not find root tag' );
 	}
 
 	/**
@@ -1806,7 +1806,7 @@ XML;
 		$this->assertEquals( 'http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd', $processor->get_system_literal(),
 			'Did not find system literal' );
 		$this->assertTrue( $processor->next_token(), 'Did not find root tag' );
-		$this->assertEquals( 'root', $processor->get_qualified_tag(), 'Did not find root tag' );
+		$this->assertEquals( 'root', $processor->get_local_tag_name(), 'Did not find root tag' );
 	}
 
 	/**
@@ -1826,7 +1826,7 @@ XML;
 		$this->assertEquals( 'http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd', $processor->get_system_literal(),
 			'Did not find system literal' );
 		$this->assertTrue( $processor->next_token(), 'Did not find root tag' );
-		$this->assertEquals( 'root', $processor->get_qualified_tag(), 'Did not find root tag' );
+		$this->assertEquals( 'root', $processor->get_local_tag_name(), 'Did not find root tag' );
 	}
 
 	/**

--- a/components/XML/Tests/XMLProcessorTest.php
+++ b/components/XML/Tests/XMLProcessorTest.php
@@ -26,36 +26,36 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_tag
+	 * @covers XMLProcessor::get_qualified_tag
 	 */
 	public function test_get_tag_returns_null_before_finding_tags() {
 		$processor = XMLProcessor::create_from_string( '<wp:content>Test</wp:content>' );
 
-		$this->assertNull( $processor->get_tag(), 'Calling get_tag() without selecting a tag did not return null' );
+		$this->assertNull( $processor->get_qualified_tag(), 'Calling get_tag() without selecting a tag did not return null' );
 	}
 
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_tag
+	 * @covers XMLProcessor::get_qualified_tag
 	 */
 	public function test_get_tag_returns_null_when_not_in_open_tag() {
 		$processor = XMLProcessor::create_from_string( '<wp:content>Test</wp:content>' );
 
 		$this->assertFalse( $processor->next_tag( 'p' ), 'Querying a non-existing tag did not return false' );
-		$this->assertNull( $processor->get_tag(), 'Accessing a non-existing tag did not return null' );
+		$this->assertNull( $processor->get_qualified_tag(), 'Accessing a non-existing tag did not return null' );
 	}
 
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_tag
+	 * @covers XMLProcessor::get_qualified_tag
 	 */
 	public function test_get_tag_returns_open_tag_name() {
 		$processor = XMLProcessor::create_from_string( '<wp:content>Test</wp:content>' );
 
 		$this->assertTrue( $processor->next_tag( 'wp:content' ), 'Querying an existing tag did not return true' );
-		$this->assertSame( 'wp:content', $processor->get_tag(), 'Accessing an existing tag name did not return "div"' );
+		$this->assertSame( 'wp:content', $processor->get_qualified_tag(), 'Accessing an existing tag name did not return "div"' );
 	}
 
 	/**
@@ -107,20 +107,20 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute
+	 * @covers XMLProcessor::get_attribute_by_qualified_name
 	 */
 	public function test_get_attribute_returns_null_when_not_in_open_tag() {
 		$processor = XMLProcessor::create_from_string( '<wp:content wp:post-type="test">Test</wp:content>' );
 
 		$this->assertFalse( $processor->next_tag( 'p' ), 'Querying a non-existing tag did not return false' );
-		$this->assertNull( $processor->get_attribute( 'wp:post-type' ),
+		$this->assertNull( $processor->get_attribute_by_qualified_name( 'wp:post-type' ),
 			'Accessing an attribute of a non-existing tag did not return null' );
 	}
 
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute
+	 * @covers XMLProcessor::get_attribute_by_qualified_name
 	 */
 	public function test_get_attribute_returns_null_when_in_closing_tag() {
 		$processor = XMLProcessor::create_from_string( '<wp:content wp:post-type="test">Test</wp:content>' );
@@ -128,26 +128,26 @@ class XMLProcessorTest extends TestCase {
 		$this->assertTrue( $processor->next_tag( 'wp:content' ), 'Querying an existing tag did not return true' );
 		$this->assertTrue( $processor->next_token(), 'Querying an existing closing tag did not return true' );
 		$this->assertTrue( $processor->next_token(), 'Querying an existing closing tag did not return true' );
-		$this->assertNull( $processor->get_attribute( 'wp:post-type' ), 'Accessing an attribute of a closing tag did not return null' );
+		$this->assertNull( $processor->get_attribute_by_qualified_name( 'wp:post-type' ), 'Accessing an attribute of a closing tag did not return null' );
 	}
 
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute
+	 * @covers XMLProcessor::get_attribute_by_qualified_name
 	 */
 	public function test_get_attribute_returns_null_when_attribute_missing() {
 		$processor = XMLProcessor::create_from_string( '<wp:content wp:post-type="test">Test</wp:content>' );
 
 		$this->assertTrue( $processor->next_tag( 'wp:content' ), 'Querying an existing tag did not return true' );
-		$this->assertNull( $processor->get_attribute( 'test-id' ), 'Accessing a non-existing attribute did not return null' );
+		$this->assertNull( $processor->get_attribute_by_qualified_name( 'test-id' ), 'Accessing a non-existing attribute did not return null' );
 	}
 
 	/**
 	 * @ticket 61365
 	 *
 	 * @expectedIncorrectUsage XMLProcessor::base_class_next_token
-	 * @covers XMLProcessor::get_attribute
+	 * @covers XMLProcessor::get_attribute_by_qualified_name
 	 */
 	public function test_attributes_are_rejected_in_tag_closers() {
 		$processor = XMLProcessor::create_from_string( '<wp:content>Test</wp:content wp:post-type="test">' );
@@ -160,13 +160,13 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute
+	 * @covers XMLProcessor::get_attribute_by_qualified_name
 	 */
 	public function test_get_attribute_returns_attribute_value() {
 		$processor = XMLProcessor::create_from_string( '<wp:content wp:post-type="test">Test</wp:content>' );
 
 		$this->assertTrue( $processor->next_tag( 'wp:content' ), 'Querying an existing tag did not return true' );
-		$this->assertSame( 'test', $processor->get_attribute( 'wp:post-type' ),
+		$this->assertSame( 'test', $processor->get_attribute_by_qualified_name( 'wp:post-type' ),
 			'Accessing a wp:post-type="test" attribute value did not return "test"' );
 	}
 
@@ -174,7 +174,7 @@ class XMLProcessorTest extends TestCase {
 	 * @ticket 61365
 	 * @expectedIncorrectUsage XMLProcessor::parse_next_attribute
 	 *
-	 * @covers XMLProcessor::get_attribute
+	 * @covers XMLProcessor::get_attribute_by_qualified_name
 	 */
 	public function test_parsing_stops_on_malformed_attribute_value_no_value() {
 		$processor = XMLProcessor::create_from_string( '<wp:content enabled wp:post-type="test">Test</wp:content>' );
@@ -186,7 +186,7 @@ class XMLProcessorTest extends TestCase {
 	 * @ticket 61365
 	 * @expectedIncorrectUsage XMLProcessor::parse_next_attribute
 	 *
-	 * @covers XMLProcessor::get_attribute
+	 * @covers XMLProcessor::get_attribute_by_qualified_name
 	 */
 	public function test_parsing_stops_on_malformed_attribute_value_no_quotes() {
 		$processor = XMLProcessor::create_from_string( '<wp:content enabled=1 wp:post-type="test">Test</wp:content>' );
@@ -198,33 +198,33 @@ class XMLProcessorTest extends TestCase {
 	 * @ticket 61365
 	 * @expectedIncorrectUsage XMLProcessor::get_attribute
 	 *
-	 * @covers XMLProcessor::get_attribute
+	 * @covers XMLProcessor::get_attribute_by_qualified_name
 	 */
 	public function test_malformed_attribute_value_containing_ampersand_is_treated_as_plaintext() {
 		$processor = XMLProcessor::create_from_string( '<wp:content enabled="WordPress & WordPress">Test</wp:content>' );
 
 		$this->assertTrue( $processor->next_tag(), 'Querying a tag did not return true' );
-		$this->assertEquals( 'WordPress & WordPress', $processor->get_attribute( 'enabled' ) );
+		$this->assertEquals( 'WordPress & WordPress', $processor->get_attribute_by_qualified_name( 'enabled' ) );
 	}
 
 	/**
 	 * @ticket 61365
 	 * @expectedIncorrectUsage XMLProcessor::get_attribute
 	 *
-	 * @covers XMLProcessor::get_attribute
+	 * @covers XMLProcessor::get_attribute_by_qualified_name
 	 */
 	public function test_malformed_attribute_value_containing_entity_without_semicolon_is_treated_as_plaintext() {
 		$processor = XMLProcessor::create_from_string( '<wp:content enabled="&#x94">Test</wp:content>' );
 
 		$this->assertTrue( $processor->next_tag(), 'Querying a tag did not return true' );
-		$this->assertEquals( '&#x94', $processor->get_attribute( 'enabled' ) );
+		$this->assertEquals( '&#x94', $processor->get_attribute_by_qualified_name( 'enabled' ) );
 	}
 
 	/**
 	 * @ticket 61365
 	 * @expectedIncorrectUsage XMLProcessor::parse_next_attribute
 	 *
-	 * @covers XMLProcessor::get_attribute
+	 * @covers XMLProcessor::get_attribute_by_qualified_name
 	 */
 	public function test_parsing_stops_on_malformed_attribute_value_contains_lt_character() {
 		$processor = XMLProcessor::create_from_string( '<wp:content enabled="I love <3 this">Test</wp:content>' );
@@ -236,7 +236,7 @@ class XMLProcessorTest extends TestCase {
 	 * @ticket 61365
 	 * @expectedIncorrectUsage XMLProcessor::parse_next_attribute
 	 *
-	 * @covers XMLProcessor::get_attribute
+	 * @covers XMLProcessor::get_attribute_by_qualified_name
 	 */
 	public function test_parsing_stops_on_malformed_tags_duplicate_attributes() {
 		$processor = XMLProcessor::create_from_string( '<wp:content id="update-me" id="ignored-id"><wp:text id="second">Text</wp:text></wp:content>' );
@@ -248,7 +248,7 @@ class XMLProcessorTest extends TestCase {
 	 * @ticket 61365
 	 * @expectedIncorrectUsage XMLProcessor::parse_next_attribute
 	 *
-	 * @covers XMLProcessor::get_attribute
+	 * @covers XMLProcessor::get_attribute_by_qualified_name
 	 */
 	public function test_parsing_stops_on_malformed_attribute_name_contains_slash() {
 		$processor = XMLProcessor::create_from_string( '<wp:content a/b="test">Test</wp:content>' );
@@ -259,7 +259,7 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute
+	 * @covers XMLProcessor::get_attribute_by_qualified_name
 	 */
 	public function test_get_modifiable_text_returns_a_decoded_value() {
 		$processor = XMLProcessor::create_from_string( '<root>&#x201C;&#x1f604;&#x201D;</root>' );
@@ -277,7 +277,7 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute
+	 * @covers XMLProcessor::get_attribute_by_qualified_name
 	 */
 	public function test_get_attribute_returns_a_decoded_value() {
 		$processor = XMLProcessor::create_from_string( '<root encoded-data="&#x201C;&#x1f604;&#x201D;"></root>' );
@@ -285,7 +285,7 @@ class XMLProcessorTest extends TestCase {
 		$this->assertTrue( $processor->next_tag( 'root' ), 'Querying a tag did not return true' );
 		$this->assertEquals(
 			'“😄”',
-			$processor->get_attribute( 'encoded-data' ),
+			$processor->get_attribute_by_qualified_name( 'encoded-data' ),
 			'Reading an encoded attribute did not decode it.'
 		);
 	}
@@ -293,7 +293,7 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute
+	 * @covers XMLProcessor::get_attribute_by_qualified_name
 	 *
 	 * @param  string  $attribute_name  Name of data-enabled attribute with case variations.
 	 */
@@ -303,12 +303,12 @@ class XMLProcessorTest extends TestCase {
 
 		$this->assertEquals(
 			'true',
-			$processor->get_attribute( 'DATA-enabled' ),
+			$processor->get_attribute_by_qualified_name( 'DATA-enabled' ),
 			'Accessing an attribute by a same-cased name did return not its value'
 		);
 
 		$this->assertNull(
-			$processor->get_attribute( 'data-enabled' ),
+			$processor->get_attribute_by_qualified_name( 'data-enabled' ),
 			'Accessing an attribute by a differently-cased name did return its value'
 		);
 	}
@@ -350,12 +350,12 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute_names_with_prefix
+	 * @covers XMLProcessor::get_attribute_qualified_names_with_prefix
 	 */
 	public function test_get_attribute_names_with_prefix_returns_null_before_finding_tags() {
 		$processor = XMLProcessor::create_from_string( '<wp:content data-foo="bar">Test</wp:content>' );
 		$this->assertNull(
-			$processor->get_attribute_names_with_prefix( 'data-' ),
+			$processor->get_attribute_qualified_names_with_prefix( 'data-' ),
 			'Accessing attributes by their prefix did not return null when no tag was selected'
 		);
 	}
@@ -363,46 +363,46 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute_names_with_prefix
+	 * @covers XMLProcessor::get_attribute_qualified_names_with_prefix
 	 */
 	public function test_get_attribute_names_with_prefix_returns_null_when_not_in_open_tag() {
 		$processor = XMLProcessor::create_from_string( '<wp:content data-foo="bar">Test</wp:content>' );
 		$processor->next_tag( 'p' );
-		$this->assertNull( $processor->get_attribute_names_with_prefix( 'data-' ),
+		$this->assertNull( $processor->get_attribute_qualified_names_with_prefix( 'data-' ),
 			'Accessing attributes of a non-existing tag did not return null' );
 	}
 
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute_names_with_prefix
+	 * @covers XMLProcessor::get_attribute_qualified_names_with_prefix
 	 */
 	public function test_get_attribute_names_with_prefix_returns_null_when_in_closing_tag() {
 		$processor = XMLProcessor::create_from_string( '<wp:content data-foo="bar">Test</wp:content>' );
 		$processor->next_tag( 'wp:content' );
 		$processor->next_tag( array( 'tag_closers' => 'visit' ) );
 
-		$this->assertNull( $processor->get_attribute_names_with_prefix( 'data-' ),
+		$this->assertNull( $processor->get_attribute_qualified_names_with_prefix( 'data-' ),
 			'Accessing attributes of a closing tag did not return null' );
 	}
 
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute_names_with_prefix
+	 * @covers XMLProcessor::get_attribute_qualified_names_with_prefix
 	 */
 	public function test_get_attribute_names_with_prefix_returns_empty_array_when_no_attributes_present() {
 		$processor = XMLProcessor::create_from_string( '<wp:content>Test</wp:content>' );
 		$processor->next_tag( 'wp:content' );
 
-		$this->assertSame( array(), $processor->get_attribute_names_with_prefix( 'data-' ),
+		$this->assertSame( array(), $processor->get_attribute_qualified_names_with_prefix( 'data-' ),
 			'Accessing the attributes on a tag without any did not return an empty array' );
 	}
 
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute_names_with_prefix
+	 * @covers XMLProcessor::get_attribute_qualified_names_with_prefix
 	 */
 	public function test_get_attribute_names_with_prefix_returns_matching_attribute_names_in_original_case() {
 		$processor = XMLProcessor::create_from_string( '<wp:content DATA-enabled="yes" wp:post-type="test" data-test-ID="14">Test</wp:content>' );
@@ -410,7 +410,7 @@ class XMLProcessorTest extends TestCase {
 
 		$this->assertSame(
 			array( 'data-test-ID' ),
-			$processor->get_attribute_names_with_prefix( 'data-' ),
+			$processor->get_attribute_qualified_names_with_prefix( 'data-' ),
 			'Accessing attributes by their prefix did not return their lowercase names'
 		);
 	}
@@ -418,7 +418,7 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute_names_with_prefix
+	 * @covers XMLProcessor::get_attribute_qualified_names_with_prefix
 	 */
 	public function test_get_attribute_names_with_prefix_returns_attribute_added_by_set_attribute() {
 		$processor = XMLProcessor::create_from_string( '<wp:content data-foo="bar">Test</wp:content>' );
@@ -432,7 +432,7 @@ class XMLProcessorTest extends TestCase {
 		);
 		$this->assertSame(
 			array( 'data-test-id', 'data-foo' ),
-			$processor->get_attribute_names_with_prefix( 'data-' ),
+			$processor->get_attribute_qualified_names_with_prefix( 'data-' ),
 			"Accessing attribute names doesn't find attribute added via set_attribute"
 		);
 	}
@@ -753,7 +753,7 @@ class XMLProcessorTest extends TestCase {
 		$tags->seek( 'here' );
 		$this->assertSame( '<root><wp:content wp:post-type="foo">outside</wp:content><section><wp:content><photo>inside</wp:content></section></root>',
 			$tags->get_updated_xml() );
-		$this->assertSame( 'section', $tags->get_tag() );
+		$this->assertSame( 'section', $tags->get_qualified_tag() );
 		$this->assertFalse( $tags->is_tag_closer() );
 	}
 
@@ -821,7 +821,7 @@ class XMLProcessorTest extends TestCase {
 		);
 		$this->assertSame(
 			'test-value',
-			$processor->get_attribute( 'test-attribute' ),
+			$processor->get_attribute_by_qualified_name( 'test-attribute' ),
 			'get_attribute() (called after get_updated_xml()) did not return attribute added via set_attribute()'
 		);
 	}
@@ -829,7 +829,7 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute
+	 * @covers XMLProcessor::get_attribute_by_qualified_name
 	 */
 	public function test_get_attribute_returns_updated_values_before_they_are_applied() {
 		$processor = XMLProcessor::create_from_string( self::XML_SIMPLE );
@@ -838,7 +838,7 @@ class XMLProcessorTest extends TestCase {
 
 		$this->assertSame(
 			'test-value',
-			$processor->get_attribute( 'test-attribute' ),
+			$processor->get_attribute_by_qualified_name( 'test-attribute' ),
 			'get_attribute() (called before get_updated_xml()) did not return attribute added via set_attribute()'
 		);
 		$this->assertSame(
@@ -851,7 +851,7 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute
+	 * @covers XMLProcessor::get_attribute_by_qualified_name
 	 */
 	public function test_get_attribute_returns_updated_values_before_they_are_applied_with_different_name_casing() {
 		$processor = XMLProcessor::create_from_string( self::XML_SIMPLE );
@@ -860,7 +860,7 @@ class XMLProcessorTest extends TestCase {
 
 		$this->assertSame(
 			'test-value',
-			$processor->get_attribute( 'test-ATTribute' ),
+			$processor->get_attribute_by_qualified_name( 'test-ATTribute' ),
 			'get_attribute() (called before get_updated_xml()) did not return attribute added via set_attribute()'
 		);
 		$this->assertSame(
@@ -874,7 +874,7 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute
+	 * @covers XMLProcessor::get_attribute_by_qualified_name
 	 */
 	public function test_get_attribute_reflects_removed_attribute_before_it_is_applied() {
 		$processor = XMLProcessor::create_from_string( self::XML_SIMPLE );
@@ -882,7 +882,7 @@ class XMLProcessorTest extends TestCase {
 		$processor->remove_attribute( 'id' );
 
 		$this->assertNull(
-			$processor->get_attribute( 'id' ),
+			$processor->get_attribute_by_qualified_name( 'id' ),
 			'get_attribute() (called before get_updated_xml()) returned attribute that was removed by remove_attribute()'
 		);
 		$this->assertSame(
@@ -895,7 +895,7 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute
+	 * @covers XMLProcessor::get_attribute_by_qualified_name
 	 */
 	public function test_get_attribute_reflects_adding_and_then_removing_an_attribute_before_those_updates_are_applied() {
 		$processor = XMLProcessor::create_from_string( self::XML_SIMPLE );
@@ -904,7 +904,7 @@ class XMLProcessorTest extends TestCase {
 		$processor->remove_attribute( 'test-attribute' );
 
 		$this->assertNull(
-			$processor->get_attribute( 'test-attribute' ),
+			$processor->get_attribute_by_qualified_name( 'test-attribute' ),
 			'get_attribute() (called before get_updated_xml()) returned attribute that was added via set_attribute() and then removed by remove_attribute()'
 		);
 		$this->assertSame(
@@ -917,7 +917,7 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * @ticket 61365
 	 *
-	 * @covers XMLProcessor::get_attribute
+	 * @covers XMLProcessor::get_attribute_by_qualified_name
 	 */
 	public function test_get_attribute_reflects_setting_and_then_removing_an_existing_attribute_before_those_updates_are_applied() {
 		$processor = XMLProcessor::create_from_string( self::XML_SIMPLE );
@@ -926,7 +926,7 @@ class XMLProcessorTest extends TestCase {
 		$processor->remove_attribute( 'id' );
 
 		$this->assertNull(
-			$processor->get_attribute( 'id' ),
+			$processor->get_attribute_by_qualified_name( 'id' ),
 			'get_attribute() (called before get_updated_xml()) returned attribute that was overwritten by set_attribute() and then removed by remove_attribute()'
 		);
 		$this->assertSame(
@@ -1106,7 +1106,7 @@ class XMLProcessorTest extends TestCase {
 
 		$this->assertFalse(
 			$processor->next_tag(),
-			"Should not have found any tag, but found {$processor->get_tag()}."
+			"Should not have found any tag, but found {$processor->get_qualified_tag()}."
 		);
 
 		$this->assertTrue(
@@ -1144,7 +1144,7 @@ class XMLProcessorTest extends TestCase {
 
 		$this->assertFalse(
 			$processor->next_tag(),
-			"Should not have found any tag, but found {$processor->get_tag()}."
+			"Should not have found any tag, but found {$processor->get_qualified_tag()}."
 		);
 
 		$this->assertFalse(
@@ -1189,7 +1189,7 @@ class XMLProcessorTest extends TestCase {
 		$processor->next_tag();
 		$this->assertFalse(
 			$processor->next_tag(),
-			"Shouldn't have found any tags but found {$processor->get_tag()}."
+			"Shouldn't have found any tags but found {$processor->get_qualified_tag()}."
 		);
 
 		$this->assertTrue(
@@ -1379,8 +1379,8 @@ class XMLProcessorTest extends TestCase {
 			$processor->get_token_type(),
 			'The XML declaration was not correctly identified.'
 		);
-		$this->assertEquals( '1.0', $processor->get_attribute( 'version' ), 'The version attribute was not correctly captured.' );
-		$this->assertEquals( 'UTF-8', $processor->get_attribute( 'encoding' ), 'The encoding attribute was not correctly captured.' );
+		$this->assertEquals( '1.0', $processor->get_attribute_by_qualified_name( 'version' ), 'The version attribute was not correctly captured.' );
+		$this->assertEquals( 'UTF-8', $processor->get_attribute_by_qualified_name( 'encoding' ), 'The encoding attribute was not correctly captured.' );
 	}
 
 	/**
@@ -1395,8 +1395,8 @@ class XMLProcessorTest extends TestCase {
 			$processor->get_token_type(),
 			'The XML declaration was not correctly identified.'
 		);
-		$this->assertEquals( '1.0', $processor->get_attribute( 'version' ), 'The version attribute was not correctly captured.' );
-		$this->assertEquals( 'UTF-8', $processor->get_attribute( 'encoding' ), 'The encoding attribute was not correctly captured.' );
+		$this->assertEquals( '1.0', $processor->get_attribute_by_qualified_name( 'version' ), 'The version attribute was not correctly captured.' );
+		$this->assertEquals( 'UTF-8', $processor->get_attribute_by_qualified_name( 'encoding' ), 'The encoding attribute was not correctly captured.' );
 	}
 
 	/**
@@ -1456,7 +1456,7 @@ class XMLProcessorTest extends TestCase {
 		$subclass->next_tag();
 		$this->assertSame(
 			'p',
-			$subclass->get_tag(),
+			$subclass->get_qualified_tag(),
 			'Should have matched inserted XML as next tag.'
 		);
 
@@ -1544,7 +1544,7 @@ class XMLProcessorTest extends TestCase {
 			)
 		);
 
-		$this->assertEquals( 'image', $processor->get_tag(), 'Did not find the expected tag' );
+		$this->assertEquals( 'image', $processor->get_qualified_tag(), 'Did not find the expected tag' );
 	}
 
 	/**
@@ -1623,7 +1623,7 @@ class XMLProcessorTest extends TestCase {
 		$processor = XMLProcessor::create_from_string( '<root></root>   <?xml hey ?> <!-- comment --> <?xml another pi ?> <!-- more comments! -->' );
 
 		$processor->next_tag();
-		$this->assertEquals( 'root', $processor->get_tag(), 'Did not find a tag.' );
+		$this->assertEquals( 'root', $processor->get_qualified_tag(), 'Did not find a tag.' );
 
 		$processor->next_tag();
 		$this->assertNull( $processor->get_last_error(), 'Did not run into a parse error after the root element' );
@@ -1758,7 +1758,7 @@ XML;
 		$processor = XMLProcessor::create_for_streaming( $xml );
 		$processor->next_tag();
 		$processor->next_tag();
-		$this->assertEquals( 'first_child', $processor->get_tag(), 'Did not find a tag.' );
+		$this->assertEquals( 'first_child', $processor->get_qualified_tag(), 'Did not find a tag.' );
 
 		$entity_offset = $processor->get_token_byte_offset_in_the_input_stream();
 		$cursor        = $processor->get_reentrancy_cursor();
@@ -1768,7 +1768,7 @@ XML;
 			$cursor
 		);
 		$resumed->next_tag();
-		$this->assertEquals( 'first_child', $resumed->get_tag(), 'Did not find a tag.' );
+		$this->assertEquals( 'first_child', $resumed->get_qualified_tag(), 'Did not find a tag.' );
 		$resumed->next_token();
 		$this->assertEquals( 'Hello there', $resumed->get_modifiable_text(), 'Did not find the expected text.' );
 	}
@@ -1786,7 +1786,7 @@ XML;
 		$this->assertTrue( $processor->next_token(), 'Did not find DOCTYPE node' );
 		$this->assertEquals( '#doctype', $processor->get_token_type(), 'Did not find DOCTYPE node' );
 		$this->assertTrue( $processor->next_token(), 'Did not find root tag' );
-		$this->assertEquals( 'root', $processor->get_tag(), 'Did not find root tag' );
+		$this->assertEquals( 'root', $processor->get_qualified_tag(), 'Did not find root tag' );
 	}
 
 	/**
@@ -1806,7 +1806,7 @@ XML;
 		$this->assertEquals( 'http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd', $processor->get_system_literal(),
 			'Did not find system literal' );
 		$this->assertTrue( $processor->next_token(), 'Did not find root tag' );
-		$this->assertEquals( 'root', $processor->get_tag(), 'Did not find root tag' );
+		$this->assertEquals( 'root', $processor->get_qualified_tag(), 'Did not find root tag' );
 	}
 
 	/**
@@ -1826,7 +1826,7 @@ XML;
 		$this->assertEquals( 'http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd', $processor->get_system_literal(),
 			'Did not find system literal' );
 		$this->assertTrue( $processor->next_token(), 'Did not find root tag' );
-		$this->assertEquals( 'root', $processor->get_tag(), 'Did not find root tag' );
+		$this->assertEquals( 'root', $processor->get_qualified_tag(), 'Did not find root tag' );
 	}
 
 	/**

--- a/components/XML/Tests/XMLProcessorTest.php
+++ b/components/XML/Tests/XMLProcessorTest.php
@@ -24,7 +24,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::get_tag_local_name
 	 */
@@ -35,7 +34,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::get_tag_local_name
 	 */
@@ -47,7 +45,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::get_tag_local_name
 	 */
@@ -59,7 +56,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers       XMLProcessor::is_empty_element
 	 *
@@ -105,7 +101,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::get_attribute
 	 */
@@ -118,7 +113,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::get_attribute
 	 */
@@ -132,7 +126,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::get_attribute
 	 */
@@ -144,7 +137,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @expectedIncorrectUsage XMLProcessor::base_class_next_token
 	 * @covers XMLProcessor::get_attribute
@@ -158,7 +150,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::get_attribute
 	 */
@@ -171,7 +162,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 * @expectedIncorrectUsage XMLProcessor::parse_next_attribute
 	 *
 	 * @covers XMLProcessor::get_attribute
@@ -183,7 +173,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 * @expectedIncorrectUsage XMLProcessor::parse_next_attribute
 	 *
 	 * @covers XMLProcessor::get_attribute
@@ -195,7 +184,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 * @expectedIncorrectUsage XMLProcessor::get_attribute
 	 *
 	 * @covers XMLProcessor::get_attribute
@@ -208,7 +196,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 * @expectedIncorrectUsage XMLProcessor::get_attribute
 	 *
 	 * @covers XMLProcessor::get_attribute
@@ -221,7 +208,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 * @expectedIncorrectUsage XMLProcessor::parse_next_attribute
 	 *
 	 * @covers XMLProcessor::get_attribute
@@ -233,7 +219,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 * @expectedIncorrectUsage XMLProcessor::parse_next_attribute
 	 *
 	 * @covers XMLProcessor::get_attribute
@@ -245,7 +230,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 * @expectedIncorrectUsage XMLProcessor::parse_next_attribute
 	 *
 	 * @covers XMLProcessor::get_attribute
@@ -257,7 +241,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::get_attribute
 	 */
@@ -275,7 +258,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::get_attribute
 	 */
@@ -291,7 +273,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::get_attribute
 	 *
@@ -315,7 +296,6 @@ class XMLProcessorTest extends TestCase {
 
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::remove_attribute
 	 */
@@ -334,7 +314,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::set_attribute
 	 */
@@ -348,7 +327,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::get_attribute_qualified_names_with_prefix
 	 */
@@ -361,7 +339,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::get_attribute_qualified_names_with_prefix
 	 */
@@ -373,7 +350,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::get_attribute_qualified_names_with_prefix
 	 */
@@ -387,7 +363,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::get_attribute_qualified_names_with_prefix
 	 */
@@ -400,7 +375,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::get_attribute_qualified_names_with_prefix
 	 */
@@ -416,7 +390,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::get_attribute_qualified_names_with_prefix
 	 */
@@ -438,7 +411,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::__toString
 	 */
@@ -459,7 +431,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::get_updated_xml
 	 */
@@ -496,7 +467,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::get_updated_xml
 	 */
@@ -514,7 +484,6 @@ class XMLProcessorTest extends TestCase {
 	 * Ensures that when seeking to an earlier spot in the document that
 	 * all previously-enqueued updates are applied as they ought to be.
 	 *
-	 * @ticket 61365
 	 * @expectedIncorrectUsage XMLProcessor::parse_next_attribute
 	 */
 	public function test_get_updated_xml_applies_updates_to_content_after_seeking_to_before_parsed_bytes() {
@@ -561,7 +530,6 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * Ensures that bookmarks start and length correctly describe a given token in XML.
 	 *
-	 * @ticket 61365
 	 *
 	 * @dataProvider data_xml_nth_token_substring
 	 *
@@ -658,7 +626,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::next_tag
 	 */
@@ -669,7 +636,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::next_tag
 	 */
@@ -680,7 +646,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::get_modifiable_text
 	 */
@@ -698,7 +663,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::get_modifiable_text
 	 */
@@ -716,8 +680,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::next_tag
 	 * @covers XMLProcessor::is_tag_closer
@@ -734,7 +696,6 @@ class XMLProcessorTest extends TestCase {
 	 * Verifies that updates to a document before calls to `get_updated_xml()` don't
 	 * lead to the Tag Processor jumping to the wrong tag after the updates.
 	 *
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::get_updated_xml
 	 */
@@ -759,7 +720,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::set_attribute
 	 */
@@ -779,7 +739,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::set_attribute
 	 * @covers XMLProcessor::remove_attribute
@@ -806,7 +765,6 @@ class XMLProcessorTest extends TestCase {
 
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::set_attribute
 	 */
@@ -828,7 +786,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::get_attribute
 	 */
@@ -850,7 +807,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::get_attribute
 	 */
@@ -873,7 +829,6 @@ class XMLProcessorTest extends TestCase {
 
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::get_attribute
 	 */
@@ -894,7 +849,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::get_attribute
 	 */
@@ -916,7 +870,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::get_attribute
 	 */
@@ -938,7 +891,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::set_attribute
 	 */
@@ -957,7 +909,6 @@ class XMLProcessorTest extends TestCase {
 	 * Ensures that when setting an attribute multiple times that only
 	 * one update flushes out into the updated XML.
 	 *
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::set_attribute
 	 */
@@ -972,7 +923,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::next_tag
 	 * @covers XMLProcessor::set_attribute
@@ -991,7 +941,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::remove_attribute
 	 */
@@ -1008,7 +957,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::remove_attribute
 	 */
@@ -1025,7 +973,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::next_tag
 	 */
@@ -1055,7 +1002,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 * @expectedIncorrectUsage XMLProcessor::parse_next_attribute
 	 * @expectedIncorrectUsage XMLProcessor::set_attribute
 	 *
@@ -1073,7 +1019,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 * @expectedIncorrectUsage XMLProcessor::set_attribute
 	 *
 	 * @covers XMLProcessor::set_attribute
@@ -1093,7 +1038,6 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * Ensures that unclosed and invalid comments trigger warnings or errors.
 	 *
-	 * @ticket 61365
 	 *
 	 * @covers       XMLProcessor::next_tag
 	 * @covers       XMLProcessor::paused_at_incomplete_token
@@ -1131,7 +1075,6 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * Ensures that partial syntax triggers warnings or errors.
 	 *
-	 * @ticket 61365
 	 *
 	 * @covers       XMLProcessor::next_tag
 	 * @covers       XMLProcessor::paused_at_incomplete_token
@@ -1175,7 +1118,6 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * Ensures that the processor doesn't attempt to match an incomplete token.
 	 *
-	 * @ticket 61365
 	 *
 	 * @covers       XMLProcessor::next_tag
 	 * @covers       XMLProcessor::paused_at_incomplete_token
@@ -1225,7 +1167,6 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * Ensures that the processor doesn't attempt to match an incomplete text node.
 	 *
-	 * @ticket 61365
 	 *
 	 * @covers       XMLProcessor::next_tag
 	 * @covers       XMLProcessor::paused_at_incomplete_token
@@ -1312,7 +1253,6 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * Ensures that non-tag syntax starting with `<` is rejected.
 	 *
-	 * @ticket 61365
 	 */
 	public function test_single_text_node_with_taglike_text() {
 		$processor = XMLProcessor::create_from_string( '<root xmlns:wp="w.org">This is a text node< /A>' );
@@ -1326,7 +1266,6 @@ class XMLProcessorTest extends TestCase {
 	/**
 	 * Ensures that non-tag syntax starting with `<` is rejected.
 	 *
-	 * @ticket 61365
 	 */
 	public function test_parses_CDATA() {
 		$processor = XMLProcessor::create_from_string( '<root xmlns:wp="w.org"><![CDATA[This is a CDATA text node.]]></root>' );
@@ -1340,7 +1279,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 */
 	public function test_yields_CDATA_a_separate_text_node() {
 		$processor = XMLProcessor::create_from_string( '<root xmlns:wp="w.org">This is the first text node <![CDATA[ and this is a second text node ]]> and this is the third text node.</root>' );
@@ -1370,7 +1308,6 @@ class XMLProcessorTest extends TestCase {
 
 	/**
 	 *
-	 * @ticket 61365
 	 */
 	public function test_xml_declaration() {
 		$processor = XMLProcessor::create_from_string( '<?xml version="1.0" encoding="UTF-8" ?>' );
@@ -1386,7 +1323,6 @@ class XMLProcessorTest extends TestCase {
 
 	/**
 	 *
-	 * @ticket 61365
 	 */
 	public function test_xml_declaration_with_single_quotes() {
 		$processor = XMLProcessor::create_from_string( "<?xml version='1.0' encoding='UTF-8' ?>" );
@@ -1402,7 +1338,6 @@ class XMLProcessorTest extends TestCase {
 
 	/**
 	 *
-	 * @ticket 61365
 	 */
 	public function test_processor_instructions() {
 		$processor = XMLProcessor::create_from_string(
@@ -1426,7 +1361,6 @@ class XMLProcessorTest extends TestCase {
 	 * Ensures that updates which are enqueued in front of the cursor
 	 * are applied before moving forward in the document.
 	 *
-	 * @ticket 61365
 	 */
 	public function test_applies_updates_before_proceeding() {
 		$xml = '<root xmlns:wp="w.org"><wp:content><photo/></wp:content><wp:content><photo/></wp:content></root>';
@@ -1473,7 +1407,6 @@ class XMLProcessorTest extends TestCase {
 
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::next_tag
 	 * @covers XMLProcessor::get_breadcrumbs
@@ -1511,7 +1444,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @return void
 	 */
@@ -1530,7 +1462,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @return void
 	 */
@@ -1549,7 +1480,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @return void
 	 */
@@ -1582,7 +1512,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @expectedIncorrectUsage XMLProcessor::step_in_misc
 	 */
@@ -1598,7 +1527,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 */
 	public function test_whitespace_text_allowed_after_root_element() {
 		$processor = XMLProcessor::create_from_string( '<root xmlns:wp="w.org"></root>   ' );
@@ -1608,7 +1536,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 */
 	public function test_processing_directives_allowed_after_root_element() {
 		$processor = XMLProcessor::create_from_string( '<root xmlns:wp="w.org"></root><?xml processing directive! ?>' );
@@ -1618,7 +1545,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 */
 	public function test_mixed_misc_grammar_allowed_after_root_element() {
 		$processor = XMLProcessor::create_from_string( '<root xmlns:wp="w.org"></root>   <?xml hey ?> <!-- comment --> <?xml another pi ?> <!-- more comments! -->' );
@@ -1631,7 +1557,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @expectedIncorrectUsage XMLProcessor::step_in_misc
 	 */
@@ -1647,7 +1572,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @return void
 	 */
@@ -1659,7 +1583,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @expectedIncorrectUsage XMLProcessor::step_in_misc
 	 * @return void
@@ -1676,7 +1599,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::next_tag
 	 */
@@ -1690,7 +1612,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::next_tag
 	 */
@@ -1708,7 +1629,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::next_token
 	 */
@@ -1726,7 +1646,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::next_token
 	 */
@@ -1744,7 +1663,6 @@ class XMLProcessorTest extends TestCase {
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::pause
 	 * @covers XMLProcessor::resume
@@ -1775,7 +1693,6 @@ XML;
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::next_token
 	 */
@@ -1791,7 +1708,6 @@ XML;
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::next_token
 	 */
@@ -1811,7 +1727,6 @@ XML;
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::next_token
 	 */
@@ -1831,7 +1746,6 @@ XML;
 	}
 
 	/**
-	 * @ticket 61365
 	 *
 	 * @covers XMLProcessor::next_token
 	 */
@@ -1854,5 +1768,117 @@ XML;
 
 		$this->assertFalse( $processor->next_token(), 'Did not reject DOCTYPE in tag content' );
 		$this->assertEquals( 'syntax', $processor->get_last_error(), 'Did not detect a syntax error' );
+	}
+
+	/**
+	 *
+	 * @covers XMLProcessor::set_attribute
+	 * @covers XMLProcessor::get_namespace
+	 */
+	public function test_setting_the_default_namespace_applies_to_element_and_children() {
+		$processor = XMLProcessor::create_from_string( '<root xmlns="http://example.com/ns1" attr="val1"><child attr="val2"><grandchild /></child></root>' );
+
+		// Root element should be in the http://example.com/ns1 namespace.
+		$this->assertTrue( $processor->next_tag( array( 'http://example.com/ns1', 'root' ) ) );
+		$this->assertEquals( 'http://example.com/ns1', $processor->get_namespace() );
+		// The attribute without a namespace prefix isn't namespaced.
+		$this->assertEquals( 'val1', $processor->get_attribute( '', 'attr' ), 'Unprefixed attribute attr was not found in the default namespace.' );
+
+		// Child element
+		$this->assertTrue( $processor->next_tag( array( 'http://example.com/ns1', 'child' ) ) );
+		$this->assertEquals( 'http://example.com/ns1', $processor->get_namespace() );
+		$this->assertEquals( 'val2', $processor->get_attribute( '', 'attr' ), 'Unprefixed attribute attr was not found in the default namespace.' ); 
+
+		// Grandchild element
+		$this->assertTrue( $processor->next_tag( array( 'http://example.com/ns1', 'grandchild' ) ) );
+		$this->assertEquals( 'http://example.com/ns1', $processor->get_namespace() );
+	}
+
+	/**
+	 *
+	 * @covers XMLProcessor::set_attribute
+	 * @covers XMLProcessor::get_namespace
+	 */
+	public function test_search_by_namespace() {
+		$processor = XMLProcessor::create_from_string( '<root xmlns="http://example.com/ns1" attr="val1"><child xmlns="http://example.com/ns2" attr="val2"><grandchild /></child></root>' );
+
+		// Root element should be in the http://example.com/ns1 namespace.
+		$this->assertTrue( $processor->next_tag( array( 'http://example.com/ns1', 'root' ) ) );
+		$this->assertEquals( 'http://example.com/ns1', $processor->get_namespace() );
+		// The attribute without a namespace prefix isn't namespaced.
+		$this->assertEquals( 'val1', $processor->get_attribute( '', 'attr' ), 'Unprefixed attribute attr was not found in the default namespace.' );
+
+		// Child element
+		$this->assertTrue( $processor->next_tag( array( 'http://example.com/ns2', 'child' ) ) );
+		$this->assertEquals( 'http://example.com/ns2', $processor->get_namespace() );
+		$this->assertEquals( 'val2', $processor->get_attribute( '', 'attr' ), 'Unprefixed attribute attr was not found in the default namespace.' ); 
+
+		// Grandchild element
+		$this->assertTrue( $processor->next_tag( array( 'http://example.com/ns2', 'grandchild' ) ) );
+		$this->assertEquals( 'http://example.com/ns2', $processor->get_namespace() );
+	}
+
+	/**
+	 *
+	 * @covers XMLProcessor::set_attribute
+	 * @covers XMLProcessor::get_namespace
+	 */
+	public function test_overriding_the_default_namespace_applies_to_element_and_children() {
+		$processor = XMLProcessor::create_from_string( '<root xmlns="http://example.com/ns1"><child xmlns="http://example.com/ns2" attr="val"><grandchild /></child></root>' );
+		$this->assertTrue( $processor->next_tag(['*', 'child']) );
+		$this->assertEquals( 'child', $processor->get_tag_local_name() );
+		$this->assertEquals( 'http://example.com/ns2', $processor->get_namespace() );
+		$this->assertEquals( 'val', $processor->get_attribute( '', 'attr' ), 'Unprefixed attribute attr was not found in the default namespace.' ); // Unprefixed attributes are in no namespace.
+
+		$processor->next_tag();
+		$this->assertEquals( 'grandchild', $processor->get_tag_local_name() );
+		$this->assertEquals( 'http://example.com/ns2', $processor->get_namespace() );
+	}
+
+	/**
+	 *
+	 * @covers XMLProcessor::set_attribute
+	 * @covers XMLProcessor::get_namespace
+	 */
+	public function test_changing_default_namespace_to_empty_string_removes_namespace() {
+		$processor = XMLProcessor::create_from_string( '<root xmlns="http://example.com/ns1"><child xmlns="" attr="val"><grandchild /></child></root>' );
+
+		// Root element
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertEquals( 'http://example.com/ns1', $processor->get_namespace() );
+
+		// Child element - default namespace removed
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertEquals( '', $processor->get_namespace() ); // Empty string indicates no namespace.
+		$this->assertEquals( 'val', $processor->get_attribute( '', 'attr' ) ); // Unprefixed attributes are in no namespace.
+
+		// Grandchild element - inherits no namespace from parent
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertEquals( '', $processor->get_namespace() ); // Empty string indicates no namespace.
+	}
+
+	/**
+	 * @expectedIncorrectUsage XMLProcessor::parse_next_attribute
+	 *
+	 * @covers XMLProcessor::get_attribute
+	 */
+	public function test_rejects_duplicate_attributes_with_different_prefixes_same_namespace_uri() {
+		$processor = XMLProcessor::create_from_string( '<x xmlns:n1="http://www.w3.org" xmlns:n2="http://www.w3.org"><bad n1:a="1" n2:a="2" /></x>' );
+		$processor->next_tag( 'x' ); // Move to <x>
+		$this->assertFalse( $processor->next_tag( 'bad' ), 'Should reject tag with duplicate extended attribute names.' );
+		$this->assertEquals( 'syntax', $processor->get_last_error(), 'Did not detect a syntax error' );
+		$this->assertStringContainsString( 'Duplicate attribute', $processor->get_exception()->getMessage() );
+	}
+
+	/**
+	 * @expectedIncorrectUsage XMLProcessor::parse_next_attribute
+	 *
+	 * @covers XMLProcessor::get_attribute
+	 */
+	public function test_rejects_duplicate_unprefixed_attributes_on_element_with_default_namespace() {
+		// Though unprefixed attributes are in "no namespace", they are still checked for duplicates locally.
+		$processor = XMLProcessor::create_from_string( '<x xmlns="http://www.w3.org"><bad a="1" a="2" /></x>' );
+		$processor->next_tag( 'x' ); // Move to <x>
+		$this->assertFalse( $processor->next_tag( 'bad' ), 'Should reject tag with duplicate unprefixed attributes.' );
 	}
 }

--- a/components/XML/XMLAttributeToken.php
+++ b/components/XML/XMLAttributeToken.php
@@ -25,7 +25,7 @@ class XMLAttributeToken {
 	 *
 	 * @var string
 	 */
-	public $name;
+	public $qualified_name;
 
 	/**
 	 * Attribute value.
@@ -102,8 +102,8 @@ class XMLAttributeToken {
 	 * @param  string  $namespace  Namespace.
 	 *
 	 */
-	public function __construct( $name, $value_start, $value_length, $start, $length, $namespace_prefix=null, $local_name=null, $namespace=null ) {
-		$this->name            = $name;
+	public function __construct( $qualified_name, $value_start, $value_length, $start, $length, $namespace_prefix=null, $local_name=null, $namespace=null ) {
+		$this->qualified_name  = $qualified_name;
 		$this->value_starts_at = $value_start;
 		$this->value_length    = $value_length;
 		$this->start           = $start;

--- a/components/XML/XMLAttributeToken.php
+++ b/components/XML/XMLAttributeToken.php
@@ -1,0 +1,115 @@
+<?php
+namespace WordPress\XML;
+
+/**
+ * XML API: XMLAttributeToken class
+ *
+ * @package WordPress
+ * @subpackage XML-API
+ * @since 6.2.0
+ */
+
+/**
+ * Core class used by the XML tag processor as a data structure for the attribute token,
+ * allowing to drastically improve performance.
+ *
+ * This class is for internal usage of the XMLProcessor class.
+ *
+ * @see XMLProcessor
+ */
+class XMLAttributeToken {
+	/**
+	 * Attribute name.
+	 *
+	 * @since 6.2.0
+	 *
+	 * @var string
+	 */
+	public $name;
+
+	/**
+	 * Attribute value.
+	 *
+	 * @since 6.2.0
+	 *
+	 * @var int
+	 */
+	public $value_starts_at;
+
+	/**
+	 * How many bytes the value occupies in the input XML.
+	 *
+	 * @since 6.2.0
+	 *
+	 * @var int
+	 */
+	public $value_length;
+
+	/**
+	 * The string offset where the attribute name starts.
+	 *
+	 * @since 6.2.0
+	 *
+	 * @var int
+	 */
+	public $start;
+
+	/**
+	 * Byte length of text spanning the attribute inside a tag.
+	 *
+	 * This span starts at the first character of the attribute name
+	 * and it ends after one of three cases:
+	 *
+	 *  - at the end of the attribute name for boolean attributes.
+	 *  - at the end of the value for unquoted attributes.
+	 *  - at the final single or double quote for quoted attributes.
+	 *
+	 * @var int
+	 */
+	public $length;
+
+	/**
+	 * Namespace prefix.
+	 *
+	 * @var string
+	 */
+	public $namespace_prefix;
+
+	/**
+	 * Local name.
+	 *
+	 * @var string
+	 */
+	public $local_name;
+
+	/**
+	 * Namespace.
+	 *
+	 * @var string
+	 */
+	public $namespace;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param  string  $name  Attribute name.
+	 * @param  int  $value_start  Attribute value.
+	 * @param  int  $value_length  Number of bytes attribute value spans.
+	 * @param  int  $start  The string offset where the attribute name starts.
+	 * @param  int  $length  Byte length of the entire attribute name or name and value pair expression.
+	 * @param  string  $namespace_prefix  Namespace prefix.
+	 * @param  string  $local_name  Local name.
+	 * @param  string  $namespace  Namespace.
+	 *
+	 */
+	public function __construct( $name, $value_start, $value_length, $start, $length, $namespace_prefix=null, $local_name=null, $namespace=null ) {
+		$this->name            = $name;
+		$this->value_starts_at = $value_start;
+		$this->value_length    = $value_length;
+		$this->start           = $start;
+		$this->length          = $length;
+		$this->namespace_prefix = $namespace_prefix;
+		$this->local_name      = $local_name;
+		$this->namespace       = $namespace;
+	}
+}

--- a/components/XML/XMLAttributeToken.php
+++ b/components/XML/XMLAttributeToken.php
@@ -102,8 +102,7 @@ class XMLAttributeToken {
 	 * @param  string  $namespace  Namespace.
 	 *
 	 */
-	public function __construct( $qualified_name, $value_start, $value_length, $start, $length, $namespace_prefix=null, $local_name=null, $namespace=null ) {
-		$this->qualified_name  = $qualified_name;
+	public function __construct( $value_start, $value_length, $start, $length, $namespace_prefix=null, $local_name=null, $namespace=null ) {
 		$this->value_starts_at = $value_start;
 		$this->value_length    = $value_length;
 		$this->start           = $start;
@@ -111,5 +110,6 @@ class XMLAttributeToken {
 		$this->namespace_prefix = $namespace_prefix;
 		$this->local_name      = $local_name;
 		$this->namespace       = $namespace;
+		$this->qualified_name  = $namespace_prefix ? $namespace_prefix . ':' . $local_name : $local_name;
 	}
 }

--- a/components/XML/XMLElement.php
+++ b/components/XML/XMLElement.php
@@ -1,0 +1,72 @@
+<?php
+namespace WordPress\XML;
+
+/**
+ * XML API: XMLElement class
+ *
+ * @package WordPress
+ * @subpackage XML-API
+ * @since 6.2.0
+ */
+
+/**
+ * Core class used by the XML tag processor as a data structure for the attribute token,
+ * allowing to drastically improve performance.
+ *
+ * This class is for internal usage of the XMLProcessor class.
+ *
+ * @see XMLProcessor
+ */
+class XMLElement {
+	/**
+	 * Local name.
+	 *
+	 * @var string
+	 */
+	public $local_name;
+
+	/**
+	 * Namespace Prefix.
+	 *
+	 * @var string
+	 */
+	public $namespace_prefix;
+
+	/**
+	 * Full XML namespace name.
+	 *
+	 * @var string
+	 */
+	public $namespace;
+
+	/**
+	 * Namespaces in current element's scope.
+	 *
+	 * @var array<string, string>
+	 */
+	public $namespaces_in_scope;
+
+	/**
+	 * Qualified name.
+	 *
+	 * @var string
+	 */
+	public $qualified_name;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $local_name Local name.
+	 * @param string $namespace_prefix Namespace prefix.
+	 * @param string $namespace Full XML namespace name.
+	 * @param array<string, string> $namespaces_in_scope Namespaces in current element's scope.
+	 */
+	public function __construct( $local_name, $namespace_prefix, $namespace, $namespaces_in_scope ) {
+		$this->local_name = $local_name;
+		$this->namespace_prefix = $namespace_prefix;
+		$this->namespace = $namespace;
+		$this->namespaces_in_scope = $namespaces_in_scope;
+		$this->qualified_name = $namespace_prefix ? $namespace_prefix . ':' . $local_name : $local_name;
+	}
+	
+}

--- a/components/XML/XMLElement.php
+++ b/components/XML/XMLElement.php
@@ -68,5 +68,9 @@ class XMLElement {
 		$this->namespaces_in_scope = $namespaces_in_scope;
 		$this->qualified_name = $namespace_prefix ? $namespace_prefix . ':' . $local_name : $local_name;
 	}
+
+	public function get_full_name() {
+		return $this->namespace ? '{' . $this->namespace . '}' . $this->local_name : $this->local_name;
+	}
 	
 }

--- a/components/XML/XMLElement.php
+++ b/components/XML/XMLElement.php
@@ -72,5 +72,23 @@ class XMLElement {
 	public function get_full_name() {
 		return $this->namespace ? '{' . $this->namespace . '}' . $this->local_name : $this->local_name;
 	}
+
+	public function to_array() {
+		return [
+			'local_name' => $this->local_name,
+			'namespace_prefix' => $this->namespace_prefix,
+			'namespace' => $this->namespace,
+			'namespaces_in_scope' => $this->namespaces_in_scope,
+		];
+	}
+
+	public static function from_array( $array_value ) {
+		return new self(
+			$array_value['local_name'],
+			$array_value['namespace_prefix'],
+			$array_value['namespace'],
+			$array_value['namespaces_in_scope']
+		);
+	}
 	
 }

--- a/components/XML/XMLProcessor.php
+++ b/components/XML/XMLProcessor.php
@@ -533,22 +533,27 @@ class XMLProcessor {
 	private $exception = null;
 
 	/**
-	 * Lazily-built index of attributes found within an XML tag, keyed by the attribute name.
+	 * Temporary index of attributes found within an XML tag, keyed by the qualified
+	 * attribute name. It is only used during the initial attributes parsing phase and
+	 * discarded once all the attributes have been parsed.
+	 *
+	 * @since WP_VERSION
+	 * @var XMLAttributeToken[]
+	 */
+	private $qualified_attributes = array();
+
+	/**
+	 * Stores the attributes found within an XML tag, keyed by their namespace
+	 * and local name combination.
 	 *
 	 * Example:
 	 *
-	 *     // Supposing the parser is working through this content
-	 *     // and stops after recognizing the `id` attribute.
-	 *     // <wp:content id="test-4" class=outline title="data:text/plain;base64=asdk3nk1j3fo8">
-	 *     //                 ^ parsing will continue from this point.
-	 *     $this->attributes = array(
-	 *         'id' => new XMLAttributeToken( 'id', 9, 6, 5, 11, '', 'id', '' )
-	 *     );
-	 *
-	 *     // When picking up parsing again, or when asking to find the
-	 *     // `class` attribute we will continue and add to this array.
-	 *     $this->attributes = array(
-	 *         'id'    => new XMLAttributeToken( 'id', 9, 6, 5, 11, '', 'id', '' ),
+	 *     // Supposing the parser just finished parsing the wp:content tag:
+	 *     // <channel xmlns:wp="http://wordpress.org/export/1.2/">
+	 *     //   <wp:content wp:id="test-4" class="outline">
+	 *     // </channel>
+	 *     $this->qualified_attributes = array(
+	 *         '{http://wordpress.org/export/1.2/}id' => new XMLAttributeToken( 'id', 9, 6, 5, 14, 'wp', 'id' ),
 	 *         'class' => new XMLAttributeToken( 'class', 23, 7, 17, 13, '', 'class', '' )
 	 *     );
 	 *
@@ -1056,12 +1061,129 @@ class XMLProcessor {
 		$this->token_length         = $this->bytes_already_parsed - $this->token_starts_at;
 
 		/**
-		 * Confirm the tag name is valid with respect to XML namespaces.
-		 * @see https://www.w3.org/TR/2006/REC-xml-names11-20060816/#Conformance
+		 * Resolve the namespaces defined in opening tags.
 		 */
-		$tag_name = $this->get_local_tag_name();
-		if ( false === $this->validate_qualified_name( $tag_name ) ) {
-			return false;
+		if ( ! $this->is_closing_tag ) {
+			/**
+			 * By default, inherit all namespaces from the parent element.
+			 */
+			$namespaces = $this->stack_of_open_elements->get_namespaces_in_scope();
+			foreach ( $this->qualified_attributes as $attribute ) {
+				/**
+				 * xmlns attribute is the default namespace
+				 * xmlns:<prefix> declares a namespace prefix scoped to the current element and its descendants
+				 *
+				 * @see https://www.w3.org/TR/2006/REC-xml-names11-20060816/#ns-decl
+				 */
+				if ( 'xmlns' === $attribute->qualified_name ) {
+					$value                                        = $this->get_qualified_attribute( $attribute->qualified_name );
+					$namespaces[ self::DEFAULT_NAMESPACE_PREFIX ] = $value;
+					continue;
+				}
+
+				if ( 'xmlns' === $attribute->namespace_prefix ) {
+					$value = $this->get_qualified_attribute( $attribute->qualified_name );
+
+					/**
+					 * @see https://www.w3.org/TR/2006/REC-xml-names11-20060816/#xmlReserved
+					 */
+					if ( 'xml' === $attribute->namespace_prefix && 'http://www.w3.org/XML/1998/namespace' !== $value ) {
+						$this->bail( 'The `xml` namespace prefix is by definition bound to the namespace name http://www.w3.org/XML/1998/namespace and must not be overridden.',
+							self::ERROR_SYNTAX );
+
+						return false;
+					}
+					/**
+					 * The attribute value in a namespace declaration for a prefix MAY be empty.
+					 * This has the effect, within the scope of the declaration, of removing any
+					 * association of the prefix with a namespace name. Further declarations MAY
+					 * re-declare the prefix again.
+					 */
+					if ( '' === $value ) {
+						unset( $namespaces[ $attribute->namespace_prefix ] );
+						continue;
+					}
+
+					$namespaces[ $attribute->local_name ] = $value;
+					continue;
+				}
+			}
+
+			/**
+			 * Confirm the tag name is valid with respect to XML namespaces.
+			 * @see https://www.w3.org/TR/2006/REC-xml-names11-20060816/#Conformance
+			 */
+			$tag_name = $this->get_qualified_tag_name();
+			if ( false === $this->validate_qualified_name( $tag_name ) ) {
+				return false;
+			}
+
+			list( $tag_namespace_prefix, $tag_local_name ) = $this->parse_qualified_name( $tag_name );
+
+			/**
+			 * Validate the element namespace.
+			 */
+			if ( ! array_key_exists( $tag_namespace_prefix, $namespaces ) ) {
+				$this->bail(
+					sprintf(
+						'Namespace prefix "%s" does not resolve to any namespace in the current element\'s scope.',
+						$tag_namespace_prefix
+					),
+					self::ERROR_SYNTAX
+				);
+			}
+
+			/**
+			 * Compute fully qualified attributes and assert:
+			 *
+			 * * All attributes have valid namespaces.
+			 * * No two attributes have the same (local name, namespace) pair.
+			 *
+			 * @see https://www.w3.org/TR/2006/REC-xml-names11-20060816/#uniqAttrs
+			 */
+			$namespaced_attributes = array();
+			foreach ( $this->qualified_attributes as $attribute ) {
+				list( $attribute_namespace_prefix, $attribute_local_name ) = $this->parse_qualified_name( $attribute->qualified_name );
+				if ( ! array_key_exists( $attribute_namespace_prefix, $namespaces ) ) {
+					$this->bail(
+						sprintf(
+							'Attribute "%s" has an invalid namespace prefix "%s".',
+							$attribute->qualified_name,
+							$attribute_namespace_prefix
+						),
+						self::ERROR_SYNTAX
+					);
+
+					return false;
+				}
+				$namespace_reference = $namespaces[ $attribute_namespace_prefix ];
+
+				/**
+				 * It looks supicious but it's safe – $local_name is guaranteed to not contain
+				 * curly braces at this point.
+				 */
+				$attribute_full_name = $namespace_reference ? '{' . $namespace_reference . '}' . $attribute_local_name : $attribute_local_name;
+				if ( isset( $namespaced_attributes[ $attribute_full_name ] ) ) {
+					$this->bail(
+						sprintf(
+							'Duplicate attribute "%s" with namespace "%s" found in the same element.',
+							$attribute_local_name,
+							$namespace_reference
+						),
+						self::ERROR_SYNTAX
+					);
+
+					return false;
+				}
+				$namespaced_attributes[ $attribute_full_name ] = $attribute;
+			}
+
+			// Store attributes with their namespaces and discard the temporary
+			// qualified attributes array.
+			$this->attributes = $namespaced_attributes;
+			$this->qualified_attributes = array();
+
+			$this->element = new XMLElement( $tag_local_name, $tag_namespace_prefix, $namespaces[ $tag_namespace_prefix ], $namespaces );
 		}
 
 		/*
@@ -1081,9 +1203,9 @@ class XMLProcessor {
 		$tag_name_starts_at = $this->tag_name_starts_at;
 		$tag_name_length    = $this->tag_name_length;
 		$tag_ends_at        = $this->token_starts_at + $this->token_length;
-		$attributes         = $this->attributes;
+		$attributes         = $this->qualified_attributes;
 
-		$found_closer = $this->skip_pcdata( $this->get_local_tag_name() );
+		$found_closer = $this->skip_pcdata( $this->get_tag_local_name() );
 
 		// Closer not found, the document is incomplete.
 		if ( false === $found_closer ) {
@@ -1106,7 +1228,7 @@ class XMLProcessor {
 		$this->text_length        = $this->tag_name_starts_at - $this->text_starts_at;
 		$this->tag_name_starts_at = $tag_name_starts_at;
 		$this->tag_name_length    = $tag_name_length;
-		$this->attributes         = $attributes;
+		$this->qualified_attributes         = $attributes;
 
 		return true;
 	}
@@ -1424,7 +1546,7 @@ class XMLProcessor {
 	 *
 	 */
 	public function is_pcdata_element() {
-		return array_key_exists( $this->get_local_tag_name(), $this->pcdata_elements );
+		return array_key_exists( $this->get_tag_local_name(), $this->pcdata_elements );
 	}
 
 
@@ -1478,6 +1600,10 @@ class XMLProcessor {
 			return false;
 		}
 
+		if ( array_keys($query) === array(0, 1) && is_string($query[0]) && is_string($query[1]) ) {
+			$query = array( 'breadcrumbs' => array( $query ) );
+		}
+
 		if ( ! ( array_key_exists( 'breadcrumbs', $query ) && is_array( $query['breadcrumbs'] ) ) ) {
 			while ( $this->step() ) {
 				if ( '#tag' !== $this->get_token_type() ) {
@@ -1502,7 +1628,22 @@ class XMLProcessor {
 			return false;
 		}
 
-		$breadcrumbs  = $query['breadcrumbs'];
+
+		$namespaced_breadcrumbs = array();
+		foreach($query['breadcrumbs'] as $breadcrumb) {
+			if(is_array($breadcrumb) && count($breadcrumb) === 2) {
+				$namespaced_breadcrumbs[] = $breadcrumb;
+			} else if(is_string($breadcrumb)) {
+				$namespaced_breadcrumbs[] = array('', $breadcrumb);
+			} else {
+				_doing_it_wrong(
+					__METHOD__,
+					__( 'Breadcrumbs must be an array of strings or two-tuples of (namespace, local name).' ),
+					'WP_VERSION'
+				);
+			}
+		}
+		$breadcrumbs  = $namespaced_breadcrumbs;
 		$match_offset = isset( $query['match_offset'] ) ? (int) $query['match_offset'] : 1;
 
 		while ( $match_offset > 0 && $this->step() ) {
@@ -1902,14 +2043,14 @@ class XMLProcessor {
 					return false;
 				}
 
-				foreach ( $this->attributes as $name => $attribute ) {
+				foreach ( $this->qualified_attributes as $name => $attribute ) {
 					if ( 'version' !== $name && 'encoding' !== $name && 'standalone' !== $name ) {
 						$this->bail( 'Invalid attribute found in XML declaration.', self::ERROR_SYNTAX );
 						return false;
 					}
 				}
 
-				if ( '1.0' !== $this->get_attribute( '', 'version' ) ) {
+				if ( '1.0' !== $this->get_qualified_attribute( 'version' ) ) {
 					$this->bail( 'Unsupported XML version declared', self::ERROR_UNSUPPORTED );
 					return false;
 				}
@@ -1920,15 +2061,15 @@ class XMLProcessor {
 				 *
 				 * See https://www.w3.org/TR/xml/#sec-predefined-ent.
 				 */
-				if ( null !== $this->get_attribute( '', 'encoding' )
-				     && 'UTF-8' !== strtoupper( $this->get_attribute( '', 'encoding' ) )
+				if ( null !== $this->get_qualified_attribute( 'encoding' )
+				     && 'UTF-8' !== strtoupper( $this->get_qualified_attribute( 'encoding' ) )
 				) {
 					$this->bail( 'Unsupported XML encoding declared, only UTF-8 is supported.', self::ERROR_UNSUPPORTED );
 					return false;
 				}
 
-				if ( null !== $this->get_attribute( '', 'standalone' )
-				     && 'YES' !== strtoupper( $this->get_attribute( '', 'standalone' ) )
+				if ( null !== $this->get_qualified_attribute( 'standalone' )
+				     && 'YES' !== strtoupper( $this->get_qualified_attribute( 'standalone' ) )
 				) {
 					$this->bail( 'Standalone XML documents are not supported.', self::ERROR_UNSUPPORTED );
 					return false;
@@ -1954,6 +2095,12 @@ class XMLProcessor {
 				$this->text_length          = $at - $this->text_starts_at;
 				$this->bytes_already_parsed = $at + 2;
 				$this->parser_state         = self::STATE_XML_DECLARATION;
+
+				// Processing instructions don't have namespaces. We can just
+				// copy the qualified attributes to the attributes array without
+				// resolving anything.
+				$this->attributes           = $this->qualified_attributes;
+				$this->qualified_attributes = array();
 
 				return true;
 			}
@@ -2064,12 +2211,12 @@ class XMLProcessor {
 		}
 
 		$attribute_start       = $this->bytes_already_parsed;
-		$attribute_name_length = $this->parse_name( $this->bytes_already_parsed );
-		if ( 0 === $attribute_name_length ) {
+		$attribute_qname_length = $this->parse_name( $this->bytes_already_parsed );
+		if ( 0 === $attribute_qname_length ) {
 			$this->bail( 'Invalid attribute name encountered.', self::ERROR_SYNTAX );
 		}
-		$this->bytes_already_parsed += $attribute_name_length;
-		$attribute_name             = substr( $this->xml, $attribute_start, $attribute_name_length );
+		$this->bytes_already_parsed += $attribute_qname_length;
+		$attribute_qname             = substr( $this->xml, $attribute_start, $attribute_qname_length );
 		$this->skip_whitespace();
 
 		// Parse attribute value.
@@ -2126,7 +2273,7 @@ class XMLProcessor {
 			return true;
 		}
 
-		if ( array_key_exists( $attribute_name, $this->attributes ) ) {
+		if ( array_key_exists( $attribute_qname, $this->qualified_attributes ) ) {
 			$this->bail( 'Duplicate attribute found in an XML tag.', self::ERROR_SYNTAX );
 		}
 
@@ -2134,7 +2281,7 @@ class XMLProcessor {
 		 * Confirm the tag name is valid with respect to XML namespaces.
 		 * @see https://www.w3.org/TR/2006/REC-xml-names11-20060816/#Conformance
 		 */
-		if ( false === $this->validate_qualified_name( $attribute_name ) ) {
+		if ( false === $this->validate_qualified_name( $attribute_qname ) ) {
 			return false;
 		}
 
@@ -2144,21 +2291,20 @@ class XMLProcessor {
 		 * element. Note we must still keep track of string indices to support
 		 * replacements.
 		 */
-		list( $namespace_prefix, $local_name ) = $this->parse_qualified_name( $attribute_name );
+		list( $namespace_prefix, $local_name ) = $this->parse_qualified_name( $attribute_qname );
 
-		$this->attributes[ $attribute_name ] = new XMLAttributeToken(
-			$attribute_name,
+		$this->qualified_attributes[ $attribute_qname ] = new XMLAttributeToken(
+			$attribute_qname,
 			$value_start,
 			$value_length,
 			$attribute_start,
 			$attribute_end - $attribute_start,
 			$namespace_prefix,
 			$local_name
-		/**
-		 * The full namespace is resolved in push_open_element() once
-		 * we know all xmlns declarations in the current element's
-		 * scope.
-		 */
+			/**
+			 * The full namespace is resolved in parse_next_token() once
+			 * all the attributes have been consumed.
+			 */
 		);
 
 		return true;
@@ -2361,6 +2507,7 @@ class XMLProcessor {
 		$this->pubid_literal      = null;
 		$this->system_literal     = null;
 		$this->attributes         = array();
+		$this->qualified_attributes = array();
 	}
 
 	/**
@@ -2654,17 +2801,19 @@ class XMLProcessor {
 			return null;
 		}
 
+		$full_name = $namespace_reference ? '{' . $namespace_reference . '}' . $local_name : $local_name;
+
 		// Return any enqueued attribute value updates if they exist.
-		$enqueued_value = $this->get_enqueued_attribute_value( $local_name );
+		$enqueued_value = $this->get_enqueued_attribute_value( $full_name );
 		if ( false !== $enqueued_value ) {
 			return $enqueued_value;
 		}
 
-		if ( ! isset( $this->attributes[ $local_name ] ) ) {
+		if ( ! isset( $this->attributes[ $full_name ] ) ) {
 			return null;
 		}
 
-		$attribute = $this->attributes[ $local_name ];
+		$attribute = $this->attributes[ $full_name ];
 		$raw_value = substr( $this->xml, $attribute->value_starts_at, $attribute->value_length );
 
 		$decoded = XMLDecoder::decode( $raw_value );
@@ -2688,13 +2837,22 @@ class XMLProcessor {
 		return $decoded;
 	}
 
-	private function get_attribute_value( XMLAttributeToken $attribute ) {
-		// Return any enqueued attribute value updates if they exist.
-		// $enqueued_value = $this->get_enqueued_attribute_value( $local_name );
-		// if ( false !== $enqueued_value ) {
-		// 	return $enqueued_value;
-		// }
+	/**
+	 * Gets a value from a qualified attribute name if it exists in the
+	 * matched tag.
+	 *
+	 * It's for internal use only to source values of raw attributes
+	 * after they're parsed but before the namespaces are resolved.
+	 *
+	 * @param string $qname The qualified attribute name.
+	 * @return string|null The attribute value, or null if not found.
+	 */
+	private function get_qualified_attribute( $qname ) {
+		if(!isset($this->qualified_attributes[$qname])) {
+			return null;
+		}
 
+		$attribute = $this->qualified_attributes[ $qname ];
 		$raw_value = substr( $this->xml, $attribute->value_starts_at, $attribute->value_length );
 
 		$decoded = XMLDecoder::decode( $raw_value );
@@ -2727,9 +2885,9 @@ class XMLProcessor {
 	 *
 	 *     $p = new XMLProcessor( '<wp:content data-ENABLED="1" class="test" DATA-test-id="14">Test</wp:content>' );
 	 *     $p->next_tag( array( 'class_name' => 'test' ) ) === true;
-	 *     $p->get_attribute_qualified_names_with_prefix( 'data-' ) === array( 'data-ENABLED' );
-	 *     $p->get_attribute_qualified_names_with_prefix( 'DATA-' ) === array( 'DATA-test-id' );
-	 *     $p->get_attribute_qualified_names_with_prefix( 'DAta-' ) === array();
+	 *     $p->get_attribute_names_with_prefix( 'data-' ) === array( 'data-ENABLED' );
+	 *     $p->get_attribute_names_with_prefix( 'DATA-' ) === array( 'DATA-test-id' );
+	 *     $p->get_attribute_names_with_prefix( 'DAta-' ) === array();
 	 *
 	 * @param  string  $prefix  Prefix of requested attribute names.
 	 *
@@ -2737,7 +2895,7 @@ class XMLProcessor {
 	 * @since WP_VERSION
 	 *
 	 */
-	public function get_attribute_qualified_names_with_prefix( $prefix ) {
+	public function get_attribute_names_with_prefix( $ns_prefix, $name_prefix ) {
 		if (
 			self::STATE_MATCHED_TAG !== $this->parser_state ||
 			$this->is_closing_tag
@@ -2746,9 +2904,9 @@ class XMLProcessor {
 		}
 
 		$matches = array();
-		foreach ( array_keys( $this->attributes ) as $attr_name ) {
-			if ( strncmp( $attr_name, $prefix, strlen( $prefix ) ) === 0 ) {
-				$matches[] = $attr_name;
+		foreach ( $this->attributes as $attr ) {
+			if ( 0 === strncmp( $attr->local_name, $name_prefix, strlen( $name_prefix ) ) && 0 === strncmp( $attr->namespace_prefix, $ns_prefix, strlen( $ns_prefix ) ) ) {
+				$matches[] = [$attr->namespace_prefix, $attr->local_name];
 			}
 		}
 
@@ -2771,7 +2929,7 @@ class XMLProcessor {
 	 * @since WP_VERSION
 	 *
 	 */
-	public function get_local_tag_name() {
+	public function get_tag_local_name() {
 		if ( null !== $this->element ) {
 			// Return cached name if we already have it.
 			return $this->element->local_name;
@@ -3048,7 +3206,7 @@ class XMLProcessor {
 	public function get_token_name() {
 		switch ( $this->parser_state ) {
 			case self::STATE_MATCHED_TAG:
-				return $this->get_local_tag_name();
+				return $this->get_tag_local_name();
 
 			case self::STATE_TEXT_NODE:
 				return '#text';
@@ -3196,7 +3354,7 @@ class XMLProcessor {
 	 * @since WP_VERSION
 	 *
 	 */
-	public function set_attribute( $name, $value ) {
+	public function set_attribute( $namespace, $local_name, $value ) {
 		if ( ! is_string( $value ) ) {
 			_doing_it_wrong(
 				__METHOD__,
@@ -3214,6 +3372,20 @@ class XMLProcessor {
 		}
 
 		$value             = htmlspecialchars( $value, ENT_XML1, 'UTF-8' );
+		
+		if($namespace !== '') {
+			$prefix = $this->stack_of_open_elements->get_namespace_prefix($namespace);
+			if(false === $prefix) {
+				$this->bail(
+					__( 'The namespace "%1$s" is not in scope.' ),
+					$namespace
+				);
+				return false;
+			}
+			$name = $prefix . ':' . $local_name;
+		} else {
+			$name = $local_name;
+		}
 		$updated_attribute = "{$name}=\"{$value}\"";
 
 		/*
@@ -3274,13 +3446,15 @@ class XMLProcessor {
 	 * @since WP_VERSION
 	 *
 	 */
-	public function remove_attribute( $name ) {
+	public function remove_attribute( $namespace, $local_name ) {
 		if (
 			self::STATE_MATCHED_TAG !== $this->parser_state ||
 			$this->is_closing_tag
 		) {
 			return false;
 		}
+
+		$name = $namespace ? '{' . $namespace . '}' . $local_name : $local_name;
 
 		/*
 		 * If updating an attribute that didn't exist in the input
@@ -3446,7 +3620,7 @@ class XMLProcessor {
 
 		if ( self::PROCESS_NEXT_NODE === $node_to_process ) {
 			if ( $this->is_empty_element() ) {
-				$this->pop_open_element();
+				$this->stack_of_open_elements->pop();
 			}
 		}
 
@@ -3564,7 +3738,15 @@ class XMLProcessor {
 				// Update the stack of open elements
 				$tag_qname = $this->get_qualified_tag_name();
 				if ( $this->is_tag_closer() ) {
-					$popped_qname = $this->pop_open_element()->qualified_name;
+					if(!$this->stack_of_open_elements->count()) {
+						$this->bail(
+							__( 'The closing tag "%1$s" did not match the opening tag "%2$s".' ),
+							$tag_qname,
+							$tag_qname
+						);
+						return false;
+					}
+					$popped_qname = $this->stack_of_open_elements->pop()->qualified_name;
 					if ( $popped_qname !== $tag_qname ) {
 						$this->bail(
 							sprintf(
@@ -3580,7 +3762,7 @@ class XMLProcessor {
 						$this->parser_context = self::IN_MISC_CONTEXT;
 					}
 				} else {
-					$this->push_open_element( $tag_qname );
+					$this->stack_of_open_elements->push( $this->element );
 					$this->element = $this->stack_of_open_elements->top();
 				}
 
@@ -3663,7 +3845,9 @@ class XMLProcessor {
 	 *
 	 */
 	public function get_breadcrumbs() {
-		return $this->stack_of_open_elements->get_items();
+		return array_map( function( $element ) {
+			return array( $element->namespace, $element->local_name );
+		}, $this->stack_of_open_elements->get_items() );
 	}
 
 	/**
@@ -3701,29 +3885,40 @@ class XMLProcessor {
 		// Start at the last crumb.
 		$crumb = end( $breadcrumbs );
 
-		if (
-			'#tag' === $this->get_token_type() &&
-			'*' !== $crumb &&
-			$this->get_local_tag_name() !== $crumb
-		) {
+		if ( '#tag' !== $this->get_token_type() ) {
 			return false;
 		}
 
-		// @TODO: Match namespaces!
-		for ( $i = $this->stack_of_open_elements->count() - 1; $i >= 0; $i -- ) {
-			$tag_name = $this->stack_of_open_elements->get_items()[ $i ]->local_name;
-			$crumb    = current( $breadcrumbs );
+		$open_elements = $this->stack_of_open_elements->get_items();
+		$crumb_count   = count( $breadcrumbs );
+		$elem_count    = count( $open_elements );
 
-			if ( '*' !== $crumb && $tag_name !== $crumb ) {
+		// Walk backwards through both arrays, matching each crumb to the corresponding open element.
+		for ( $j = 1; $j <= $crumb_count; $j++ ) {
+			$crumb = $breadcrumbs[ $crumb_count - $j ];
+			$element = $open_elements[ $elem_count - $j ] ?? null;
+
+			if ( ! $element ) {
 				return false;
 			}
 
-			if ( false === prev( $breadcrumbs ) ) {
-				return true;
+			// Normalize crumb to [namespace, local_name]
+			if ( ! is_array( $crumb ) ) {
+				$crumb = array( '', $crumb );
+			}
+			list( $namespace, $local_name ) = $crumb;
+
+			// Match local name, respecting wildcard '*'
+			if ( '*' !== $local_name && $local_name !== $element->local_name ) {
+				return false;
+			}
+
+			// Match namespace, respecting wildcard '*'
+			if ( '*' !== $namespace && $namespace !== $element->namespace ) {
+				return false;
 			}
 		}
-
-		return false;
+		return true;
 	}
 
 	/**
@@ -3752,141 +3947,6 @@ class XMLProcessor {
 	 */
 	public function get_current_depth() {
 		return $this->stack_of_open_elements->count();
-	}
-
-	private function pop_open_element() {
-		return $this->stack_of_open_elements->pop();
-	}
-
-	private function push_open_element( $qualified_name ) {
-		/**
-		 * Before we push the element, we need to compute its:
-		 *
-		 * - local name
-		 * - namespace prefix
-		 * - namespace URI
-		 * - namespaces in current element's scope
-		 */
-
-		// All qualified names are validated at this point.
-		list( $tag_namespace_prefix, $tag_local_name ) = $this->parse_qualified_name( $qualified_name );
-
-		// Resolve namespaces:
-
-		/**
-		 * By default, inherit all namespaces from the parent element.
-		 */
-		$namespaces = $this->stack_of_open_elements->get_namespaces_in_scope();
-		foreach ( $this->attributes as $attribute ) {
-			/**
-			 * xmlns attribute is the default namespace
-			 * xmlns:<prefix> declares a namespace prefix scoped to the current element and its descendants
-			 *
-			 * @see https://www.w3.org/TR/2006/REC-xml-names11-20060816/#ns-decl
-			 */
-			if ( 'xmlns' === $attribute->name ) {
-				$value                                        = $this->get_attribute_value( $attribute );
-				$namespaces[ self::DEFAULT_NAMESPACE_PREFIX ] = $value;
-				continue;
-			}
-
-			if ( 'xmlns' === $attribute->namespace_prefix ) {
-				$value = $this->get_attribute_value( $attribute );
-
-				/**
-				 * @see https://www.w3.org/TR/2006/REC-xml-names11-20060816/#xmlReserved
-				 */
-				if ( 'xml' === $attribute->namespace_prefix && 'http://www.w3.org/XML/1998/namespace' !== $value ) {
-					$this->bail( 'The `xml` namespace prefix is by definition bound to the namespace name http://www.w3.org/XML/1998/namespace and must not be overridden.',
-						self::ERROR_SYNTAX );
-
-					return false;
-				}
-				/**
-				 * The attribute value in a namespace declaration for a prefix MAY be empty.
-				 * This has the effect, within the scope of the declaration, of removing any
-				 * association of the prefix with a namespace name. Further declarations MAY
-				 * re-declare the prefix again.
-				 */
-				if ( '' === $value ) {
-					unset( $namespaces[ $attribute->namespace_prefix ] );
-					continue;
-				}
-
-				$namespaces[ $attribute->local_name ] = $value;
-				continue;
-			}
-		}
-
-		// Validate namespaces for the element and its attributes:
-
-		/**
-		 * Validate the element namespace.
-		 */
-		if ( ! array_key_exists( $tag_namespace_prefix, $namespaces ) ) {
-			$this->bail(
-				sprintf(
-					'Namespace prefix "%s" does not resolve to any namespace in the current element\'s scope.',
-					$tag_namespace_prefix
-				),
-				self::ERROR_SYNTAX
-			);
-		}
-
-		/**
-		 * Let's assert:
-		 *
-		 * * All attributes have valid namespaces.
-		 * * No two attributes have the same (local name, namespace) pair.
-		 *
-		 * @see https://www.w3.org/TR/2006/REC-xml-names11-20060816/#uniqAttrs
-		 */
-		$namespaced_attributes = array();
-		foreach ( $this->attributes as $attribute ) {
-			list( $attribute_namespace_prefix, $attribute_local_name ) = $this->parse_qualified_name( $attribute->name );
-			if ( ! array_key_exists( $attribute_namespace_prefix, $namespaces ) ) {
-				$this->bail(
-					sprintf(
-						'Attribute "%s" has an invalid namespace prefix "%s".',
-						$attribute->name,
-						$attribute_namespace_prefix
-					),
-					self::ERROR_SYNTAX
-				);
-
-				return false;
-			}
-			$namespace_uri = $namespaces[ $attribute_namespace_prefix ];
-
-			/**
-			 * It looks supicious but it's safe – $local_name is guaranteed to not contain
-			 * curly braces at this point.
-			 */
-			$attribute_full_key = '{' . $namespace_uri . '}' . $attribute_local_name;
-			if ( isset( $namespaced_attributes[ $attribute_full_key ] ) ) {
-				$this->bail(
-					sprintf(
-						'Duplicate attribute "%s" with namespace "%s" found in the same element.',
-						$attribute_local_name,
-						$namespace_uri
-					),
-					self::ERROR_SYNTAX
-				);
-
-				return false;
-			}
-			$namespaced_attributes[ $attribute_full_key ] = true;
-		}
-
-		// Store attributes with their namespaces.
-		$this->attributes = $namespaced_attributes;
-
-		// Finally, push the element onto the stack.
-		$this->stack_of_open_elements->push(
-			new XMLElement( $tag_local_name, $tag_namespace_prefix, $namespaces[ $tag_namespace_prefix ], $namespaces )
-		);
-
-		return true;
 	}
 
 	/**

--- a/components/XML/XMLProcessor.php
+++ b/components/XML/XMLProcessor.php
@@ -130,15 +130,15 @@ use function WordPress\Encoding\utf8_codepoint_at;
  *     $remaining_count = 5;
  *     while ( $remaining_count > 0 && $tags->next_tag() ) {
  *         if (
- *              ( 'wp:musician' === $tags->get_tag() || 'wp:actor' === $tags->get_tag() ) &&
- *              'jazzy' === $tags->get_attribute( 'data-style' )
+ *              ( 'wp:musician' === $tags->get_qualified_tag() || 'wp:actor' === $tags->get_qualified_tag() ) &&
+ *              'jazzy' === $tags->get_attribute_by_qualified_name( 'data-style' )
  *         ) {
  *             $tags->set_attribute( 'wp:theme-style', 'theme-style-everest-jazz' );
  *             $remaining_count--;
  *         }
  *     }
  *
- * `get_attribute()` will return `null` if the attribute wasn't present
+ * `get_attribute_by_qualified_name()` will return `null` if the attribute wasn't present
  * on the tag when it was called. It may return `""` (the empty string)
  * in cases where the attribute was present but its value was empty.
  * For boolean attributes, those whose name is present but no value is
@@ -225,7 +225,7 @@ use function WordPress\Encoding\utf8_codepoint_at;
  *     while ( $p->next_tag( array( 'tag_name' => 'wp:todo-list' ) ) ) {
  *         $p->set_bookmark( 'list-start' );
  *         while ( $p->next_tag( array( 'tag_closers' => 'visit' ) ) ) {
- *             if ( 'wp:todo' === $p->get_tag() && $p->is_tag_closer() ) {
+ *             if ( 'wp:todo' === $p->get_qualified_tag() && $p->is_tag_closer() ) {
  *                 $p->set_bookmark( 'list-end' );
  *                 $p->seek( 'list-start' );
  *                 $p->set_attribute( 'data-contained-todos', (string) $total_todos );
@@ -234,7 +234,7 @@ use function WordPress\Encoding\utf8_codepoint_at;
  *                 break;
  *             }
  *
- *             if ( 'wp:todo-item' === $p->get_tag() && ! $p->is_tag_closer() ) {
+ *             if ( 'wp:todo-item' === $p->get_qualified_tag() && ! $p->is_tag_closer() ) {
  *                 $total_todos++;
  *             }
  *         }
@@ -347,6 +347,23 @@ class XMLProcessor {
 	 * @see XMLProcessor::seek()
 	 */
 	const MAX_SEEK_OPS = 1000;
+
+	const DEFAULT_NAMESPACE_PREFIX = '';
+
+	/**
+	 * One stack frame per element, each a prefix ⇒ URI map.
+	 * Frame 0 contains the two pre-declared namespaces and initial empty default.
+	 *
+	 * @since WP_VERSION
+	 * @var array<int,array<string,string>>
+	 */
+	private $namespace_stack = array(
+		array(
+			'xml'   => 'http://www.w3.org/XML/1998/namespace', // Predefined, cannot be unbound or changed
+			'xmlns' => 'http://www.w3.org/2000/xmlns/',        // Reserved for xmlns attributes, not a real namespace for elements/attributes
+			self::DEFAULT_NAMESPACE_PREFIX      => '',         // Default namespace is initially empty (no namespace)
+		),
+	);
 
 	/**
 	 * The XML document to parse.
@@ -709,9 +726,6 @@ class XMLProcessor {
 	 */
 	public $stack_of_open_elements = array();
 
-	/**
-	 *
-	 */
 	public static function create_from_string( $xml, $cursor = null, $known_definite_encoding = 'UTF-8' ) {
 		$processor = static::create_for_streaming( $xml, $cursor, $known_definite_encoding );
 		if ( null === $processor ) {
@@ -757,6 +771,7 @@ class XMLProcessor {
 					'parser_context'           => $this->parser_context,
 					'stack_of_open_elements'   => $this->stack_of_open_elements,
 					'expecting_more_input'     => $this->expecting_more_input,
+					'namespace_stack'          => $this->namespace_stack,
 				)
 			)
 		);
@@ -804,6 +819,7 @@ class XMLProcessor {
 		$this->stack_of_open_elements   = $cursor['stack_of_open_elements'];
 		$this->parser_context           = $cursor['parser_context'];
 		$this->expecting_more_input     = $cursor['expecting_more_input'];
+		$this->namespace_stack          = $cursor['namespace_stack'];
 
 		return true;
 	}
@@ -1035,6 +1051,19 @@ class XMLProcessor {
 		$this->bytes_already_parsed = $tag_ends_at + 1;
 		$this->token_length         = $this->bytes_already_parsed - $this->token_starts_at;
 
+		/**
+		 * Confirm the tag name is valid with respect to XML namespaces.
+		 * @see https://www.w3.org/TR/2006/REC-xml-names11-20060816/#Conformance
+		 */
+		$tag_name = $this->get_qualified_tag();
+		if ( substr_count( $tag_name, ':' ) > 1 ) {
+			$this->bail(
+				sprintf('Invalid tag name "%s" – more than one ":" in tag name. Every tag name must contain either zero or one colon.', $tag_name),
+				self::ERROR_SYNTAX
+			);
+			return false;
+		}
+
 		/*
 		 * If we are in a PCData element, everything until the closer
 		 * is considered text.
@@ -1054,7 +1083,7 @@ class XMLProcessor {
 		$tag_ends_at        = $this->token_starts_at + $this->token_length;
 		$attributes         = $this->attributes;
 
-		$found_closer = $this->skip_pcdata( $this->get_tag() );
+		$found_closer = $this->skip_pcdata( $this->get_qualified_tag() );
 
 		// Closer not found, the document is incomplete.
 		if ( false === $found_closer ) {
@@ -1146,7 +1175,7 @@ class XMLProcessor {
 	 *     $p = new XMLProcessor( $xml );
 	 *     $in_list = false;
 	 *     while ( $p->next_tag( array( 'tag_closers' => $in_list ? 'visit' : 'skip' ) ) ) {
-	 *         if ( 'UL' === $p->get_tag() ) {
+	 *         if ( 'UL' === $p->get_qualified_tag() ) {
 	 *             if ( $p->is_tag_closer() ) {
 	 *                 $in_list = false;
 	 *                 $p->set_bookmark( 'resume' );
@@ -1161,7 +1190,7 @@ class XMLProcessor {
 	 *             }
 	 *         }
 	 *
-	 *         if ( 'LI' === $p->get_tag() ) {
+	 *         if ( 'LI' === $p->get_qualified_tag() ) {
 	 *             $p->set_bookmark( 'last-li' );
 	 *         }
 	 *     }
@@ -1395,7 +1424,7 @@ class XMLProcessor {
 	 *
 	 */
 	public function is_pcdata_element() {
-		return array_key_exists( $this->get_tag(), $this->pcdata_elements );
+		return array_key_exists( $this->get_qualified_tag(), $this->pcdata_elements );
 	}
 
 
@@ -1537,7 +1566,6 @@ class XMLProcessor {
 
 			if ( $at + 1 >= $doc_length ) {
 				$this->mark_incomplete_input();
-
 				return false;
 			}
 
@@ -1842,7 +1870,7 @@ class XMLProcessor {
 				'm' === $xml[ $at + 3 ] &&
 				'l' === $xml[ $at + 4 ]
 			) {
-				// Setting the parser state early for the get_attribute() calls later in this
+				// Setting the parser state early for the get_attribute_by_qualified_name() calls later in this
 				// branch.
 				$this->parser_state = self::STATE_XML_DECLARATION;
 
@@ -1879,7 +1907,7 @@ class XMLProcessor {
 					}
 				}
 
-				if ( '1.0' !== $this->get_attribute( 'version' ) ) {
+				if ( '1.0' !== $this->get_attribute_by_qualified_name( 'version' ) ) {
 					$this->bail( 'Unsupported XML version declared', self::ERROR_UNSUPPORTED );
 				}
 
@@ -1889,13 +1917,13 @@ class XMLProcessor {
 				 *
 				 * See https://www.w3.org/TR/xml/#sec-predefined-ent.
 				 */
-				if ( null !== $this->get_attribute( 'encoding' )
-				     && 'UTF-8' !== strtoupper( $this->get_attribute( 'encoding' ) )
+				if ( null !== $this->get_attribute_by_qualified_name( 'encoding' )
+				     && 'UTF-8' !== strtoupper( $this->get_attribute_by_qualified_name( 'encoding' ) )
 				) {
 					$this->bail( 'Unsupported XML encoding declared, only UTF-8 is supported.', self::ERROR_UNSUPPORTED );
 				}
-				if ( null !== $this->get_attribute( 'standalone' )
-				     && 'YES' !== strtoupper( $this->get_attribute( 'standalone' ) )
+				if ( null !== $this->get_attribute_by_qualified_name( 'standalone' )
+				     && 'YES' !== strtoupper( $this->get_attribute_by_qualified_name( 'standalone' ) )
 				) {
 					$this->bail( 'Standalone XML documents are not supported.', self::ERROR_UNSUPPORTED );
 				}
@@ -2093,6 +2121,18 @@ class XMLProcessor {
 
 		if ( array_key_exists( $attribute_name, $this->attributes ) ) {
 			$this->bail( 'Duplicate attribute found in an XML tag.', self::ERROR_SYNTAX );
+		}
+
+		/**
+		 * Confirm the tag name is valid with respect to XML namespaces.
+		 * @see https://www.w3.org/TR/2006/REC-xml-names11-20060816/#Conformance
+		 */
+		if ( substr_count( $attribute_name, ':' ) > 1 ) {
+			$this->bail(
+				sprintf('Invalid attribute name "%s" – more than one ":" in attribute name. Every attribute name must contain either zero or one colon.', $attribute_name),
+				self::ERROR_SYNTAX
+			);
+			return false;
 		}
 
 		$this->attributes[ $attribute_name ] = new WP_HTML_Attribute_Token(
@@ -2573,22 +2613,22 @@ class XMLProcessor {
 	 *
 	 * Example:
 	 *
-	 *     $p = new XMLProcessor( '<wp:content enabled class="test" data-test-id="14">Test</wp:content>' );
+	 *     $p = new XMLProcessor( '<wp:content enabled class="test" wp:data-test-id="14">Test</wp:content>' );
 	 *     $p->next_tag( array( 'class_name' => 'test' ) ) === true;
-	 *     $p->get_attribute( 'data-test-id' ) === '14';
-	 *     $p->get_attribute( 'enabled' ) === true;
-	 *     $p->get_attribute( 'aria-label' ) === null;
+	 *     $p->get_attribute_by_qualified_name( 'data-test-id' ) === '14';
+	 *     $p->get_attribute_by_qualified_name( 'enabled' ) === true;
+	 *     $p->get_attribute_by_qualified_name( 'aria-label' ) === null;
 	 *
 	 *     $p->next_tag() === false;
-	 *     $p->get_attribute( 'class' ) === null;
+	 *     $p->get_attribute_by_qualified_name( 'class' ) === null;
 	 *
-	 * @param  string  $name  Name of attribute whose value is requested.
+	 * @param  string  $qualified_name Qualified name of attribute whose value is requested, e.g. wp:data-test-id
 	 *
 	 * @return string|true|null Value of attribute or `null` if not available. Boolean attributes return `true`.
 	 * @since WP_VERSION
 	 *
 	 */
-	public function get_attribute( $name ) {
+	public function get_attribute_by_qualified_name( $qualified_name ) {
 		if (
 			self::STATE_MATCHED_TAG !== $this->parser_state &&
 			self::STATE_XML_DECLARATION !== $this->parser_state
@@ -2597,16 +2637,16 @@ class XMLProcessor {
 		}
 
 		// Return any enqueued attribute value updates if they exist.
-		$enqueued_value = $this->get_enqueued_attribute_value( $name );
+		$enqueued_value = $this->get_enqueued_attribute_value( $qualified_name );
 		if ( false !== $enqueued_value ) {
 			return $enqueued_value;
 		}
 
-		if ( ! isset( $this->attributes[ $name ] ) ) {
+		if ( ! isset( $this->attributes[ $qualified_name ] ) ) {
 			return null;
 		}
 
-		$attribute = $this->attributes[ $name ];
+		$attribute = $this->attributes[ $qualified_name ];
 		$raw_value = substr( $this->xml, $attribute->value_starts_at, $attribute->value_length );
 
 		$decoded = XMLDecoder::decode( $raw_value );
@@ -2631,7 +2671,31 @@ class XMLProcessor {
 	}
 
 	/**
-	 * Gets names of all attributes matching a given prefix in the current tag.
+	 * Returns the value of an attribute scoped to a given fully-qualified namespace name.
+	 *
+	 * Example:
+	 *
+	 *     $p = new XMLProcessor( '<root xmlns:isbn="urn:ISBN:0-395-36341-6"><wp:content isbn:test="123">Test</wp:content></root>' );
+	 *     $p->get_attribute_by_expanded_name( 'urn:ISBN:0-395-36341-6', 'test' ) === '123';
+	 *
+	 * @param $namespace_name Fully-qualified namespace name, e.g. urn:ISBN:0-395-36341-6
+	 * @param $local_name Local name of the attribute, e.g. test
+	 *
+	 * @return string|null Value of the attribute, or null if not found.
+	 */
+	public function get_attribute_by_expanded_name( $namespace_name, $local_name ) {
+		// Find a local prefix of the fully-qualified namespace name
+		$namespaces = $this->namespace_stack[count($this->namespace_stack) - 1];
+		$prefix = array_search($namespace_name, $namespaces);
+		if(false === $prefix) {
+			return null;
+		}
+		// Found! Create a qualified name and return the attribute value
+		return $this->get_attribute_by_qualified_name($prefix . ':' . $local_name);
+	}
+
+	/**
+	 * Gets qualified names of all attributes matching a given prefix in the current tag.
 	 *
 	 * Note that matching is case-sensitive. This is in accordance with the spec.
 	 *
@@ -2639,9 +2703,9 @@ class XMLProcessor {
 	 *
 	 *     $p = new XMLProcessor( '<wp:content data-ENABLED="1" class="test" DATA-test-id="14">Test</wp:content>' );
 	 *     $p->next_tag( array( 'class_name' => 'test' ) ) === true;
-	 *     $p->get_attribute_names_with_prefix( 'data-' ) === array( 'data-ENABLED' );
-	 *     $p->get_attribute_names_with_prefix( 'DATA-' ) === array( 'DATA-test-id' );
-	 *     $p->get_attribute_names_with_prefix( 'DAta-' ) === array();
+	 *     $p->get_attribute_qualified_names_with_prefix( 'data-' ) === array( 'data-ENABLED' );
+	 *     $p->get_attribute_qualified_names_with_prefix( 'DATA-' ) === array( 'DATA-test-id' );
+	 *     $p->get_attribute_qualified_names_with_prefix( 'DAta-' ) === array();
 	 *
 	 * @param  string  $prefix  Prefix of requested attribute names.
 	 *
@@ -2649,7 +2713,7 @@ class XMLProcessor {
 	 * @since WP_VERSION
 	 *
 	 */
-	public function get_attribute_names_with_prefix( $prefix ) {
+	public function get_attribute_qualified_names_with_prefix( $prefix ) {
 		if (
 			self::STATE_MATCHED_TAG !== $this->parser_state ||
 			$this->is_closing_tag
@@ -2674,16 +2738,16 @@ class XMLProcessor {
 	 *
 	 *     $p = new XMLProcessor( '<wp:content class="test">Test</wp:content>' );
 	 *     $p->next_tag() === true;
-	 *     $p->get_tag() === 'DIV';
+	 *     $p->get_qualified_tag() === 'DIV';
 	 *
 	 *     $p->next_tag() === false;
-	 *     $p->get_tag() === null;
+	 *     $p->get_qualified_tag() === null;
 	 *
 	 * @return string|null Name of currently matched tag in input XML, or `null` if none found.
 	 * @since WP_VERSION
 	 *
 	 */
-	public function get_tag() {
+	public function get_qualified_tag() {
 		if ( null === $this->tag_name_starts_at ) {
 			return null;
 		}
@@ -2694,6 +2758,59 @@ class XMLProcessor {
 			return $tag_name;
 		}
 
+		return null;
+	}
+
+	/**
+	 * Returns the namespace prefix of the matched tag.
+	 *
+	 * Example:
+	 *
+	 *     $p = new XMLProcessor( '<wp:content xmlns:wp="http://www.w3.org/1999/xhtml">Test</wp:content>' );
+	 *     $p->next_tag() === true;
+	 *     $p->get_namespace_prefix() === 'wp';
+	 *
+	 * @return string|null The namespace prefix of the matched tag, or null if not available.
+	 */
+	public function get_namespace_prefix() {
+		$tag_name = $this->get_qualified_tag();
+		// Only tags have a namespace prefix
+		if (null === $tag_name) {
+			return null;
+		}
+		$prefix_length = strcspn($tag_name, ':');
+		if (0 === $prefix_length || $prefix_length === strlen($tag_name)) {
+			return self::DEFAULT_NAMESPACE_PREFIX;
+		}
+		return substr($tag_name, 0, $prefix_length);
+	}
+
+	/**
+	 * Returns the namespace reference of the matched tag.
+	 *
+	 * Example:
+	 *
+	 *     $p = new XMLProcessor( '<root xmlns:wp="http://www.w3.org/1999/xhtml"><wp:content>Test</wp:content></root>' );
+	 *     $p->next_tag() === true;
+	 *     $p->next_tag() === true;
+	 *     $p->get_namespace_reference() === 'http://www.w3.org/1999/xhtml';
+	 *
+	 * @return string|null The namespace reference of the matched tag, or null if not available.
+	 */
+	public function get_namespace_reference() {
+		$namespace_prefix = $this->get_namespace_prefix();
+		if(null === $namespace_prefix) {
+			return null;
+		}
+		/**
+		 * Look up the namespace reference in the last element of the namespace stack –
+		 * it reflects all the declared, inherited, and unset namespaces that are in effect
+		 * for the current element.
+		 */
+		$namespaces = $this->namespace_stack[count($this->namespace_stack) - 1];
+		if (isset($namespaces[$namespace_prefix])) {
+			return $namespaces[$namespace_prefix];
+		}
 		return null;
 	}
 
@@ -2901,7 +3018,7 @@ class XMLProcessor {
 	public function get_token_name() {
 		switch ( $this->parser_state ) {
 			case self::STATE_MATCHED_TAG:
-				return $this->get_tag();
+				return $this->get_qualified_tag();
 
 			case self::STATE_TEXT_NODE:
 				return '#text';
@@ -3415,7 +3532,7 @@ class XMLProcessor {
 				return true;
 			case '#tag':
 				// Update the stack of open elements
-				$tag_name = $this->get_tag();
+				$tag_name = $this->get_qualified_tag();
 				if ( $this->is_tag_closer() ) {
 					$popped = $this->pop_open_element();
 					if ( $popped !== $tag_name ) {
@@ -3556,7 +3673,7 @@ class XMLProcessor {
 		if (
 			'#tag' === $this->get_token_type() &&
 			'*' !== $crumb &&
-			$this->get_tag() !== $crumb
+			$this->get_qualified_tag() !== $crumb
 		) {
 			return false;
 		}
@@ -3606,14 +3723,103 @@ class XMLProcessor {
 	}
 
 	private function pop_open_element() {
+		array_pop($this->namespace_stack);
 		return array_pop( $this->stack_of_open_elements );
 	}
 
 	private function push_open_element( $tag_name ) {
+		// Track open elements
 		array_push(
 			$this->stack_of_open_elements,
 			$tag_name
 		);
+
+		/**
+		 * By default, inherit all namespaces from the parent element.
+		 */
+		$namespaces = $this->namespace_stack[count($this->namespace_stack) - 1];
+
+		// Override parent namespaces with the current element's declarations.
+		foreach($this->attributes as $attribute) {
+			/**
+			 * xmlns attribute is the default namespace
+			 * xmlns:<prefix> declares a namespace prefix scoped to the current element and its descendants
+			 *
+			 * @see https://www.w3.org/TR/2006/REC-xml-names11-20060816/#ns-decl
+			 */
+			if( 'xmlns' === $attribute->name) {
+				$namespaces[self::DEFAULT_NAMESPACE_PREFIX] = $this->get_attribute_by_qualified_name($attribute->name);
+				continue;
+			}
+
+			if (substr($attribute->name, 0, 6) === 'xmlns:') {
+				$prefix = substr($attribute->name, 6);
+				if (self::DEFAULT_NAMESPACE_PREFIX === $prefix) {
+					$this->bail( sprintf('Invalid namespace prefix: %s', $attribute->name), self::ERROR_SYNTAX );
+					return false;
+				}
+				$ns_reference = $this->get_attribute_by_qualified_name($attribute->name);
+				/**
+				 * @see https://www.w3.org/TR/2006/REC-xml-names11-20060816/#xmlReserved
+				 */
+				if('xml' === $prefix && 'http://www.w3.org/XML/1998/namespace' !== $ns_reference) {
+					$this->bail( 'The `xml` namespace prefix is by definition bound to the namespace name http://www.w3.org/XML/1998/namespace and must not be overridden.', self::ERROR_SYNTAX );
+					return false;
+				}
+				/**
+				 * The attribute value in a namespace declaration for a prefix MAY be empty.
+				 * This has the effect, within the scope of the declaration, of removing any
+				 * association of the prefix with a namespace name. Further declarations MAY
+				 * re-declare the prefix again.
+				 */
+				if('' === $ns_reference) {
+					unset($namespaces[$prefix]);
+					continue;
+				}
+				$namespaces[$prefix] = $ns_reference;
+				continue;
+			}
+		}
+		array_push($this->namespace_stack, $namespaces);
+
+		/**
+		 * Now that we know the namespaces associated with the current element,
+		 * assert that no two attributes have the same (name, namespace) pair.
+		 *
+		 * @see https://www.w3.org/TR/2006/REC-xml-names11-20060816/#uniqAttrs
+		 */
+		$seen = array();
+		foreach ( $this->attributes as $attribute ) {
+			$attr_name = $attribute->name;
+			// Split into prefix and local name if a colon exists.
+			$colon_pos = strpos( $attr_name, ':' );
+			if ( false === $colon_pos ) {
+				// Unprefixed attributes do not have a default namespace
+				// and were already checked for uniqueness in parse_next_attribute()
+				continue;
+			}
+			$prefix = substr($attr_name, 0, $colon_pos);
+			$local_name = substr($attr_name, $colon_pos + 1);
+			$namespace_uri = $namespaces[ $prefix ] ?? self::DEFAULT_NAMESPACE_PREFIX;
+
+			/**
+			 * It looks supicious but it's safe – $local_name is guaranteed to not contain
+			 * a colon at this point.
+			 */
+			$key = $namespace_uri . ':' . $local_name;
+			if ( isset( $seen[ $key ] ) ) {
+				$this->bail(
+					sprintf(
+						'Duplicate attribute "%s" with namespace "%s" found in the same element.',
+						$local_name,
+						$namespace_uri
+					),
+					self::ERROR_SYNTAX
+				);
+				return false;
+			}
+			$seen[ $key ] = true;
+		}
 	}
 
 	private function mark_incomplete_input(

--- a/components/XML/XMLProcessor.php
+++ b/components/XML/XMLProcessor.php
@@ -2,7 +2,6 @@
 
 namespace WordPress\XML;
 
-use WP_HTML_Attribute_Token;
 use WP_HTML_Span;
 use WP_HTML_Text_Replacement;
 
@@ -351,21 +350,6 @@ class XMLProcessor {
 	const DEFAULT_NAMESPACE_PREFIX = '';
 
 	/**
-	 * One stack frame per element, each a prefix ⇒ URI map.
-	 * Frame 0 contains the two pre-declared namespaces and initial empty default.
-	 *
-	 * @since WP_VERSION
-	 * @var array<int,array<string,string>>
-	 */
-	private $namespace_stack = array(
-		array(
-			'xml'   => 'http://www.w3.org/XML/1998/namespace', // Predefined, cannot be unbound or changed
-			'xmlns' => 'http://www.w3.org/2000/xmlns/',        // Reserved for xmlns attributes, not a real namespace for elements/attributes
-			self::DEFAULT_NAMESPACE_PREFIX      => '',         // Default namespace is initially empty (no namespace)
-		),
-	);
-
-	/**
 	 * The XML document to parse.
 	 *
 	 * @since WP_VERSION
@@ -467,6 +451,13 @@ class XMLProcessor {
 	private $token_length;
 
 	/**
+	 * Currently matched XML element object.
+	 *
+	 * @var XMLElement|null
+	 */
+	private $element;
+
+	/**
 	 * Byte offset in input document where current tag name starts.
 	 *
 	 * Example:
@@ -551,18 +542,18 @@ class XMLProcessor {
 	 *     // <wp:content id="test-4" class=outline title="data:text/plain;base64=asdk3nk1j3fo8">
 	 *     //                 ^ parsing will continue from this point.
 	 *     $this->attributes = array(
-	 *         'id' => new WP_HTML_Attribute_Token( 'id', 9, 6, 5, 11, false )
+	 *         'id' => new XMLAttributeToken( 'id', 9, 6, 5, 11, '', 'id', '' )
 	 *     );
 	 *
 	 *     // When picking up parsing again, or when asking to find the
 	 *     // `class` attribute we will continue and add to this array.
 	 *     $this->attributes = array(
-	 *         'id'    => new WP_HTML_Attribute_Token( 'id', 9, 6, 5, 11, false ),
-	 *         'class' => new WP_HTML_Attribute_Token( 'class', 23, 7, 17, 13, false )
+	 *         'id'    => new XMLAttributeToken( 'id', 9, 6, 5, 11, '', 'id', '' ),
+	 *         'class' => new XMLAttributeToken( 'class', 23, 7, 17, 13, '', 'class', '' )
 	 *     );
 	 *
 	 * @since WP_VERSION
-	 * @var WP_HTML_Attribute_Token[]
+	 * @var XMLAttributeToken[]
 	 */
 	private $attributes = array();
 
@@ -722,9 +713,9 @@ class XMLProcessor {
 	 *
 	 * @since WP_VERSION
 	 *
-	 * @var string[]
+	 * @var XMLStackOfOpenElements
 	 */
-	public $stack_of_open_elements = array();
+	private $stack_of_open_elements;
 
 	public static function create_from_string( $xml, $cursor = null, $known_definite_encoding = 'UTF-8' ) {
 		$processor = static::create_for_streaming( $xml, $cursor, $known_definite_encoding );
@@ -763,15 +754,24 @@ class XMLProcessor {
 	 * `set_bookmark()` and `seek()`.
 	 */
 	public function get_reentrancy_cursor() {
+		$stack_of_open_elements = [];
+		foreach ( $this->stack_of_open_elements->get_items() as $element ) {
+			$stack_of_open_elements[] = [
+				'local_name'          => $element->local_name,
+				'namespace_prefix'    => $element->namespace_prefix,
+				'namespace'           => $element->namespace,
+				'namespaces_in_scope' => $element->namespaces_in_scope,
+			];
+		}
+
 		return base64_encode(
 			json_encode(
 				array(
 					'is_finished'              => $this->is_finished(),
 					'upstream_bytes_forgotten' => $this->upstream_bytes_forgotten,
 					'parser_context'           => $this->parser_context,
-					'stack_of_open_elements'   => $this->stack_of_open_elements,
+					'stack_of_open_elements'   => $stack_of_open_elements,
 					'expecting_more_input'     => $this->expecting_more_input,
-					'namespace_stack'          => $this->namespace_stack,
 				)
 			)
 		);
@@ -816,10 +816,13 @@ class XMLProcessor {
 		// Assume the input stream will start from the last known byte offset.
 		$this->bytes_already_parsed     = 0;
 		$this->upstream_bytes_forgotten = $cursor['upstream_bytes_forgotten'];
-		$this->stack_of_open_elements   = $cursor['stack_of_open_elements'];
-		$this->parser_context           = $cursor['parser_context'];
-		$this->expecting_more_input     = $cursor['expecting_more_input'];
-		$this->namespace_stack          = $cursor['namespace_stack'];
+		$this->stack_of_open_elements   = new XMLStackOfOpenElements();
+		foreach ( $cursor['stack_of_open_elements'] as $element ) {
+			$this->stack_of_open_elements->push( new XMLElement( $element['local_name'], $element['namespace_prefix'],
+				$element['namespace'], $element['namespaces_in_scope'] ) );
+		}
+		$this->parser_context       = $cursor['parser_context'];
+		$this->expecting_more_input = $cursor['expecting_more_input'];
 
 		return true;
 	}
@@ -852,7 +855,8 @@ class XMLProcessor {
 				'6.4.0'
 			);
 		}
-		$this->xml = $xml;
+		$this->xml                    = $xml;
+		$this->stack_of_open_elements = new XMLStackOfOpenElements();
 	}
 
 	/**
@@ -1055,12 +1059,8 @@ class XMLProcessor {
 		 * Confirm the tag name is valid with respect to XML namespaces.
 		 * @see https://www.w3.org/TR/2006/REC-xml-names11-20060816/#Conformance
 		 */
-		$tag_name = $this->get_qualified_tag();
-		if ( substr_count( $tag_name, ':' ) > 1 ) {
-			$this->bail(
-				sprintf('Invalid tag name "%s" – more than one ":" in tag name. Every tag name must contain either zero or one colon.', $tag_name),
-				self::ERROR_SYNTAX
-			);
+		$tag_name = $this->get_local_tag_name();
+		if ( false === $this->validate_qualified_name( $tag_name ) ) {
 			return false;
 		}
 
@@ -1083,7 +1083,7 @@ class XMLProcessor {
 		$tag_ends_at        = $this->token_starts_at + $this->token_length;
 		$attributes         = $this->attributes;
 
-		$found_closer = $this->skip_pcdata( $this->get_qualified_tag() );
+		$found_closer = $this->skip_pcdata( $this->get_local_tag_name() );
 
 		// Closer not found, the document is incomplete.
 		if ( false === $found_closer ) {
@@ -1424,7 +1424,7 @@ class XMLProcessor {
 	 *
 	 */
 	public function is_pcdata_element() {
-		return array_key_exists( $this->get_qualified_tag(), $this->pcdata_elements );
+		return array_key_exists( $this->get_local_tag_name(), $this->pcdata_elements );
 	}
 
 
@@ -1566,6 +1566,7 @@ class XMLProcessor {
 
 			if ( $at + 1 >= $doc_length ) {
 				$this->mark_incomplete_input();
+
 				return false;
 			}
 
@@ -1904,11 +1905,13 @@ class XMLProcessor {
 				foreach ( $this->attributes as $name => $attribute ) {
 					if ( 'version' !== $name && 'encoding' !== $name && 'standalone' !== $name ) {
 						$this->bail( 'Invalid attribute found in XML declaration.', self::ERROR_SYNTAX );
+						return false;
 					}
 				}
 
-				if ( '1.0' !== $this->get_attribute_by_qualified_name( 'version' ) ) {
+				if ( '1.0' !== $this->get_attribute( '', 'version' ) ) {
 					$this->bail( 'Unsupported XML version declared', self::ERROR_UNSUPPORTED );
+					return false;
 				}
 
 				/**
@@ -1917,15 +1920,18 @@ class XMLProcessor {
 				 *
 				 * See https://www.w3.org/TR/xml/#sec-predefined-ent.
 				 */
-				if ( null !== $this->get_attribute_by_qualified_name( 'encoding' )
-				     && 'UTF-8' !== strtoupper( $this->get_attribute_by_qualified_name( 'encoding' ) )
+				if ( null !== $this->get_attribute( '', 'encoding' )
+				     && 'UTF-8' !== strtoupper( $this->get_attribute( '', 'encoding' ) )
 				) {
 					$this->bail( 'Unsupported XML encoding declared, only UTF-8 is supported.', self::ERROR_UNSUPPORTED );
+					return false;
 				}
-				if ( null !== $this->get_attribute_by_qualified_name( 'standalone' )
-				     && 'YES' !== strtoupper( $this->get_attribute_by_qualified_name( 'standalone' ) )
+
+				if ( null !== $this->get_attribute( '', 'standalone' )
+				     && 'YES' !== strtoupper( $this->get_attribute( '', 'standalone' ) )
 				) {
 					$this->bail( 'Standalone XML documents are not supported.', self::ERROR_UNSUPPORTED );
+					return false;
 				}
 
 				$at = $this->bytes_already_parsed;
@@ -1940,6 +1946,7 @@ class XMLProcessor {
 					'>' === $xml[ $at + 1 ]
 				) ) {
 					$this->bail( 'XML declaration closer not found.', self::ERROR_SYNTAX );
+					return false;
 				}
 
 				$this->token_length         = $at + 2 - $this->token_starts_at;
@@ -2127,21 +2134,31 @@ class XMLProcessor {
 		 * Confirm the tag name is valid with respect to XML namespaces.
 		 * @see https://www.w3.org/TR/2006/REC-xml-names11-20060816/#Conformance
 		 */
-		if ( substr_count( $attribute_name, ':' ) > 1 ) {
-			$this->bail(
-				sprintf('Invalid attribute name "%s" – more than one ":" in attribute name. Every attribute name must contain either zero or one colon.', $attribute_name),
-				self::ERROR_SYNTAX
-			);
+		if ( false === $this->validate_qualified_name( $attribute_name ) ) {
 			return false;
 		}
 
-		$this->attributes[ $attribute_name ] = new WP_HTML_Attribute_Token(
+		/**
+		 * We must compute the namespace prefix and local name for each attribute
+		 * to assert there are no duplicate (local name, namespace) pairs in any
+		 * element. Note we must still keep track of string indices to support
+		 * replacements.
+		 */
+		list( $namespace_prefix, $local_name ) = $this->parse_qualified_name( $attribute_name );
+
+		$this->attributes[ $attribute_name ] = new XMLAttributeToken(
 			$attribute_name,
 			$value_start,
 			$value_length,
 			$attribute_start,
 			$attribute_end - $attribute_start,
-			false
+			$namespace_prefix,
+			$local_name
+		/**
+		 * The full namespace is resolved in push_open_element() once
+		 * we know all xmlns declarations in the current element's
+		 * scope.
+		 */
 		);
 
 		return true;
@@ -2333,6 +2350,7 @@ class XMLProcessor {
 			unset( $this->lexical_updates[ $name ] );
 		}
 
+		$this->element            = null;
 		$this->token_starts_at    = null;
 		$this->token_length       = null;
 		$this->tag_name_starts_at = null;
@@ -2622,13 +2640,13 @@ class XMLProcessor {
 	 *     $p->next_tag() === false;
 	 *     $p->get_attribute_by_qualified_name( 'class' ) === null;
 	 *
-	 * @param  string  $qualified_name Qualified name of attribute whose value is requested, e.g. wp:data-test-id
+	 * @param  string  $local_name  Qualified name of attribute whose value is requested, e.g. wp:data-test-id
 	 *
 	 * @return string|true|null Value of attribute or `null` if not available. Boolean attributes return `true`.
 	 * @since WP_VERSION
 	 *
 	 */
-	public function get_attribute_by_qualified_name( $qualified_name ) {
+	public function get_attribute( $namespace_reference, $local_name ) {
 		if (
 			self::STATE_MATCHED_TAG !== $this->parser_state &&
 			self::STATE_XML_DECLARATION !== $this->parser_state
@@ -2637,16 +2655,16 @@ class XMLProcessor {
 		}
 
 		// Return any enqueued attribute value updates if they exist.
-		$enqueued_value = $this->get_enqueued_attribute_value( $qualified_name );
+		$enqueued_value = $this->get_enqueued_attribute_value( $local_name );
 		if ( false !== $enqueued_value ) {
 			return $enqueued_value;
 		}
 
-		if ( ! isset( $this->attributes[ $qualified_name ] ) ) {
+		if ( ! isset( $this->attributes[ $local_name ] ) ) {
 			return null;
 		}
 
-		$attribute = $this->attributes[ $qualified_name ];
+		$attribute = $this->attributes[ $local_name ];
 		$raw_value = substr( $this->xml, $attribute->value_starts_at, $attribute->value_length );
 
 		$decoded = XMLDecoder::decode( $raw_value );
@@ -2670,28 +2688,34 @@ class XMLProcessor {
 		return $decoded;
 	}
 
-	/**
-	 * Returns the value of an attribute scoped to a given fully-qualified namespace name.
-	 *
-	 * Example:
-	 *
-	 *     $p = new XMLProcessor( '<root xmlns:isbn="urn:ISBN:0-395-36341-6"><wp:content isbn:test="123">Test</wp:content></root>' );
-	 *     $p->get_attribute_by_expanded_name( 'urn:ISBN:0-395-36341-6', 'test' ) === '123';
-	 *
-	 * @param $namespace_name Fully-qualified namespace name, e.g. urn:ISBN:0-395-36341-6
-	 * @param $local_name Local name of the attribute, e.g. test
-	 *
-	 * @return string|null Value of the attribute, or null if not found.
-	 */
-	public function get_attribute_by_expanded_name( $namespace_name, $local_name ) {
-		// Find a local prefix of the fully-qualified namespace name
-		$namespaces = $this->namespace_stack[count($this->namespace_stack) - 1];
-		$prefix = array_search($namespace_name, $namespaces);
-		if(false === $prefix) {
-			return null;
+	private function get_attribute_value( XMLAttributeToken $attribute ) {
+		// Return any enqueued attribute value updates if they exist.
+		// $enqueued_value = $this->get_enqueued_attribute_value( $local_name );
+		// if ( false !== $enqueued_value ) {
+		// 	return $enqueued_value;
+		// }
+
+		$raw_value = substr( $this->xml, $attribute->value_starts_at, $attribute->value_length );
+
+		$decoded = XMLDecoder::decode( $raw_value );
+		if ( ! isset( $decoded ) ) {
+			/**
+			 * If the attribute contained an invalid value, it's
+			 * a fatal error.
+			 *
+			 * @see WP_XML_Decoder::decode()
+			 */
+			$this->last_error = self::ERROR_SYNTAX;
+			_doing_it_wrong(
+				__METHOD__,
+				__( 'Invalid attribute value encountered.' ),
+				'WP_VERSION'
+			);
+
+			return false;
 		}
-		// Found! Create a qualified name and return the attribute value
-		return $this->get_attribute_by_qualified_name($prefix . ':' . $local_name);
+
+		return $decoded;
 	}
 
 	/**
@@ -2747,18 +2771,38 @@ class XMLProcessor {
 	 * @since WP_VERSION
 	 *
 	 */
-	public function get_qualified_tag() {
+	public function get_local_tag_name() {
+		if ( null !== $this->element ) {
+			// Return cached name if we already have it.
+			return $this->element->local_name;
+		}
+
+		$qualified_tag_name = $this->get_qualified_tag_name();
+		if ( null === $qualified_tag_name ) {
+			return null;
+		}
+
+		list( $_, $local_name ) = $this->parse_qualified_name( $qualified_tag_name );
+
+		return $local_name;
+	}
+
+	public function get_qualified_tag_name() {
+		if ( null !== $this->element ) {
+			// Return cached name if we already have it.
+			return $this->element->qualified_name;
+		}
+
 		if ( null === $this->tag_name_starts_at ) {
 			return null;
 		}
 
 		$tag_name = substr( $this->xml, $this->tag_name_starts_at, $this->tag_name_length );
-
-		if ( self::STATE_MATCHED_TAG === $this->parser_state ) {
-			return $tag_name;
+		if ( self::STATE_MATCHED_TAG !== $this->parser_state ) {
+			return null;
 		}
 
-		return null;
+		return $tag_name;
 	}
 
 	/**
@@ -2773,16 +2817,11 @@ class XMLProcessor {
 	 * @return string|null The namespace prefix of the matched tag, or null if not available.
 	 */
 	public function get_namespace_prefix() {
-		$tag_name = $this->get_qualified_tag();
-		// Only tags have a namespace prefix
-		if (null === $tag_name) {
+		if ( self::STATE_MATCHED_TAG !== $this->parser_state ) {
 			return null;
 		}
-		$prefix_length = strcspn($tag_name, ':');
-		if (0 === $prefix_length || $prefix_length === strlen($tag_name)) {
-			return self::DEFAULT_NAMESPACE_PREFIX;
-		}
-		return substr($tag_name, 0, $prefix_length);
+
+		return $this->element->namespace_prefix;
 	}
 
 	/**
@@ -2797,21 +2836,12 @@ class XMLProcessor {
 	 *
 	 * @return string|null The namespace reference of the matched tag, or null if not available.
 	 */
-	public function get_namespace_reference() {
-		$namespace_prefix = $this->get_namespace_prefix();
-		if(null === $namespace_prefix) {
+	public function get_namespace() {
+		if ( self::STATE_MATCHED_TAG !== $this->parser_state ) {
 			return null;
 		}
-		/**
-		 * Look up the namespace reference in the last element of the namespace stack –
-		 * it reflects all the declared, inherited, and unset namespaces that are in effect
-		 * for the current element.
-		 */
-		$namespaces = $this->namespace_stack[count($this->namespace_stack) - 1];
-		if (isset($namespaces[$namespace_prefix])) {
-			return $namespaces[$namespace_prefix];
-		}
-		return null;
+
+		return $this->element->namespace;
 	}
 
 	/**
@@ -3018,7 +3048,7 @@ class XMLProcessor {
 	public function get_token_name() {
 		switch ( $this->parser_state ) {
 			case self::STATE_MATCHED_TAG:
-				return $this->get_qualified_tag();
+				return $this->get_local_tag_name();
 
 			case self::STATE_TEXT_NODE:
 				return '#text';
@@ -3532,25 +3562,26 @@ class XMLProcessor {
 				return true;
 			case '#tag':
 				// Update the stack of open elements
-				$tag_name = $this->get_qualified_tag();
+				$tag_qname = $this->get_qualified_tag_name();
 				if ( $this->is_tag_closer() ) {
-					$popped = $this->pop_open_element();
-					if ( $popped !== $tag_name ) {
+					$popped_qname = $this->pop_open_element()->qualified_name;
+					if ( $popped_qname !== $tag_qname ) {
 						$this->bail(
 							sprintf(
 							// translators: %1$s is the name of the closing HTML tag, %2$s is the name of the opening HTML tag.
 								__( 'The closing tag "%1$s" did not match the opening tag "%2$s".' ),
-								$tag_name,
-								$popped
+								$tag_qname,
+								$popped_qname
 							),
 							self::ERROR_SYNTAX
 						);
 					}
-					if ( count( $this->stack_of_open_elements ) === 0 ) {
+					if ( $this->stack_of_open_elements->count() === 0 ) {
 						$this->parser_context = self::IN_MISC_CONTEXT;
 					}
 				} else {
-					$this->push_open_element( $tag_name );
+					$this->push_open_element( $tag_qname );
+					$this->element = $this->stack_of_open_elements->top();
 				}
 
 				return true;
@@ -3632,7 +3663,7 @@ class XMLProcessor {
 	 *
 	 */
 	public function get_breadcrumbs() {
-		return $this->stack_of_open_elements;
+		return $this->stack_of_open_elements->get_items();
 	}
 
 	/**
@@ -3673,13 +3704,14 @@ class XMLProcessor {
 		if (
 			'#tag' === $this->get_token_type() &&
 			'*' !== $crumb &&
-			$this->get_qualified_tag() !== $crumb
+			$this->get_local_tag_name() !== $crumb
 		) {
 			return false;
 		}
 
-		for ( $i = count( $this->stack_of_open_elements ) - 1; $i >= 0; $i -- ) {
-			$tag_name = $this->stack_of_open_elements[ $i ];
+		// @TODO: Match namespaces!
+		for ( $i = $this->stack_of_open_elements->count() - 1; $i >= 0; $i -- ) {
+			$tag_name = $this->stack_of_open_elements->get_items()[ $i ]->local_name;
 			$crumb    = current( $breadcrumbs );
 
 			if ( '*' !== $crumb && $tag_name !== $crumb ) {
@@ -3719,51 +3751,55 @@ class XMLProcessor {
 	 *
 	 */
 	public function get_current_depth() {
-		return count( $this->stack_of_open_elements );
+		return $this->stack_of_open_elements->count();
 	}
 
 	private function pop_open_element() {
-		array_pop($this->namespace_stack);
-		return array_pop( $this->stack_of_open_elements );
+		return $this->stack_of_open_elements->pop();
 	}
 
-	private function push_open_element( $tag_name ) {
-		// Track open elements
-		array_push(
-			$this->stack_of_open_elements,
-			$tag_name
-		);
+	private function push_open_element( $qualified_name ) {
+		/**
+		 * Before we push the element, we need to compute its:
+		 *
+		 * - local name
+		 * - namespace prefix
+		 * - namespace URI
+		 * - namespaces in current element's scope
+		 */
+
+		// All qualified names are validated at this point.
+		list( $tag_namespace_prefix, $tag_local_name ) = $this->parse_qualified_name( $qualified_name );
+
+		// Resolve namespaces:
 
 		/**
 		 * By default, inherit all namespaces from the parent element.
 		 */
-		$namespaces = $this->namespace_stack[count($this->namespace_stack) - 1];
-
-		// Override parent namespaces with the current element's declarations.
-		foreach($this->attributes as $attribute) {
+		$namespaces = $this->stack_of_open_elements->get_namespaces_in_scope();
+		foreach ( $this->attributes as $attribute ) {
 			/**
 			 * xmlns attribute is the default namespace
 			 * xmlns:<prefix> declares a namespace prefix scoped to the current element and its descendants
 			 *
 			 * @see https://www.w3.org/TR/2006/REC-xml-names11-20060816/#ns-decl
 			 */
-			if( 'xmlns' === $attribute->name) {
-				$namespaces[self::DEFAULT_NAMESPACE_PREFIX] = $this->get_attribute_by_qualified_name($attribute->name);
+			if ( 'xmlns' === $attribute->name ) {
+				$value                                        = $this->get_attribute_value( $attribute );
+				$namespaces[ self::DEFAULT_NAMESPACE_PREFIX ] = $value;
 				continue;
 			}
 
-			if (substr($attribute->name, 0, 6) === 'xmlns:') {
-				$prefix = substr($attribute->name, 6);
-				if (self::DEFAULT_NAMESPACE_PREFIX === $prefix) {
-					$this->bail( sprintf('Invalid namespace prefix: %s', $attribute->name), self::ERROR_SYNTAX );
-					return false;
-				}
-				$ns_reference = $this->get_attribute_by_qualified_name($attribute->name);
+			if ( 'xmlns' === $attribute->namespace_prefix ) {
+				$value = $this->get_attribute_value( $attribute );
+
 				/**
 				 * @see https://www.w3.org/TR/2006/REC-xml-names11-20060816/#xmlReserved
 				 */
-				if('xml' === $prefix && 'http://www.w3.org/XML/1998/namespace' !== $ns_reference) {
-					$this->bail( 'The `xml` namespace prefix is by definition bound to the namespace name http://www.w3.org/XML/1998/namespace and must not be overridden.', self::ERROR_SYNTAX );
+				if ( 'xml' === $attribute->namespace_prefix && 'http://www.w3.org/XML/1998/namespace' !== $value ) {
+					$this->bail( 'The `xml` namespace prefix is by definition bound to the namespace name http://www.w3.org/XML/1998/namespace and must not be overridden.',
+						self::ERROR_SYNTAX );
+
 					return false;
 				}
 				/**
@@ -3772,54 +3808,135 @@ class XMLProcessor {
 				 * association of the prefix with a namespace name. Further declarations MAY
 				 * re-declare the prefix again.
 				 */
-				if('' === $ns_reference) {
-					unset($namespaces[$prefix]);
+				if ( '' === $value ) {
+					unset( $namespaces[ $attribute->namespace_prefix ] );
 					continue;
 				}
-				$namespaces[$prefix] = $ns_reference;
+
+				$namespaces[ $attribute->local_name ] = $value;
 				continue;
 			}
 		}
-		array_push($this->namespace_stack, $namespaces);
+
+		// Validate namespaces for the element and its attributes:
 
 		/**
-		 * Now that we know the namespaces associated with the current element,
-		 * assert that no two attributes have the same (name, namespace) pair.
+		 * Validate the element namespace.
+		 */
+		if ( ! array_key_exists( $tag_namespace_prefix, $namespaces ) ) {
+			$this->bail(
+				sprintf(
+					'Namespace prefix "%s" does not resolve to any namespace in the current element\'s scope.',
+					$tag_namespace_prefix
+				),
+				self::ERROR_SYNTAX
+			);
+		}
+
+		/**
+		 * Let's assert:
+		 *
+		 * * All attributes have valid namespaces.
+		 * * No two attributes have the same (local name, namespace) pair.
 		 *
 		 * @see https://www.w3.org/TR/2006/REC-xml-names11-20060816/#uniqAttrs
 		 */
-		$seen = array();
+		$namespaced_attributes = array();
 		foreach ( $this->attributes as $attribute ) {
-			$attr_name = $attribute->name;
-			// Split into prefix and local name if a colon exists.
-			$colon_pos = strpos( $attr_name, ':' );
-			if ( false === $colon_pos ) {
-				// Unprefixed attributes do not have a default namespace
-				// and were already checked for uniqueness in parse_next_attribute()
-				continue;
+			list( $attribute_namespace_prefix, $attribute_local_name ) = $this->parse_qualified_name( $attribute->name );
+			if ( ! array_key_exists( $attribute_namespace_prefix, $namespaces ) ) {
+				$this->bail(
+					sprintf(
+						'Attribute "%s" has an invalid namespace prefix "%s".',
+						$attribute->name,
+						$attribute_namespace_prefix
+					),
+					self::ERROR_SYNTAX
+				);
+
+				return false;
 			}
-			$prefix = substr($attr_name, 0, $colon_pos);
-			$local_name = substr($attr_name, $colon_pos + 1);
-			$namespace_uri = $namespaces[ $prefix ] ?? self::DEFAULT_NAMESPACE_PREFIX;
+			$namespace_uri = $namespaces[ $attribute_namespace_prefix ];
 
 			/**
 			 * It looks supicious but it's safe – $local_name is guaranteed to not contain
-			 * a colon at this point.
+			 * curly braces at this point.
 			 */
-			$key = $namespace_uri . ':' . $local_name;
-			if ( isset( $seen[ $key ] ) ) {
+			$attribute_full_key = '{' . $namespace_uri . '}' . $attribute_local_name;
+			if ( isset( $namespaced_attributes[ $attribute_full_key ] ) ) {
 				$this->bail(
 					sprintf(
 						'Duplicate attribute "%s" with namespace "%s" found in the same element.',
-						$local_name,
+						$attribute_local_name,
 						$namespace_uri
 					),
 					self::ERROR_SYNTAX
 				);
+
 				return false;
 			}
-			$seen[ $key ] = true;
+			$namespaced_attributes[ $attribute_full_key ] = true;
 		}
+
+		// Store attributes with their namespaces.
+		$this->attributes = $namespaced_attributes;
+
+		// Finally, push the element onto the stack.
+		$this->stack_of_open_elements->push(
+			new XMLElement( $tag_local_name, $tag_namespace_prefix, $namespaces[ $tag_namespace_prefix ], $namespaces )
+		);
+
+		return true;
+	}
+
+	/**
+	 * Parses a qualified name into a namespace prefix and local name.
+	 *
+	 * Example:
+	 *
+	 *     $processor = new XMLProcessor( '<root><wp:post><content><image /></content></wp:post></root>' );
+	 *     $processor->parse_qualified_name( 'wp:post' ); // Returns array( 'wp', 'post' )
+	 *     $processor->parse_qualified_name( 'image' ); // Returns array( '', 'image' )
+	 *
+	 * @param  string  $qualified_name  The qualified name to parse.
+	 *
+	 * @return array<string, string> The namespace prefix and local name.
+	 */
+	private function parse_qualified_name( $qualified_name ) {
+		$namespace_prefix = self::DEFAULT_NAMESPACE_PREFIX;
+		$local_name       = $qualified_name;
+
+		$prefix_length = strcspn( $qualified_name, ':' );
+		if ( null !== $prefix_length && $prefix_length !== strlen( $qualified_name ) ) {
+			$namespace_prefix = substr( $qualified_name, 0, $prefix_length );
+			$local_name       = substr( $qualified_name, $prefix_length + 1 );
+		}
+
+		return array( $namespace_prefix, $local_name );
+	}
+
+	private function validate_qualified_name( $qualified_name ) {
+		if ( substr_count( $qualified_name, ':' ) > 1 ) {
+			$this->bail(
+				sprintf( 'Invalid identifier "%s" – more than one ":" in tag name. Every tag name must contain either zero or one colon.',
+					$qualified_name ),
+				self::ERROR_SYNTAX
+			);
+
+			return false;
+		}
+
+		$prefix_length = strcspn( $qualified_name, ':' );
+		if ( $prefix_length === 0 && strlen( $qualified_name ) > 0 ) {
+			$this->bail(
+				sprintf( 'Invalid identifier "%s" – namespace qualifier must not have zero length.', $qualified_name ),
+				self::ERROR_SYNTAX
+			);
+
+			return false;
+		}
+
+		return true;
 	}
 
 	private function mark_incomplete_input(

--- a/components/XML/XMLProcessor.php
+++ b/components/XML/XMLProcessor.php
@@ -553,8 +553,8 @@ class XMLProcessor {
 	 *     //   <wp:content wp:id="test-4" class="outline">
 	 *     // </channel>
 	 *     $this->qualified_attributes = array(
-	 *         '{http://wordpress.org/export/1.2/}id' => new XMLAttributeToken( 'id', 9, 6, 5, 14, 'wp', 'id' ),
-	 *         'class' => new XMLAttributeToken( 'class', 23, 7, 17, 13, '', 'class', '' )
+	 *         '{http://wordpress.org/export/1.2/}id' => new XMLAttributeToken( 9, 6, 5, 14, 'wp', 'id' ),
+	 *         'class' => new XMLAttributeToken( 23, 7, 17, 13, '', 'class', '' )
 	 *     );
 	 *
 	 * @since WP_VERSION
@@ -2294,7 +2294,6 @@ class XMLProcessor {
 		list( $namespace_prefix, $local_name ) = $this->parse_qualified_name( $attribute_qname );
 
 		$this->qualified_attributes[ $attribute_qname ] = new XMLAttributeToken(
-			$attribute_qname,
 			$value_start,
 			$value_length,
 			$attribute_start,

--- a/components/XML/XMLProcessor.php
+++ b/components/XML/XMLProcessor.php
@@ -759,12 +759,7 @@ class XMLProcessor {
 	public function get_reentrancy_cursor() {
 		$stack_of_open_elements = [];
 		foreach ( $this->stack_of_open_elements->get_items() as $element ) {
-			$stack_of_open_elements[] = [
-				'local_name'          => $element->local_name,
-				'namespace_prefix'    => $element->namespace_prefix,
-				'namespace'           => $element->namespace,
-				'namespaces_in_scope' => $element->namespaces_in_scope,
-			];
+			$stack_of_open_elements[] = $element->to_array();
 		}
 
 		return base64_encode(
@@ -774,7 +769,7 @@ class XMLProcessor {
 					'upstream_bytes_forgotten' => $this->upstream_bytes_forgotten,
 					'parser_context'           => $this->parser_context,
 					'stack_of_open_elements'   => $stack_of_open_elements,
-					'expecting_more_input'     => $this->expecting_more_input,
+					'expecting_more_input'     => $this->expecting_more_input
 				)
 			)
 		);
@@ -821,8 +816,7 @@ class XMLProcessor {
 		$this->upstream_bytes_forgotten = $cursor['upstream_bytes_forgotten'];
 		$this->stack_of_open_elements   = new XMLStackOfOpenElements();
 		foreach ( $cursor['stack_of_open_elements'] as $element ) {
-			$this->stack_of_open_elements->push( new XMLElement( $element['local_name'], $element['namespace_prefix'],
-				$element['namespace'], $element['namespaces_in_scope'] ) );
+			$this->stack_of_open_elements->push( XMLElement::from_array( $element ) );
 		}
 		$this->parser_context       = $cursor['parser_context'];
 		$this->expecting_more_input = $cursor['expecting_more_input'];
@@ -1112,7 +1106,7 @@ class XMLProcessor {
 			 * Confirm the tag name is valid with respect to XML namespaces.
 			 * @see https://www.w3.org/TR/2006/REC-xml-names11-20060816/#Conformance
 			 */
-			$tag_name = $this->get_qualified_tag_name();
+			$tag_name = $this->get_tag_name_qualified();
 			if ( false === $this->validate_qualified_name( $tag_name ) ) {
 				return false;
 			}
@@ -1183,6 +1177,8 @@ class XMLProcessor {
 			$this->qualified_attributes = array();
 
 			$this->element = new XMLElement( $tag_local_name, $tag_namespace_prefix, $namespaces[ $tag_namespace_prefix ], $namespaces );
+			// Closers assume $this->element is the element created for the opener.
+			// @see step_in_element
 		}
 
 		/*
@@ -1576,7 +1572,7 @@ class XMLProcessor {
 		} else {
 			$query = $query_or_ns;
 		}
-		
+
 		if ( null === $query ) {
 			while ( $this->step() ) {
 				if ( '#tag' !== $this->get_token_type() ) {
@@ -2939,7 +2935,7 @@ class XMLProcessor {
 			return $this->element->local_name;
 		}
 
-		$qualified_tag_name = $this->get_qualified_tag_name();
+		$qualified_tag_name = $this->get_tag_name_qualified();
 		if ( null === $qualified_tag_name ) {
 			return null;
 		}
@@ -2949,7 +2945,7 @@ class XMLProcessor {
 		return $local_name;
 	}
 
-	public function get_qualified_tag_name() {
+	public function get_tag_name_qualified() {
 		if ( null !== $this->element ) {
 			// Return cached name if we already have it.
 			return $this->element->qualified_name;
@@ -2965,6 +2961,15 @@ class XMLProcessor {
 		}
 
 		return $tag_name;
+	}
+
+	public function get_tag_name_with_namespace() {
+		$namespace = $this->get_namespace();
+		if ( ! $namespace ) {
+			return $this->get_tag_local_name();
+		}
+
+		return '{' . $namespace . '}' . $this->get_tag_local_name();
 	}
 
 	/**
@@ -3376,7 +3381,7 @@ class XMLProcessor {
 		}
 
 		$value             = htmlspecialchars( $value, ENT_XML1, 'UTF-8' );
-		
+
 		if($namespace !== '') {
 			$prefix = $this->stack_of_open_elements->get_namespace_prefix($namespace);
 			if(false === $prefix) {
@@ -3740,7 +3745,7 @@ class XMLProcessor {
 				return true;
 			case '#tag':
 				// Update the stack of open elements
-				$tag_qname = $this->get_qualified_tag_name();
+				$tag_qname = $this->get_tag_name_qualified();
 				if ( $this->is_tag_closer() ) {
 					if(!$this->stack_of_open_elements->count()) {
 						$this->bail(
@@ -3750,7 +3755,8 @@ class XMLProcessor {
 						);
 						return false;
 					}
-					$popped_qname = $this->stack_of_open_elements->pop()->qualified_name;
+					$this->element = $this->stack_of_open_elements->pop();
+					$popped_qname = $this->element->qualified_name;
 					if ( $popped_qname !== $tag_qname ) {
 						$this->bail(
 							sprintf(

--- a/components/XML/XMLProcessor.php
+++ b/components/XML/XMLProcessor.php
@@ -347,8 +347,6 @@ class XMLProcessor {
 	 */
 	const MAX_SEEK_OPS = 1000;
 
-	const DEFAULT_NAMESPACE_PREFIX = '';
-
 	/**
 	 * The XML document to parse.
 	 *
@@ -1076,8 +1074,9 @@ class XMLProcessor {
 				 * @see https://www.w3.org/TR/2006/REC-xml-names11-20060816/#ns-decl
 				 */
 				if ( 'xmlns' === $attribute->qualified_name ) {
-					$value                                        = $this->get_qualified_attribute( $attribute->qualified_name );
-					$namespaces[ self::DEFAULT_NAMESPACE_PREFIX ] = $value;
+					$value          = $this->get_qualified_attribute( $attribute->qualified_name );
+					// Update the default namespace.
+					$namespaces[''] = $value;
 					continue;
 				}
 
@@ -1156,7 +1155,7 @@ class XMLProcessor {
 
 					return false;
 				}
-				$namespace_reference = $namespaces[ $attribute_namespace_prefix ];
+				$namespace_reference = $attribute_namespace_prefix ? $namespaces[ $attribute_namespace_prefix ] : '';
 
 				/**
 				 * It looks supicious but it's safe – $local_name is guaranteed to not contain
@@ -1571,7 +1570,13 @@ class XMLProcessor {
 	 * @since WP_VERSION
 	 *
 	 */
-	public function next_tag( $query = null ) {
+	public function next_tag( $query_or_ns = null, $null_or_local_name = null ) {
+		if ( null !== $null_or_local_name ) {
+			$query = array( 'breadcrumbs' => array( $query_or_ns, $null_or_local_name ) );
+		} else {
+			$query = $query_or_ns;
+		}
+		
 		if ( null === $query ) {
 			while ( $this->step() ) {
 				if ( '#tag' !== $this->get_token_type() ) {
@@ -3962,7 +3967,7 @@ class XMLProcessor {
 	 * @return array<string, string> The namespace prefix and local name.
 	 */
 	private function parse_qualified_name( $qualified_name ) {
-		$namespace_prefix = self::DEFAULT_NAMESPACE_PREFIX;
+		$namespace_prefix = '';
 		$local_name       = $qualified_name;
 
 		$prefix_length = strcspn( $qualified_name, ':' );

--- a/components/XML/XMLStackOfOpenElements.php
+++ b/components/XML/XMLStackOfOpenElements.php
@@ -81,4 +81,14 @@ class XMLStackOfOpenElements {
 		return $top->namespaces_in_scope;
 	}
 
+	public function get_namespace_prefix($namespace) {
+		$namespaces_in_scope = $this->get_namespaces_in_scope();
+		foreach($namespaces_in_scope as $prefix => $uri) {
+			if($uri === $namespace) {
+				return $prefix;
+			}
+		}
+		return false;
+	}
+
 }

--- a/components/XML/XMLStackOfOpenElements.php
+++ b/components/XML/XMLStackOfOpenElements.php
@@ -1,0 +1,84 @@
+<?php
+namespace WordPress\XML;
+
+/**
+ * XML API: XMLElement class
+ *
+ * @package WordPress
+ * @subpackage XML-API
+ * @since 6.2.0
+ */
+
+class XMLStackOfOpenElements {
+
+	/**
+	 * @var XMLElement[]
+	 */
+	private $stack = array();
+
+	/**
+	 * Pushes an XMLElement onto the stack.
+	 *
+	 * @param XMLElement $element
+	 * @return void
+	 */
+	public function push( XMLElement $element ) {
+		$this->stack[] = $element;
+	}
+
+	/**
+	 * Pops the top XMLElement from the stack.
+	 *
+	 * @return XMLElement|null Returns the popped element, or null if stack is empty.
+	 */
+	public function pop() {
+		if ( empty( $this->stack ) ) {
+			return null;
+		}
+		return array_pop( $this->stack );
+	}
+
+	/**
+	 * Returns the top XMLElement on the stack without removing it.
+	 *
+	 * @return XMLElement|null Returns the top element, or null if stack is empty.
+	 */
+	public function top() {
+		if ( empty( $this->stack ) ) {
+			return null;
+		}
+		return $this->stack[ count( $this->stack ) - 1 ];
+	}
+
+	/**
+	 * Returns the number of elements in the stack.
+	 *
+	 * @return int
+	 */
+	public function count() {
+		return count( $this->stack );
+	}
+
+	public function get_items() {
+		return $this->stack;
+	}
+
+	/**
+	 * Returns the namespaces in scope for the top element.
+	 *
+	 * @return array<string, string>|null Namespaces in scope, or null if stack is empty.
+	 */
+	public function get_namespaces_in_scope() {
+		$top = $this->top();
+		if ( null === $top ) {
+			// Namespaces defined by default in every XML document.
+			return array(
+				'xml'   => 'http://www.w3.org/XML/1998/namespace', // Predefined, cannot be unbound or changed
+				'xmlns' => 'http://www.w3.org/2000/xmlns/',        // Reserved for xmlns attributes, not a real namespace for elements/attributes
+				XMLProcessor::DEFAULT_NAMESPACE_PREFIX      => '', // Default namespace is initially empty (no namespace)
+			);
+		}
+		return $top->namespaces_in_scope;
+	}
+
+}

--- a/components/XML/XMLStackOfOpenElements.php
+++ b/components/XML/XMLStackOfOpenElements.php
@@ -75,7 +75,7 @@ class XMLStackOfOpenElements {
 			return array(
 				'xml'   => 'http://www.w3.org/XML/1998/namespace', // Predefined, cannot be unbound or changed
 				'xmlns' => 'http://www.w3.org/2000/xmlns/',        // Reserved for xmlns attributes, not a real namespace for elements/attributes
-				XMLProcessor::DEFAULT_NAMESPACE_PREFIX      => '', // Default namespace is initially empty (no namespace)
+				''      => '', // Default namespace is initially empty (no namespace)
 			);
 		}
 		return $top->namespaces_in_scope;

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="bootstrap.php"
          colors="true"
-		 stopOnFailure="true">
+		 stopOnFailure="false">
     <testsuites>
         <!--
 			Blueprints tests are slow so we'll run them last.


### PR DESCRIPTION
A first WIP draft of XML namespaces support in the processor. Built to satisfy https://www.w3.org/TR/2006/REC-xml-names11-20060816/#uniqAttrs.

Remaining work:

* Merging `$stack_of_open_elements` and `$namespace_stack` into a single stack of objects that carry tag's local name, namespace prefix, full namespace reference, and a list of namespaces for the current tag scope.
* Support querying by namespaces in `next_tag()`
* Tests

cc @sirreal @dmsnell 