### PR TITLE
Persist WP Origin history in WordPress

### DIFF
--- a/bin/run-wp-origin-playground.sh
+++ b/bin/run-wp-origin-playground.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PORT="${WP_ORIGIN_PLAYGROUND_PORT:-${1:-9400}}"
+CONTEXT_DIR="$ROOT_DIR/.context"
+BLUEPRINT_TEMPLATE="$ROOT_DIR/plugins/wp-origin/blueprint-e2e.json"
+BLUEPRINT_FILE="$CONTEXT_DIR/wp-origin-playground-$PORT.json"
+CREDENTIALS_FILE="$CONTEXT_DIR/wp-origin-e2e-$PORT.json"
+
+if command -v wp-playground >/dev/null 2>&1; then
+	PLAYGROUND_CMD=(wp-playground)
+elif command -v wp-playground-cli >/dev/null 2>&1; then
+	PLAYGROUND_CMD=(wp-playground-cli)
+else
+	PLAYGROUND_CMD=(npx @wp-playground/cli@latest)
+fi
+
+cleanup() {
+	if [ -n "${PLAYGROUND_PID:-}" ] && kill -0 "$PLAYGROUND_PID" 2>/dev/null; then
+		kill "$PLAYGROUND_PID" 2>/dev/null || true
+		wait "$PLAYGROUND_PID" 2>/dev/null || true
+	fi
+}
+trap cleanup EXIT INT TERM
+
+mkdir -p "$CONTEXT_DIR"
+rm -f "$CREDENTIALS_FILE"
+
+php -r '
+$template = file_get_contents( $argv[1] );
+if ( false === $template ) {
+	fwrite( STDERR, "Unable to read blueprint template.\n" );
+	exit( 1 );
+}
+$blueprint = str_replace( "__WP_ORIGIN_CREDENTIALS_FILE__", $argv[2], $template );
+if ( false === file_put_contents( $argv[3], $blueprint ) ) {
+	fwrite( STDERR, "Unable to write playground blueprint.\n" );
+	exit( 1 );
+}
+' \
+	"$BLUEPRINT_TEMPLATE" \
+	"/workspace/.context/$(basename "$CREDENTIALS_FILE")" \
+	"$BLUEPRINT_FILE"
+
+PLAYGROUND_PHP_VERSION="$(php -r '$config = json_decode(file_get_contents($argv[1]), true); echo $config["preferredVersions"]["php"];' "$BLUEPRINT_FILE")"
+PLAYGROUND_WP_VERSION="$(php -r '$config = json_decode(file_get_contents($argv[1]), true); echo $config["preferredVersions"]["wp"];' "$BLUEPRINT_FILE")"
+
+"${PLAYGROUND_CMD[@]}" server \
+	--port="$PORT" \
+	--php="$PLAYGROUND_PHP_VERSION" \
+	--wp="$PLAYGROUND_WP_VERSION" \
+	--blueprint="$BLUEPRINT_FILE" \
+	--mount="$ROOT_DIR:/workspace" \
+	--mount="$ROOT_DIR/vendor:/wordpress/wp-content/vendor" \
+	--mount="$ROOT_DIR/components:/wordpress/wp-content/components" \
+	--mount="$ROOT_DIR/plugins/wp-origin:/wordpress/wp-content/plugins/wp-origin" &
+PLAYGROUND_PID=$!
+
+for _ in $(seq 1 120); do
+	if [ -f "$CREDENTIALS_FILE" ]; then
+		break
+	fi
+	if ! kill -0 "$PLAYGROUND_PID" 2>/dev/null; then
+		wait "$PLAYGROUND_PID"
+		exit $?
+	fi
+	sleep 1
+done
+
+if [ ! -f "$CREDENTIALS_FILE" ]; then
+	echo "WP Origin Playground did not produce credentials at $CREDENTIALS_FILE." >&2
+	exit 1
+fi
+
+USERNAME="$(php -r 'echo json_decode(file_get_contents($argv[1]), true)["username"];' "$CREDENTIALS_FILE")"
+PASSWORD="$(php -r 'echo json_decode(file_get_contents($argv[1]), true)["password"];' "$CREDENTIALS_FILE")"
+
+cat <<EOF
+WP Origin Playground is ready.
+
+Site URL: http://127.0.0.1:$PORT
+Credentials file: $CREDENTIALS_FILE
+Git remote: http://$USERNAME:$PASSWORD@127.0.0.1:$PORT/wp-json/git/v1/md.git
+
+Press Ctrl-C to stop the server.
+EOF
+
+wait "$PLAYGROUND_PID"

--- a/bin/test-wp-origin-git-actions.sh
+++ b/bin/test-wp-origin-git-actions.sh
@@ -129,6 +129,28 @@ git pull --rebase origin trunk
 
 php -r '
 $path = $argv[1];
+$contents = file_get_contents($path);
+$contents .= "\nEscaped path literal: C:\\\\Temp\\\\wp-origin\nQuoted JSON literal: {\"windows\":\"C:\\\\\\\\Temp\\\\\\\\wp-origin\"}\n";
+file_put_contents($path, $contents);
+' "$CLONE_DIR/post/hello-world.md"
+
+EXACT_COMMIT_MESSAGE='Preserve C:\\Temp\\wp-origin in commit metadata'
+git add post/hello-world.md
+git commit -m "$EXACT_COMMIT_MESSAGE"
+git push origin trunk
+
+EXACT_CLONE_DIR="$WORK_DIR/exact-clone"
+git -c protocol.version=2 clone "$REMOTE_AUTH_URL" "$EXACT_CLONE_DIR"
+EXACT_COMMIT_HASH="$(git -C "$EXACT_CLONE_DIR" log --grep='Preserve' --format=%H -n 1)"
+[ -n "$EXACT_COMMIT_HASH" ]
+git -C "$EXACT_CLONE_DIR" show "$EXACT_COMMIT_HASH:post/hello-world.md" > "$WORK_DIR/exact-blob.md"
+grep -Fq 'Escaped path literal: C:\\Temp\\wp-origin' "$WORK_DIR/exact-blob.md"
+grep -Fq 'Quoted JSON literal: {"windows":"C:\\\\Temp\\\\wp-origin"}' "$WORK_DIR/exact-blob.md"
+ACTUAL_COMMIT_MESSAGE="$(git -C "$EXACT_CLONE_DIR" show -s --format=%B "$EXACT_COMMIT_HASH" | php -r 'echo rtrim(stream_get_contents(STDIN), "\r\n");')"
+[ "$ACTUAL_COMMIT_MESSAGE" = "$EXACT_COMMIT_MESSAGE" ]
+
+php -r '
+$path = $argv[1];
 $markdown = "---\n"
 	. "type: \"post\"\n"
 	. "slug: \"created-from-git\"\n"

--- a/components/Git/Model/class-treeentry.php
+++ b/components/Git/Model/class-treeentry.php
@@ -57,7 +57,7 @@ class TreeEntry {
 		}
 	}
 
-	const FILE_MODE_DIRECTORY              = '040000';
+	const FILE_MODE_DIRECTORY              = '40000';
 	const FILE_MODE_REGULAR_NON_EXECUTABLE = '100644';
 	const FILE_MODE_REGULAR_EXECUTABLE     = '100755';
 	const FILE_MODE_SYMBOLIC_LINK          = '120000';

--- a/components/Git/Tests/GitTreeParserTest.php
+++ b/components/Git/Tests/GitTreeParserTest.php
@@ -28,7 +28,7 @@ class GitTreeParserTest extends TestCase {
 		$this->assertTrue( $tree_parser->next() );
 		$entry = $tree_parser->get_tree_entry();
 		$this->assertEquals( '.github', $entry->name );
-		$this->assertEquals( '040000', $entry->get_mode_bucket() );
+		$this->assertEquals( '40000', $entry->get_mode_bucket() );
 		$this->assertEquals( '614260657b661e57774e4f9663c09d5e252079bd', $entry->hash );
 
 		$this->assertTrue( $tree_parser->next() );

--- a/components/Git/Tests/PackParserTest.php
+++ b/components/Git/Tests/PackParserTest.php
@@ -111,7 +111,7 @@ BODY
 		$keys        = array_keys( $tree->entries );
 		$first_entry = $tree->entries[ $keys[0] ];
 		$this->assertEquals( '.github', $first_entry->name );
-		$this->assertEquals( '040000', $first_entry->get_mode_bucket() );
+		$this->assertEquals( '40000', $first_entry->get_mode_bucket() );
 		$this->assertEquals( '614260657b661e57774e4f9663c09d5e252079bd', $first_entry->hash );
 
 		$second_entry = $tree->entries[ $keys[1] ];

--- a/plugins/wp-origin/class-wp-origin-plugin.php
+++ b/plugins/wp-origin/class-wp-origin-plugin.php
@@ -1,7 +1,7 @@
 <?php
 
 use WordPress\DataLiberation\DataFormatConsumer\BlocksWithMetadata;
-use WordPress\Filesystem\LocalFilesystem;
+use WordPress\Filesystem\InMemoryFilesystem;
 use WordPress\Git\GitEndpoint;
 use WordPress\Git\GitException;
 use WordPress\Git\GitRepository;
@@ -11,17 +11,46 @@ use WordPress\Markdown\MarkdownConsumer;
 use WordPress\Markdown\MarkdownProducer;
 
 class WP_Origin_Plugin {
-	const DEFAULT_BRANCH  = 'trunk';
-	const ROUTE_NAMESPACE = 'git/v1';
-	const ROUTE_PATTERN   = '/md\.git(?P<path>/.*)?';
-	const EPOCH_TIMESTAMP = 946684800;
+	const DEFAULT_BRANCH          = 'trunk';
+	const ROUTE_NAMESPACE         = 'git/v1';
+	const ROUTE_PATTERN           = '/md\.git(?P<path>/.*)?';
+	const EPOCH_TIMESTAMP         = 946684800;
+	const COMMIT_POST_TYPE        = 'wp_origin_commit';
+	const HEAD_OPTION             = 'wp_origin_head_commit_id';
+	const MARKDOWN_META_KEY       = '_wp_origin_markdown';
+	const COMMIT_MESSAGE_META_KEY = '_wp_origin_commit_message';
+	const COMMIT_AUTHOR_META_KEY  = '_wp_origin_commit_author';
+	const COMMIT_AUTHOR_DATE_META = '_wp_origin_commit_author_date';
+	const COMMITTER_META_KEY      = '_wp_origin_committer';
+	const COMMITTER_DATE_META     = '_wp_origin_committer_date';
 
 	private static $supported_post_types = array( 'post', 'page' );
 
 	public static function bootstrap() {
+		add_action( 'init', array( __CLASS__, 'register_commit_post_type' ) );
 		add_action( 'rest_api_init', array( __CLASS__, 'register_routes' ) );
 		add_filter( 'rest_post_dispatch', array( __CLASS__, 'add_authentication_challenge' ), 10, 3 );
 		add_filter( 'rest_pre_serve_request', array( __CLASS__, 'serve_git_response' ), 10, 4 );
+	}
+
+	public static function register_commit_post_type() {
+		register_post_type(
+			self::COMMIT_POST_TYPE,
+			array(
+				'public'             => false,
+				'show_ui'            => false,
+				'show_in_rest'       => false,
+				'exclude_from_search' => true,
+				'query_var'          => false,
+				'rewrite'            => false,
+				'delete_with_user'   => false,
+				'hierarchical'       => true,
+				'supports'           => array( 'title', 'editor', 'author', 'page-attributes' ),
+				'labels'             => array(
+					'name' => 'WP Origin Commits',
+				),
+			)
+		);
 	}
 
 	public static function register_routes() {
@@ -58,18 +87,15 @@ class WP_Origin_Plugin {
 	}
 
 	public static function handle_rest_request( WP_REST_Request $request ) {
-		$repository_path = null;
-		// Fail closed if PHP would otherwise emit warnings into the Git packet stream.
 		$previous_error_handler = set_error_handler( array( __CLASS__, 'throw_on_php_warning' ) ); // phpcs:ignore
 
 		try {
-			$repository_data = self::open_repository();
-			$repository      = $repository_data['repository'];
-			$repository_path = $repository_data['path'];
+			$repository = self::open_repository();
 			self::sync_repository_from_wordpress( $repository );
 
 			$git_path     = self::build_git_path( $request );
 			$request_body = file_get_contents( 'php://input' );
+			$current_head = $repository->get_branch_tip( 'refs/heads/' . self::DEFAULT_BRANCH );
 
 			$push_header = null;
 			if ( self::is_push_request( $git_path ) ) {
@@ -81,7 +107,6 @@ class WP_Origin_Plugin {
 					);
 				}
 
-				$current_head = $repository->get_branch_tip( 'refs/heads/' . self::DEFAULT_BRANCH );
 				if ( $push_header['old_oid'] !== $current_head ) {
 					return self::build_protocol_error_response(
 						'git-receive-pack',
@@ -118,7 +143,6 @@ class WP_Origin_Plugin {
 			);
 		} finally {
 			restore_error_handler();
-			self::delete_directory( $repository_path );
 		}
 	}
 
@@ -145,6 +169,7 @@ class WP_Origin_Plugin {
 		}
 
 		echo $result->get_data();
+
 		return true;
 	}
 
@@ -200,9 +225,8 @@ class WP_Origin_Plugin {
 	}
 
 	private static function open_repository() {
-		$repository_path = trailingslashit( sys_get_temp_dir() ) . 'wp-origin-' . wp_generate_uuid4();
-		$repository      = new GitRepository(
-			LocalFilesystem::create( $repository_path ),
+		$repository = new GitRepository(
+			InMemoryFilesystem::create(),
 			array(
 				'default_branch' => self::DEFAULT_BRANCH,
 			)
@@ -216,70 +240,161 @@ class WP_Origin_Plugin {
 		}
 		$repository->set_branch_tip( 'HEAD', 'ref: refs/heads/' . self::DEFAULT_BRANCH );
 
-		return array(
-			'path'       => $repository_path,
-			'repository' => $repository,
+		self::load_repository_history( $repository );
+
+		return $repository;
+	}
+
+	private static function load_repository_history( GitRepository $repository ) {
+		$commits           = self::get_persisted_commits();
+		$previous_manifest = array();
+
+		foreach ( $commits as $commit_post ) {
+			$manifest = self::get_commit_manifest_from_post( $commit_post );
+			$updates  = self::get_manifest_update_bytes( $previous_manifest, $manifest );
+			$deletes  = self::get_manifest_deletes( $previous_manifest, $manifest );
+			$commit   = array(
+				'message'        => (string) get_post_meta( $commit_post->ID, self::COMMIT_MESSAGE_META_KEY, true ),
+				'author'         => (string) get_post_meta( $commit_post->ID, self::COMMIT_AUTHOR_META_KEY, true ),
+				'author_date'    => (string) get_post_meta( $commit_post->ID, self::COMMIT_AUTHOR_DATE_META, true ),
+				'committer'      => (string) get_post_meta( $commit_post->ID, self::COMMITTER_META_KEY, true ),
+				'committer_date' => (string) get_post_meta( $commit_post->ID, self::COMMITTER_DATE_META, true ),
+			);
+
+			$commit_oid = $repository->commit(
+				array(
+					'updates' => $updates,
+					'deletes' => $deletes,
+					'commit'  => $commit,
+				)
+			);
+
+			if ( $commit_oid !== $commit_post->post_name ) {
+				throw new Exception(
+					sprintf(
+						'Stored WP Origin history does not match the reconstructed Git history for commit %s (rebuilt as %s).',
+						$commit_post->post_name,
+						$commit_oid
+					)
+				);
+			}
+
+			$previous_manifest = $manifest;
+		}
+	}
+
+	private static function get_persisted_commits() {
+		$head_commit_id = intval( get_option( self::HEAD_OPTION, 0 ) );
+		if ( ! $head_commit_id ) {
+			return array();
+		}
+
+		$commits = array();
+		$visited = array();
+		while ( $head_commit_id ) {
+			if ( isset( $visited[ $head_commit_id ] ) ) {
+				throw new Exception( 'WP Origin commit history is cyclic.' );
+			}
+			$visited[ $head_commit_id ] = true;
+
+			$commit_post = get_post( $head_commit_id );
+			if ( ! $commit_post || self::COMMIT_POST_TYPE !== $commit_post->post_type ) {
+				throw new Exception( 'WP Origin HEAD points to a missing commit.' );
+			}
+
+			$commits[]      = $commit_post;
+			$head_commit_id = intval( $commit_post->post_parent );
+		}
+
+		return array_reverse( $commits );
+	}
+
+	private static function get_head_commit_post() {
+		$head_commit_id = intval( get_option( self::HEAD_OPTION, 0 ) );
+		if ( ! $head_commit_id ) {
+			return null;
+		}
+
+		$commit_post = get_post( $head_commit_id );
+		if ( ! $commit_post || self::COMMIT_POST_TYPE !== $commit_post->post_type ) {
+			return null;
+		}
+
+		return $commit_post;
+	}
+
+	private static function get_commit_post_by_oid( $oid ) {
+		$commits = get_posts(
+			array(
+				'name'           => $oid,
+				'post_type'      => self::COMMIT_POST_TYPE,
+				'post_status'    => 'private',
+				'posts_per_page' => 1,
+			)
 		);
+
+		if ( empty( $commits ) ) {
+			return null;
+		}
+
+		return $commits[0];
+	}
+
+	private static function get_commit_manifest_from_post( WP_Post $commit_post ) {
+		$manifest = json_decode( $commit_post->post_content, true );
+		if ( ! is_array( $manifest ) ) {
+			return array();
+		}
+
+		foreach ( $manifest as $path => $revision_id ) {
+			$manifest[ $path ] = intval( $revision_id );
+		}
+		ksort( $manifest );
+
+		return $manifest;
 	}
 
 	private static function sync_repository_from_wordpress( GitRepository $repository ) {
-		$exported_files = self::export_wordpress_content();
-		$current_files  = array();
+		$exported_files    = self::export_wordpress_content();
+		$head_commit_post  = self::get_head_commit_post();
+		$previous_manifest = $head_commit_post ? self::get_commit_manifest_from_post( $head_commit_post ) : array();
+		$new_manifest      = array();
+		$commit_timestamp  = self::EPOCH_TIMESTAMP;
 
-		try {
-			$current_head = $repository->get_branch_tip( 'refs/heads/' . self::DEFAULT_BRANCH );
-			if ( ! Commit::is_null_hash( $current_head ) ) {
-				$current_files = self::read_markdown_files_from_commit( $repository, $current_head );
+		foreach ( $exported_files as $path => $entry ) {
+			$markdown = $entry['markdown'];
+			$post     = $entry['post'];
+
+			if ( isset( $previous_manifest[ $path ] ) && self::get_markdown_for_revision( $previous_manifest[ $path ] ) === $markdown ) {
+				$new_manifest[ $path ] = $previous_manifest[ $path ];
+			} else {
+				$new_manifest[ $path ] = self::capture_post_snapshot( $post, $markdown );
 			}
-		} catch ( GitException $exception ) {
-			$current_head = Commit::NULL_HASH;
+
+			$maybe_timestamp = self::timestamp_from_gmt_string( $post->post_modified_gmt );
+			if ( false !== $maybe_timestamp ) {
+				$commit_timestamp = max( $commit_timestamp, $maybe_timestamp );
+			} else {
+				$maybe_timestamp = self::timestamp_from_gmt_string( $post->post_date_gmt );
+				if ( false !== $maybe_timestamp ) {
+					$commit_timestamp = max( $commit_timestamp, $maybe_timestamp );
+				}
+			}
 		}
 
-		$updates = array();
-		foreach ( $exported_files as $path => $contents ) {
-			if ( ! isset( $current_files[ $path ] ) || $current_files[ $path ] !== $contents ) {
-				$updates[ $path ] = $contents;
-			}
-		}
-
-		$deletes = array();
-		foreach ( $current_files as $path => $contents ) {
-			if ( ! isset( $exported_files[ $path ] ) ) {
-				$deletes[] = $path;
-			}
-		}
-
-		if ( empty( $updates ) && empty( $deletes ) ) {
+		if ( self::manifests_are_equal( $previous_manifest, $new_manifest ) ) {
 			return;
 		}
 
-		$commit_timestamp = self::EPOCH_TIMESTAMP;
-		foreach ( $exported_files as $path => $contents ) {
-			$metadata = self::parse_markdown_metadata( $contents );
-			if ( isset( $metadata['modified_gmt'] ) ) {
-				$maybe_timestamp = strtotime( $metadata['modified_gmt'] . ' UTC' );
-				if ( false !== $maybe_timestamp ) {
-					$commit_timestamp = max( $commit_timestamp, $maybe_timestamp );
-					continue;
-				}
-			}
-			if ( isset( $metadata['date_gmt'] ) ) {
-				$maybe_timestamp = strtotime( $metadata['date_gmt'] . ' UTC' );
-				if ( false !== $maybe_timestamp ) {
-					$commit_timestamp = max( $commit_timestamp, $maybe_timestamp );
-				}
-			}
-		}
-
-		$repository->commit(
+		self::commit_manifest_to_repository(
+			$repository,
+			$new_manifest,
 			array(
-				'updates' => $updates,
-				'deletes' => $deletes,
-				'commit'  => array(
-					'message'        => 'Sync from WordPress',
-					'author_date'    => gmdate( Commit::DATE_FORMAT, $commit_timestamp ),
-					'committer_date' => gmdate( Commit::DATE_FORMAT, $commit_timestamp ),
-				),
+				'message'        => 'Sync from WordPress',
+				'author'         => self::get_repository_identity( $repository ),
+				'author_date'    => gmdate( Commit::DATE_FORMAT, $commit_timestamp ),
+				'committer'      => self::get_repository_identity( $repository ),
+				'committer_date' => gmdate( Commit::DATE_FORMAT, $commit_timestamp ),
 			)
 		);
 	}
@@ -311,14 +426,18 @@ class WP_Origin_Plugin {
 				'modified_gmt' => array( $post->post_modified_gmt ),
 			);
 
-			$producer       = new MarkdownProducer(
+			$producer = new MarkdownProducer(
 				new BlocksWithMetadata(
 					$post->post_content,
 					$metadata
 				)
 			);
-			$path           = self::build_markdown_path( $post->post_type, $post->post_name );
-			$files[ $path ] = $producer->produce();
+			$path     = self::build_markdown_path( $post->post_type, $post->post_name );
+
+			$files[ $path ] = array(
+				'post'     => $post,
+				'markdown' => $producer->produce(),
+			);
 		}
 
 		ksort( $files );
@@ -330,20 +449,157 @@ class WP_Origin_Plugin {
 		return ltrim( $post_type . '/' . $slug . '.md', '/' );
 	}
 
-	private static function apply_repository_changes_to_wordpress( GitRepository $repository, $old_commit, $new_commit ) {
-		$old_files = Commit::is_null_hash( $old_commit ) ? array() : self::read_markdown_files_from_commit( $repository, $old_commit );
-		$new_files = self::read_markdown_files_from_commit( $repository, $new_commit );
+	private static function commit_manifest_to_repository( GitRepository $repository, $manifest, $commit_meta ) {
+		$head_commit_post  = self::get_head_commit_post();
+		$previous_manifest = $head_commit_post ? self::get_commit_manifest_from_post( $head_commit_post ) : array();
+		$updates           = self::get_manifest_update_bytes( $previous_manifest, $manifest );
+		$deletes           = self::get_manifest_deletes( $previous_manifest, $manifest );
+		$commit_oid        = $repository->commit(
+			array(
+				'updates' => $updates,
+				'deletes' => $deletes,
+				'commit'  => $commit_meta,
+			)
+		);
 
+		self::persist_repository_commit( $repository, $commit_oid, $manifest );
+
+		return $commit_oid;
+	}
+
+	private static function persist_repository_commit( GitRepository $repository, $commit_oid, $manifest ) {
+		$existing_commit = self::get_commit_post_by_oid( $commit_oid );
+		if ( $existing_commit ) {
+			update_option( self::HEAD_OPTION, $existing_commit->ID, false );
+
+			return $existing_commit->ID;
+		}
+
+		$commit            = $repository->read_object( $commit_oid )->as_commit();
+		$parent_commit_oid = empty( $commit->parents ) ? Commit::NULL_HASH : $commit->get_first_parent_hash();
+		$parent_commit     = Commit::is_null_hash( $parent_commit_oid ) ? null : self::get_commit_post_by_oid( $parent_commit_oid );
+		if ( ! Commit::is_null_hash( $parent_commit_oid ) && ! $parent_commit ) {
+			throw new Exception( 'Push rejected because the parent commit is missing from WordPress storage.' );
+		}
+
+		$commit_date_gmt = self::git_date_to_mysql_gmt( $commit->committer_date );
+		$postarr         = array(
+			'post_type'    => self::COMMIT_POST_TYPE,
+			'post_status'  => 'private',
+			'post_name'    => $commit_oid,
+			'post_title'   => self::get_commit_subject( $commit->message ),
+			'post_content' => self::encode_manifest( $manifest ),
+			'post_parent'  => $parent_commit ? $parent_commit->ID : 0,
+		);
+
+		if ( $commit_date_gmt ) {
+			$postarr['post_date_gmt'] = $commit_date_gmt;
+			$postarr['post_date']     = get_date_from_gmt( $commit_date_gmt );
+		}
+		if ( get_current_user_id() ) {
+			$postarr['post_author'] = get_current_user_id();
+		}
+
+		$commit_post_id = wp_insert_post( wp_slash( $postarr ), true );
+		if ( is_wp_error( $commit_post_id ) ) {
+			throw new Exception( $commit_post_id->get_error_message() );
+		}
+
+		update_post_meta( $commit_post_id, self::COMMIT_MESSAGE_META_KEY, $commit->message );
+		update_post_meta( $commit_post_id, self::COMMIT_AUTHOR_META_KEY, $commit->author );
+		update_post_meta( $commit_post_id, self::COMMIT_AUTHOR_DATE_META, $commit->author_date );
+		update_post_meta( $commit_post_id, self::COMMITTER_META_KEY, $commit->committer );
+		update_post_meta( $commit_post_id, self::COMMITTER_DATE_META, $commit->committer_date );
+		update_option( self::HEAD_OPTION, $commit_post_id, false );
+
+		return $commit_post_id;
+	}
+
+	private static function apply_repository_changes_to_wordpress( GitRepository $repository, $old_commit, $new_commit ) {
+		$commit_hashes     = self::get_push_commit_hashes( $repository, $old_commit, $new_commit );
+		$head_commit_post  = self::get_head_commit_post();
+		$previous_manifest = $head_commit_post ? self::get_commit_manifest_from_post( $head_commit_post ) : array();
+
+		foreach ( $commit_hashes as $index => $commit_hash ) {
+			$commit = $repository->read_object( $commit_hash )->as_commit();
+			self::validate_push_commit( $repository, $commit );
+
+			$parent_hash = empty( $commit->parents ) ? Commit::NULL_HASH : $commit->get_first_parent_hash();
+			$old_files   = Commit::is_null_hash( $parent_hash ) ? array() : self::read_markdown_files_from_commit( $repository, $parent_hash );
+			$new_files   = self::read_markdown_files_from_commit( $repository, $commit_hash );
+
+			$previous_manifest = self::apply_single_commit_to_wordpress(
+				$old_files,
+				$new_files,
+				$previous_manifest,
+				0 !== $index
+			);
+
+			self::persist_repository_commit( $repository, $commit_hash, $previous_manifest );
+		}
+	}
+
+	private static function get_push_commit_hashes( GitRepository $repository, $old_commit, $new_commit ) {
+		if ( Commit::is_null_hash( $old_commit ) ) {
+			$commit_hashes = array();
+			$current_hash  = $new_commit;
+
+			while ( ! Commit::is_null_hash( $current_hash ) ) {
+				$commit_hashes[] = $current_hash;
+				$commit          = $repository->read_object( $current_hash )->as_commit();
+				if ( count( $commit->parents ) > 1 ) {
+					throw new Exception( 'Push rejected because merge commits are not supported yet.' );
+				}
+				$current_hash = empty( $commit->parents ) ? Commit::NULL_HASH : $commit->get_first_parent_hash();
+			}
+
+			return array_reverse( $commit_hashes );
+		}
+
+		return array_reverse(
+			$repository->get_commits_range(
+				$new_commit,
+				$old_commit,
+				array(
+					'include_ancestor' => false,
+				)
+			)
+		);
+	}
+
+	private static function validate_push_commit( GitRepository $repository, Commit $commit ) {
+		if ( count( $commit->parents ) > 1 ) {
+			throw new Exception( 'Push rejected because merge commits are not supported yet.' );
+		}
+
+		if ( empty( $commit->parents ) ) {
+			return;
+		}
+
+		$parent_commit = $repository->read_object( $commit->get_first_parent_hash() )->as_commit();
+		if ( $parent_commit->tree === $commit->tree ) {
+			throw new Exception( 'Push rejected because empty commits are not supported yet.' );
+		}
+	}
+
+	private static function apply_single_commit_to_wordpress( $old_files, $new_files, $previous_manifest, $skip_modified_checks ) {
+		$next_manifest    = $previous_manifest;
 		$updated_post_ids = array();
+
 		foreach ( $new_files as $path => $contents ) {
 			if ( isset( $old_files[ $path ] ) && $old_files[ $path ] === $contents ) {
 				continue;
 			}
 
-			$post_id = self::upsert_post_from_markdown( $path, $contents );
-			if ( $post_id ) {
-				$updated_post_ids[ $post_id ] = true;
-			}
+			$post_id                      = self::upsert_post_from_markdown(
+				$path,
+				$contents,
+				array(
+					'skip_modified_check' => $skip_modified_checks,
+				)
+			);
+			$updated_post_ids[ $post_id ] = true;
+			$next_manifest[ $path ]       = self::capture_post_snapshot( get_post( $post_id ), $contents );
 		}
 
 		foreach ( $old_files as $path => $contents ) {
@@ -356,11 +612,14 @@ class WP_Origin_Plugin {
 			if ( ! $post_id ) {
 				$post_id = self::find_post_id_by_path_metadata( $path, $metadata );
 			}
+
+			unset( $next_manifest[ $path ] );
+
 			if ( ! $post_id || isset( $updated_post_ids[ $post_id ] ) ) {
 				continue;
 			}
 
-			if ( isset( $metadata['modified_gmt'] ) ) {
+			if ( ! $skip_modified_checks && isset( $metadata['modified_gmt'] ) ) {
 				$current_modified = get_post_field( 'post_modified_gmt', $post_id );
 				if ( $current_modified && $current_modified !== $metadata['modified_gmt'] ) {
 					throw new Exception( 'Push rejected because a deleted post changed in WordPress. Pull the latest changes and try again.' );
@@ -372,9 +631,13 @@ class WP_Origin_Plugin {
 				throw new Exception( 'Push rejected because WordPress could not trash the deleted content.' );
 			}
 		}
+
+		ksort( $next_manifest );
+
+		return $next_manifest;
 	}
 
-	private static function upsert_post_from_markdown( $path, $markdown ) {
+	private static function upsert_post_from_markdown( $path, $markdown, $options = array() ) {
 		$post_type = self::path_to_post_type( $path );
 		$slug      = self::path_to_slug( $path );
 		$consumer  = new MarkdownConsumer( $markdown );
@@ -399,7 +662,12 @@ class WP_Origin_Plugin {
 			$existing_post = $post_id ? get_post( $post_id ) : null;
 		}
 
-		if ( $existing_post && isset( $metadata['modified_gmt'] ) && $existing_post->post_modified_gmt !== $metadata['modified_gmt'] ) {
+		if (
+			$existing_post &&
+			empty( $options['skip_modified_check'] ) &&
+			isset( $metadata['modified_gmt'] ) &&
+			$existing_post->post_modified_gmt !== $metadata['modified_gmt']
+		) {
 			throw new Exception( 'Push rejected because WordPress content changed since the last pull.' );
 		}
 
@@ -433,6 +701,121 @@ class WP_Origin_Plugin {
 		}
 
 		return $post_id;
+	}
+
+	private static function capture_post_snapshot( WP_Post $post, $markdown ) {
+		$revision_id = 0;
+
+		if ( function_exists( '_wp_put_post_revision' ) ) {
+			$revision_id = _wp_put_post_revision( get_post( $post->ID, ARRAY_A ) );
+		}
+
+		if ( ! $revision_id && function_exists( 'wp_save_post_revision' ) ) {
+			wp_save_post_revision( $post->ID );
+			$revisions = wp_get_post_revisions(
+				$post->ID,
+				array(
+					'posts_per_page' => 1,
+					'orderby'        => 'ID',
+					'order'          => 'DESC',
+				)
+			);
+			if ( ! empty( $revisions ) ) {
+				$revision    = reset( $revisions );
+				$revision_id = $revision->ID;
+			}
+		}
+
+		if ( is_wp_error( $revision_id ) || ! $revision_id ) {
+			throw new Exception( 'WP Origin could not create a revision snapshot for this post.' );
+		}
+
+		update_metadata( 'post', $revision_id, self::MARKDOWN_META_KEY, $markdown );
+
+		return intval( $revision_id );
+	}
+
+	private static function get_manifest_update_bytes( $previous_manifest, $manifest ) {
+		$updates = array();
+
+		foreach ( $manifest as $path => $revision_id ) {
+			if ( isset( $previous_manifest[ $path ] ) && intval( $previous_manifest[ $path ] ) === intval( $revision_id ) ) {
+				continue;
+			}
+
+			$updates[ $path ] = self::get_markdown_for_revision( $revision_id );
+		}
+
+		return $updates;
+	}
+
+	private static function get_manifest_deletes( $previous_manifest, $manifest ) {
+		$deletes = array();
+
+		foreach ( $previous_manifest as $path => $revision_id ) {
+			unset( $revision_id );
+			if ( ! isset( $manifest[ $path ] ) ) {
+				$deletes[] = $path;
+			}
+		}
+
+		return $deletes;
+	}
+
+	private static function get_markdown_for_revision( $revision_id ) {
+		$markdown = get_metadata( 'post', $revision_id, self::MARKDOWN_META_KEY, true );
+		if ( ! is_string( $markdown ) ) {
+			throw new Exception( 'WP Origin is missing Markdown bytes for a stored revision snapshot.' );
+		}
+
+		return $markdown;
+	}
+
+	private static function manifests_are_equal( $left, $right ) {
+		ksort( $left );
+		ksort( $right );
+
+		return $left === $right;
+	}
+
+	private static function encode_manifest( $manifest ) {
+		ksort( $manifest );
+		$encoded_manifest = wp_json_encode( $manifest );
+		if ( false === $encoded_manifest ) {
+			throw new Exception( 'WP Origin could not encode the commit manifest.' );
+		}
+
+		return $encoded_manifest;
+	}
+
+	private static function get_repository_identity( GitRepository $repository ) {
+		return $repository->get_config_value( 'user.name' ) . ' <' . $repository->get_config_value( 'user.email' ) . '>';
+	}
+
+	private static function get_commit_subject( $message ) {
+		$lines = preg_split( "/\r\n|\n|\r/", $message );
+		$line  = is_array( $lines ) && isset( $lines[0] ) ? trim( $lines[0] ) : '';
+
+		return '' === $line ? 'WP Origin Commit' : $line;
+	}
+
+	private static function timestamp_from_gmt_string( $gmt_string ) {
+		if ( ! is_string( $gmt_string ) || '' === $gmt_string || '0000-00-00 00:00:00' === $gmt_string ) {
+			return false;
+		}
+
+		return strtotime( $gmt_string . ' UTC' );
+	}
+
+	private static function git_date_to_mysql_gmt( $git_date ) {
+		if ( ! is_string( $git_date ) ) {
+			return '';
+		}
+		if ( ! preg_match( '/^(\d+)\s+[+-]\d{4}$/', $git_date, $matches ) ) {
+			return '';
+		}
+
+		return gmdate( 'Y-m-d H:i:s', intval( $matches[1] ) );
 	}
 
 	private static function find_post_id_by_path_metadata( $path, $metadata ) {
@@ -548,26 +931,6 @@ class WP_Origin_Plugin {
 		}
 
 		return $message;
-	}
-
-	private static function delete_directory( $path ) {
-		if ( ! is_string( $path ) || '' === $path || ! is_dir( $path ) ) {
-			return;
-		}
-
-		$iterator = new RecursiveIteratorIterator(
-			new RecursiveDirectoryIterator( $path, FilesystemIterator::SKIP_DOTS ),
-			RecursiveIteratorIterator::CHILD_FIRST
-		);
-		foreach ( $iterator as $item ) {
-			if ( $item->isDir() ) {
-				rmdir( $item->getPathname() );
-			} else {
-				unlink( $item->getPathname() );
-			}
-		}
-
-		rmdir( $path );
 	}
 
 	public static function throw_on_php_warning( $severity, $message, $file, $line ) {

--- a/plugins/wp-origin/class-wp-origin-plugin.php
+++ b/plugins/wp-origin/class-wp-origin-plugin.php
@@ -24,7 +24,8 @@ class WP_Origin_Plugin {
 	const COMMITTER_META_KEY      = '_wp_origin_committer';
 	const COMMITTER_DATE_META     = '_wp_origin_committer_date';
 
-	private static $supported_post_types = array( 'post', 'page' );
+	private static $supported_post_types    = array( 'post', 'page' );
+	private static $supported_post_statuses = array( 'publish', 'draft', 'pending', 'private', 'future' );
 
 	public static function bootstrap() {
 		add_action( 'init', array( __CLASS__, 'register_commit_post_type' ) );
@@ -403,7 +404,7 @@ class WP_Origin_Plugin {
 		$posts = get_posts(
 			array(
 				'post_type'      => self::$supported_post_types,
-				'post_status'    => array( 'publish', 'draft', 'pending', 'private', 'future' ),
+				'post_status'    => self::$supported_post_statuses,
 				'posts_per_page' => -1,
 				'orderby'        => 'ID',
 				'order'          => 'ASC',
@@ -516,9 +517,21 @@ class WP_Origin_Plugin {
 	}
 
 	private static function apply_repository_changes_to_wordpress( GitRepository $repository, $old_commit, $new_commit ) {
+		$commit_plans      = self::build_push_plan( $repository, $old_commit, $new_commit );
+		$head_commit_post  = self::get_head_commit_post();
+		$previous_manifest = $head_commit_post ? self::get_commit_manifest_from_post( $head_commit_post ) : array();
+
+		foreach ( $commit_plans as $commit_plan ) {
+			$previous_manifest = self::apply_single_commit_plan_to_wordpress( $commit_plan, $previous_manifest );
+			self::persist_repository_commit( $repository, $commit_plan['commit_hash'], $previous_manifest );
+		}
+	}
+
+	private static function build_push_plan( GitRepository $repository, $old_commit, $new_commit ) {
 		$commit_hashes     = self::get_push_commit_hashes( $repository, $old_commit, $new_commit );
 		$head_commit_post  = self::get_head_commit_post();
 		$previous_manifest = $head_commit_post ? self::get_commit_manifest_from_post( $head_commit_post ) : array();
+		$commit_plans      = array();
 
 		foreach ( $commit_hashes as $index => $commit_hash ) {
 			$commit = $repository->read_object( $commit_hash )->as_commit();
@@ -528,15 +541,18 @@ class WP_Origin_Plugin {
 			$old_files   = Commit::is_null_hash( $parent_hash ) ? array() : self::read_markdown_files_from_commit( $repository, $parent_hash );
 			$new_files   = self::read_markdown_files_from_commit( $repository, $commit_hash );
 
-			$previous_manifest = self::apply_single_commit_to_wordpress(
+			$commit_plan                = self::build_single_commit_plan(
 				$old_files,
 				$new_files,
 				$previous_manifest,
 				0 !== $index
 			);
-
-			self::persist_repository_commit( $repository, $commit_hash, $previous_manifest );
+			$commit_plan['commit_hash'] = $commit_hash;
+			$commit_plans[]             = $commit_plan;
+			$previous_manifest          = $commit_plan['manifest'];
 		}
+
+		return $commit_plans;
 	}
 
 	private static function get_push_commit_hashes( GitRepository $repository, $old_commit, $new_commit ) {
@@ -582,24 +598,28 @@ class WP_Origin_Plugin {
 		}
 	}
 
-	private static function apply_single_commit_to_wordpress( $old_files, $new_files, $previous_manifest, $skip_modified_checks ) {
+	private static function build_single_commit_plan( $old_files, $new_files, $previous_manifest, $skip_modified_checks ) {
 		$next_manifest    = $previous_manifest;
 		$updated_post_ids = array();
+		$operations       = array();
 
 		foreach ( $new_files as $path => $contents ) {
 			if ( isset( $old_files[ $path ] ) && $old_files[ $path ] === $contents ) {
 				continue;
 			}
 
-			$post_id                      = self::upsert_post_from_markdown(
+			$operation              = self::plan_post_upsert_from_markdown(
 				$path,
 				$contents,
 				array(
 					'skip_modified_check' => $skip_modified_checks,
 				)
 			);
-			$updated_post_ids[ $post_id ] = true;
-			$next_manifest[ $path ]       = self::capture_post_snapshot( get_post( $post_id ), $contents );
+			$operations[]           = $operation;
+			$next_manifest[ $path ] = 0;
+			if ( $operation['post_id'] ) {
+				$updated_post_ids[ $operation['post_id'] ] = true;
+			}
 		}
 
 		foreach ( $old_files as $path => $contents ) {
@@ -615,20 +635,50 @@ class WP_Origin_Plugin {
 
 			unset( $next_manifest[ $path ] );
 
-			if ( ! $post_id || isset( $updated_post_ids[ $post_id ] ) ) {
+			if ( isset( $updated_post_ids[ $post_id ] ) ) {
 				continue;
 			}
 
-			if ( ! $skip_modified_checks && isset( $metadata['modified_gmt'] ) ) {
+			if ( $post_id && ! $skip_modified_checks && isset( $metadata['modified_gmt'] ) ) {
 				$current_modified = get_post_field( 'post_modified_gmt', $post_id );
 				if ( $current_modified && $current_modified !== $metadata['modified_gmt'] ) {
 					throw new Exception( 'Push rejected because a deleted post changed in WordPress. Pull the latest changes and try again.' );
 				}
 			}
-			self::assert_can_edit_post( $post_id );
+			if ( $post_id ) {
+				self::assert_can_edit_post( $post_id );
+			}
 
-			if ( false === wp_trash_post( $post_id ) ) {
-				throw new Exception( 'Push rejected because WordPress could not trash the deleted content.' );
+			$operations[] = array(
+				'type'     => 'delete',
+				'path'     => $path,
+				'metadata' => $metadata,
+			);
+		}
+
+		ksort( $next_manifest );
+
+		return array(
+			'manifest'   => $next_manifest,
+			'operations' => $operations,
+		);
+	}
+
+	private static function apply_single_commit_plan_to_wordpress( $commit_plan, $previous_manifest ) {
+		$next_manifest    = $previous_manifest;
+		$updated_post_ids = array();
+
+		foreach ( $commit_plan['operations'] as $operation ) {
+			if ( 'upsert' === $operation['type'] ) {
+				$post_id                             = self::apply_post_upsert_plan( $operation );
+				$updated_post_ids[ $post_id ]        = true;
+				$next_manifest[ $operation['path'] ] = self::capture_post_snapshot( get_post( $post_id ), $operation['contents'] );
+				continue;
+			}
+
+			if ( 'delete' === $operation['type'] ) {
+				unset( $next_manifest[ $operation['path'] ] );
+				self::apply_post_delete_plan( $operation, $updated_post_ids );
 			}
 		}
 
@@ -638,6 +688,12 @@ class WP_Origin_Plugin {
 	}
 
 	private static function upsert_post_from_markdown( $path, $markdown, $options = array() ) {
+		return self::apply_post_upsert_plan(
+			self::plan_post_upsert_from_markdown( $path, $markdown, $options )
+		);
+	}
+
+	private static function plan_post_upsert_from_markdown( $path, $markdown, $options = array() ) {
 		$post_type = self::path_to_post_type( $path );
 		$slug      = self::path_to_slug( $path );
 		$consumer  = new MarkdownConsumer( $markdown );
@@ -653,6 +709,7 @@ class WP_Origin_Plugin {
 		if ( isset( $metadata['slug'] ) && $metadata['slug'] !== $slug ) {
 			throw new Exception( 'Push rejected because the file slug does not match its filename.' );
 		}
+		self::validate_post_status( isset( $metadata['status'] ) ? $metadata['status'] : 'draft', $post_type );
 
 		$post_id = isset( $metadata['id'] ) ? intval( $metadata['id'] ) : 0;
 		if ( $post_id && get_post( $post_id ) ) {
@@ -689,6 +746,27 @@ class WP_Origin_Plugin {
 			$postarr['post_date_gmt'] = $metadata['date_gmt'];
 		}
 
+		return array(
+			'type'      => 'upsert',
+			'path'      => $path,
+			'contents'  => $markdown,
+			'metadata'  => $metadata,
+			'post_id'   => $post_id,
+			'postarr'   => $postarr,
+		);
+	}
+
+	private static function apply_post_upsert_plan( $operation ) {
+		$metadata = $operation['metadata'];
+		$postarr  = $operation['postarr'];
+		$post_id  = isset( $metadata['id'] ) ? intval( $metadata['id'] ) : 0;
+		if ( $post_id && get_post( $post_id ) ) {
+			$existing_post = get_post( $post_id );
+		} else {
+			$post_id       = self::find_post_id_by_path_metadata( $operation['path'], $metadata );
+			$existing_post = $post_id ? get_post( $post_id ) : null;
+		}
+
 		if ( $existing_post ) {
 			$postarr['ID'] = $existing_post->ID;
 			$post_id       = wp_update_post( wp_slash( $postarr ), true );
@@ -701,6 +779,22 @@ class WP_Origin_Plugin {
 		}
 
 		return $post_id;
+	}
+
+	private static function apply_post_delete_plan( $operation, $updated_post_ids ) {
+		$metadata = $operation['metadata'];
+		$post_id  = isset( $metadata['id'] ) ? intval( $metadata['id'] ) : 0;
+		if ( ! $post_id ) {
+			$post_id = self::find_post_id_by_path_metadata( $operation['path'], $metadata );
+		}
+
+		if ( ! $post_id || isset( $updated_post_ids[ $post_id ] ) ) {
+			return;
+		}
+
+		if ( false === wp_trash_post( $post_id ) ) {
+			throw new Exception( 'Push rejected because WordPress could not trash the deleted content.' );
+		}
 	}
 
 	private static function capture_post_snapshot( WP_Post $post, $markdown ) {
@@ -825,7 +919,7 @@ class WP_Origin_Plugin {
 			array(
 				'post_type'      => $post_type,
 				'name'           => $slug,
-				'post_status'    => array( 'publish', 'draft', 'pending', 'private', 'future', 'trash' ),
+				'post_status'    => array_merge( self::$supported_post_statuses, array( 'trash' ) ),
 				'posts_per_page' => 1,
 				'fields'         => 'ids',
 			)
@@ -867,6 +961,20 @@ class WP_Origin_Plugin {
 		return $metadata;
 	}
 
+	private static function validate_post_status( $post_status, $post_type ) {
+		if ( in_array( $post_status, self::$supported_post_statuses, true ) ) {
+			return;
+		}
+
+		throw new Exception(
+			sprintf(
+				'Push rejected because "%s" is not a supported %s status.',
+				$post_status,
+				$post_type
+			)
+		);
+	}
+
 	private static function read_markdown_files_from_commit( GitRepository $repository, $commit_hash ) {
 		$commit = $repository->read_object( $commit_hash )->as_commit();
 		$files  = array();
@@ -890,7 +998,7 @@ class WP_Origin_Plugin {
 				continue;
 			}
 			if ( 'md' !== pathinfo( $path, PATHINFO_EXTENSION ) ) {
-				continue;
+				throw new Exception( 'Push rejected because only Markdown files are supported.' );
 			}
 			$files[ $path ] = $repository->read_object( $entry->hash )->consume_all();
 		}

--- a/plugins/wp-origin/class-wp-origin-plugin.php
+++ b/plugins/wp-origin/class-wp-origin-plugin.php
@@ -23,6 +23,8 @@ class WP_Origin_Plugin {
 	const COMMIT_AUTHOR_DATE_META = '_wp_origin_commit_author_date';
 	const COMMITTER_META_KEY      = '_wp_origin_committer';
 	const COMMITTER_DATE_META     = '_wp_origin_committer_date';
+	const EXACT_BYTES_ENCODING    = 'base64';
+	const COMMIT_SUBJECT_MAX_LEN  = 200;
 
 	private static $supported_post_types    = array( 'post', 'page' );
 	private static $supported_post_statuses = array( 'publish', 'draft', 'pending', 'private', 'future' );
@@ -255,11 +257,11 @@ class WP_Origin_Plugin {
 			$updates  = self::get_manifest_update_bytes( $previous_manifest, $manifest );
 			$deletes  = self::get_manifest_deletes( $previous_manifest, $manifest );
 			$commit   = array(
-				'message'        => (string) get_post_meta( $commit_post->ID, self::COMMIT_MESSAGE_META_KEY, true ),
-				'author'         => (string) get_post_meta( $commit_post->ID, self::COMMIT_AUTHOR_META_KEY, true ),
-				'author_date'    => (string) get_post_meta( $commit_post->ID, self::COMMIT_AUTHOR_DATE_META, true ),
-				'committer'      => (string) get_post_meta( $commit_post->ID, self::COMMITTER_META_KEY, true ),
-				'committer_date' => (string) get_post_meta( $commit_post->ID, self::COMMITTER_DATE_META, true ),
+				'message'        => self::get_stored_post_bytes( $commit_post->ID, self::COMMIT_MESSAGE_META_KEY ),
+				'author'         => self::get_stored_post_bytes( $commit_post->ID, self::COMMIT_AUTHOR_META_KEY ),
+				'author_date'    => self::get_stored_post_bytes( $commit_post->ID, self::COMMIT_AUTHOR_DATE_META ),
+				'committer'      => self::get_stored_post_bytes( $commit_post->ID, self::COMMITTER_META_KEY ),
+				'committer_date' => self::get_stored_post_bytes( $commit_post->ID, self::COMMITTER_DATE_META ),
 			);
 
 			$commit_oid = $repository->commit(
@@ -506,11 +508,11 @@ class WP_Origin_Plugin {
 			throw new Exception( $commit_post_id->get_error_message() );
 		}
 
-		update_post_meta( $commit_post_id, self::COMMIT_MESSAGE_META_KEY, $commit->message );
-		update_post_meta( $commit_post_id, self::COMMIT_AUTHOR_META_KEY, $commit->author );
-		update_post_meta( $commit_post_id, self::COMMIT_AUTHOR_DATE_META, $commit->author_date );
-		update_post_meta( $commit_post_id, self::COMMITTER_META_KEY, $commit->committer );
-		update_post_meta( $commit_post_id, self::COMMITTER_DATE_META, $commit->committer_date );
+		self::update_stored_post_bytes( $commit_post_id, self::COMMIT_MESSAGE_META_KEY, $commit->message );
+		self::update_stored_post_bytes( $commit_post_id, self::COMMIT_AUTHOR_META_KEY, $commit->author );
+		self::update_stored_post_bytes( $commit_post_id, self::COMMIT_AUTHOR_DATE_META, $commit->author_date );
+		self::update_stored_post_bytes( $commit_post_id, self::COMMITTER_META_KEY, $commit->committer );
+		self::update_stored_post_bytes( $commit_post_id, self::COMMITTER_DATE_META, $commit->committer_date );
 		update_option( self::HEAD_OPTION, $commit_post_id, false );
 
 		return $commit_post_id;
@@ -824,7 +826,7 @@ class WP_Origin_Plugin {
 			throw new Exception( 'WP Origin could not create a revision snapshot for this post.' );
 		}
 
-		update_metadata( 'post', $revision_id, self::MARKDOWN_META_KEY, $markdown );
+		self::update_stored_post_bytes( $revision_id, self::MARKDOWN_META_KEY, $markdown );
 
 		return intval( $revision_id );
 	}
@@ -857,12 +859,11 @@ class WP_Origin_Plugin {
 	}
 
 	private static function get_markdown_for_revision( $revision_id ) {
-		$markdown = get_metadata( 'post', $revision_id, self::MARKDOWN_META_KEY, true );
-		if ( ! is_string( $markdown ) ) {
-			throw new Exception( 'WP Origin is missing Markdown bytes for a stored revision snapshot.' );
-		}
-
-		return $markdown;
+		return self::get_stored_post_bytes(
+			$revision_id,
+			self::MARKDOWN_META_KEY,
+			'WP Origin is missing Markdown bytes for a stored revision snapshot.'
+		);
 	}
 
 	private static function manifests_are_equal( $left, $right ) {
@@ -890,7 +891,64 @@ class WP_Origin_Plugin {
 		$lines = preg_split( "/\r\n|\n|\r/", $message );
 		$line  = is_array( $lines ) && isset( $lines[0] ) ? trim( $lines[0] ) : '';
 
+		if ( function_exists( 'wp_check_invalid_utf8' ) ) {
+			$line = wp_check_invalid_utf8( $line, true );
+		}
+		if ( function_exists( 'mb_strlen' ) && function_exists( 'mb_substr' ) ) {
+			if ( mb_strlen( $line ) > self::COMMIT_SUBJECT_MAX_LEN ) {
+				$line = mb_substr( $line, 0, self::COMMIT_SUBJECT_MAX_LEN - 3 ) . '...';
+			}
+		} elseif ( strlen( $line ) > self::COMMIT_SUBJECT_MAX_LEN ) {
+			$line = substr( $line, 0, self::COMMIT_SUBJECT_MAX_LEN - 3 ) . '...';
+		}
+
 		return '' === $line ? 'WP Origin Commit' : $line;
+	}
+
+	private static function update_stored_post_bytes( $post_id, $meta_key, $bytes ) {
+		update_metadata( 'post', $post_id, $meta_key, self::encode_stored_bytes( $bytes ) );
+	}
+
+	private static function get_stored_post_bytes( $post_id, $meta_key, $missing_message = '' ) {
+		$stored_value = get_metadata( 'post', $post_id, $meta_key, true );
+
+		return self::decode_stored_bytes(
+			$stored_value,
+			'' !== $missing_message ? $missing_message : 'WP Origin is missing stored bytes.'
+		);
+	}
+
+	private static function encode_stored_bytes( $bytes ) {
+		return array(
+			'encoding' => self::EXACT_BYTES_ENCODING,
+			'data'     => base64_encode( $bytes ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Persist exact Git-visible bytes through WordPress storage.
+		);
+	}
+
+	private static function decode_stored_bytes( $stored_value, $missing_message ) {
+		if ( is_array( $stored_value ) ) {
+			if (
+				! isset( $stored_value['encoding'] ) ||
+				self::EXACT_BYTES_ENCODING !== $stored_value['encoding'] ||
+				! isset( $stored_value['data'] ) ||
+				! is_string( $stored_value['data'] )
+			) {
+				throw new Exception( $missing_message );
+			}
+
+			$decoded = base64_decode( $stored_value['data'], true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Recover exact Git-visible bytes from WordPress storage.
+			if ( false === $decoded ) {
+				throw new Exception( $missing_message );
+			}
+
+			return $decoded;
+		}
+
+		if ( is_string( $stored_value ) ) {
+			return $stored_value;
+		}
+
+		throw new Exception( $missing_message );
 	}
 
 	private static function timestamp_from_gmt_string( $gmt_string ) {


### PR DESCRIPTION
## Summary

This PR fixes the core persistence bug in `wp-origin`.

Before this change, each Git HTTP request built a fresh temporary repository, projected the current WordPress state into it, served the request, and then discarded the repository. That meant a successful `push` updated WordPress content, but the remote Git history itself was not preserved. On the next `pull`, the server exported a new synthetic snapshot with unrelated ancestry, which is why the `clone -> push -> pull` flow could conflict even when the content changes themselves were valid.

## Persistence model : CPT

The persistence model is intentionally WordPress-native:

- `wp_origin_commit` posts represent synthetic Git commits
- `post_parent` links commits into a linear parent chain
- `post_content` stores the full snapshot manifest for that commit
- revision post meta stores the exact Markdown bytes for each tracked snapshot
- a single option stores the current HEAD commit post ID

At request time, `wp-origin`:

1. loads the persisted commit chain from WordPress
2. replays those commits into an in-memory Git repository
3. exports current WordPress posts/pages into Markdown
4. creates a new synthetic sync commit if WordPress has changed since the last persisted snapshot
5. serves the Git Smart HTTP request from that reconstructed repository

That gives us persistent ancestry without needing a `.git` directory on disk.

## Why this approach

### Why not rely on revisions alone?

Revisions help with per-post history, but Git needs repository history.

A push may change multiple files atomically, delete paths, or create new paths. Git also needs a stable parent chain and access to historical snapshots as Git saw them, not just "the latest revision for each post." Revisions by themselves do not provide repo-wide snapshots or stable commit ancestry.

### Why store full snapshot manifests instead of only per-commit deltas?

A delta-only model would have reduced storage, but it would require replaying history backward to reconstruct unchanged files for older commits. That makes fetch/pull reconstruction more complex and more expensive.

The full-manifest approach is intentionally simpler:

- each commit can be reconstructed directly
- unchanged files are resolved immediately from the manifest
- deletes are represented by omission from the next manifest

This trades storage efficiency for implementation simplicity and predictable read behavior.

### Why store exact Markdown bytes instead of only hashes?

A blob hash alone is not enough to serve historical objects during `clone`, `fetch`, or `pull`. If historical Markdown were regenerated later from current exporter code, even tiny formatting changes could rewrite blob hashes, tree hashes, and commit hashes retroactively.

Persisting the exact exported Markdown bytes on the revision snapshot keeps historical Git-visible content stable.

## Tradeoffs and intentional limitations

This implementation is deliberately scoped.

- The persisted history model is linear. We do not support branches in the stored WordPress-side history yet.
- Merge commits are explicitly rejected for now.
- Empty commits are rejected.
- The commit manifest stores a full snapshot on every commit, which is simpler but duplicates path-to-revision mappings over time.
- The repository is still rebuilt in memory on each request, so this favors storage simplicity over absolute compute efficiency.
- The implementation only tracks the supported content types already exposed by `wp-origin` today: posts and pages.


## Push behavior and conflict handling

For pushes, this PR keeps the existing WordPress-first behavior but persists the Git-side result as part of the same flow. Each pushed commit is:

1. read from the incoming Git history
2. validated
3. applied to WordPress content
4. captured as a new persisted snapshot manifest
5. stored as a synthetic commit in WordPress history

Conflict checks still use the existing content-level stale-change protections based on the Markdown metadata and current WordPress modified timestamps.

## Git layer fix included here

While building and testing this, one lower-level Git issue also surfaced.

The toolkit was encoding directory tree mode as `040000`, while the Git CLI writes tree entries as `40000`. That difference changes tree hashes, which meant a client-pushed commit could not be reconstructed byte-for-byte even when the file blobs were identical.

This PR normalizes directory tree mode handling to `40000` and updates the related Git tests.

Without that fix, the new persistence approach would still fail when rebuilding some client-created commits.

## Follow-ups / future work

- I think we need to simplify front matter and remove the dates because they change with each commit
- it would be ideal if valid markdown once pushed didn't require a pull after.
- we need solid testing with an agent.

