### PR TITLE
Show WP Origin push summary URLs

### DIFF
--- a/bin/test-wp-origin-git-actions.sh
+++ b/bin/test-wp-origin-git-actions.sh
@@ -80,6 +80,16 @@ BASE_URL="http://127.0.0.1:$PORT"
 REMOTE_AUTH_URL="http://$USERNAME:$PASSWORD@127.0.0.1:$PORT/wp-json/git/v1/md.git"
 CLONE_DIR="$WORK_DIR/clone"
 
+assert_push_summary_contains() {
+	OUTPUT="$1"
+	NEEDLE="$2"
+	if ! printf '%s' "$OUTPUT" | grep -Fq "$NEEDLE"; then
+		printf '%s\n' "$OUTPUT"
+		echo "Expected push output to contain: $NEEDLE" >&2
+		exit 1
+	fi
+}
+
 git -c protocol.version=2 clone "$REMOTE_AUTH_URL" "$CLONE_DIR"
 
 test -f "$CLONE_DIR/post/hello-world.md"
@@ -112,7 +122,9 @@ file_put_contents($path, $contents);
 
 git add post/hello-world.md
 git commit -m "Update hello world from Git"
-git push origin trunk
+PUSH_OUTPUT="$(git push origin trunk 2>&1)"
+assert_push_summary_contains "$PUSH_OUTPUT" 'WP Origin applied 1 content change:'
+assert_push_summary_contains "$PUSH_OUTPUT" '/hello-world/'
 
 UPDATED_CONTENT="$(curl -sS -f -H "Authorization: Basic $AUTH_HEADER" "$BASE_URL/wp-json/wp/v2/posts/$POST_ID?context=edit" | php -r '
 $post = json_decode(stream_get_contents(STDIN), true);
@@ -137,7 +149,9 @@ file_put_contents($path, $contents);
 EXACT_COMMIT_MESSAGE='Preserve C:\\Temp\\wp-origin in commit metadata'
 git add post/hello-world.md
 git commit -m "$EXACT_COMMIT_MESSAGE"
-git push origin trunk
+PUSH_OUTPUT="$(git push origin trunk 2>&1)"
+assert_push_summary_contains "$PUSH_OUTPUT" 'WP Origin applied 1 content change:'
+assert_push_summary_contains "$PUSH_OUTPUT" '/hello-world/'
 
 EXACT_CLONE_DIR="$WORK_DIR/exact-clone"
 git -c protocol.version=2 clone "$REMOTE_AUTH_URL" "$EXACT_CLONE_DIR"
@@ -176,7 +190,11 @@ file_put_contents($path, $markdown);
 rm "$CLONE_DIR/page/sample-page.md"
 git add post/created-from-git.md page/page-from-git.md page/sample-page.md
 git commit -m "Create and delete content from Git"
-git push origin trunk
+PUSH_OUTPUT="$(git push origin trunk 2>&1)"
+assert_push_summary_contains "$PUSH_OUTPUT" 'WP Origin applied 3 content changes:'
+assert_push_summary_contains "$PUSH_OUTPUT" '/created-from-git/'
+assert_push_summary_contains "$PUSH_OUTPUT" '/page-from-git/'
+assert_push_summary_contains "$PUSH_OUTPUT" '/sample-page/'
 
 CREATED_POST_CONTENT="$(curl -sS -f -H "Authorization: Basic $AUTH_HEADER" "$BASE_URL/wp-json/wp/v2/posts?slug=created-from-git&context=edit" | php -r '
 $posts = json_decode(stream_get_contents(STDIN), true);

--- a/plugins/wp-origin/class-wp-origin-buffering-response.php
+++ b/plugins/wp-origin/class-wp-origin-buffering-response.php
@@ -21,6 +21,27 @@ class WP_Origin_Buffering_Response implements ResponseWriteStream {
 		$this->body .= $body;
 	}
 
+	public function append_progress_messages( $messages ) {
+		if ( empty( $messages ) ) {
+			return;
+		}
+
+		$progress = '';
+		foreach ( $messages as $message ) {
+			$progress .= WordPress\Git\Protocol\GitProtocolEncoderPipe::encode_packet_line(
+				rtrim( $message ) . "\n",
+				"\x02"
+			);
+		}
+
+		if ( '0000' === substr( $this->body, -4 ) ) {
+			$this->body = substr( $this->body, 0, -4 ) . $progress . '0000';
+			return;
+		}
+
+		$this->body .= $progress;
+	}
+
 	public function close_writing(): void {
 	}
 

--- a/plugins/wp-origin/class-wp-origin-plugin.php
+++ b/plugins/wp-origin/class-wp-origin-plugin.php
@@ -112,11 +112,12 @@ class WP_Origin_Plugin {
 
 			if ( self::is_push_request( $git_path ) ) {
 				try {
-					self::apply_repository_changes_to_wordpress(
+					$push_summary = self::apply_repository_changes_to_wordpress(
 						$repository,
 						$push_header['old_oid'],
 						$push_header['new_oid']
 					);
+					$response->append_progress_messages( self::format_push_summary_messages( $push_summary ) );
 				} catch ( Throwable $exception ) {
 					return self::build_protocol_error_response(
 						'git-receive-pack',
@@ -343,6 +344,7 @@ class WP_Origin_Plugin {
 
 	private static function apply_repository_changes_to_wordpress( GitRepository $repository, $old_commit, $new_commit ) {
 		$commit_hashes = self::get_push_commit_hashes( $repository, $old_commit, $new_commit );
+		$push_summary  = array();
 
 		foreach ( $commit_hashes as $index => $commit_hash ) {
 			// Conflict checks against WordPress's current modified_gmt only
@@ -350,8 +352,13 @@ class WP_Origin_Plugin {
 			// subsequent commit is being applied on top of the WP state we
 			// just produced, so per-file modified_gmt comparisons would
 			// spuriously fail.
-			self::apply_single_commit_to_wordpress( $repository, $commit_hash, 0 !== $index );
+			$push_summary = array_merge(
+				$push_summary,
+				self::apply_single_commit_to_wordpress( $repository, $commit_hash, 0 !== $index )
+			);
 		}
+
+		return $push_summary;
 	}
 
 	private static function apply_single_commit_to_wordpress( GitRepository $repository, $commit_hash, $skip_modified_checks ) {
@@ -365,19 +372,22 @@ class WP_Origin_Plugin {
 		$new_files   = self::read_markdown_files_from_commit( $repository, $commit_hash );
 
 		$updated_post_ids = array();
+		$changes          = array();
 
 		foreach ( $new_files as $path => $contents ) {
 			if ( isset( $old_files[ $path ] ) && $old_files[ $path ] === $contents ) {
 				continue;
 			}
 
-			$post_id = self::upsert_post_from_markdown(
+			$applied = self::upsert_post_from_markdown(
 				$path,
 				$contents,
 				array( 'skip_modified_check' => $skip_modified_checks )
 			);
+			$post_id = $applied['post_id'];
 			if ( $post_id ) {
 				$updated_post_ids[ $post_id ] = true;
+				$changes[]                    = $applied['change'];
 			}
 		}
 
@@ -404,10 +414,15 @@ class WP_Origin_Plugin {
 			}
 			self::assert_can_edit_post( $post_id );
 
+			$post      = get_post( $post_id );
+			$changes[] = self::build_push_summary_item( 'trashed', $post, $path );
+
 			if ( false === wp_trash_post( $post_id ) ) {
 				throw new Exception( 'Push rejected because WordPress could not trash the deleted content.' );
 			}
 		}
+
+		return $changes;
 	}
 
 	private static function get_push_commit_hashes( GitRepository $repository, $old_commit, $new_commit ) {
@@ -517,7 +532,58 @@ class WP_Origin_Plugin {
 			throw new Exception( $post_id->get_error_message() );
 		}
 
-		return $post_id;
+		$post = get_post( $post_id );
+
+		return array(
+			'post_id' => $post_id,
+			'change'  => self::build_push_summary_item(
+				$existing_post ? 'updated' : 'created',
+				$post,
+				$path
+			),
+		);
+	}
+
+	private static function build_push_summary_item( $action, $post, $path ) {
+		$post_id = $post ? $post->ID : 0;
+
+		return array(
+			'action'    => $action,
+			'post_id'   => $post_id,
+			'post_type' => $post ? $post->post_type : self::path_to_post_type( $path ),
+			'status'    => $post ? $post->post_status : '',
+			'title'     => $post ? get_the_title( $post ) : '',
+			'url'       => $post_id ? get_permalink( $post_id ) : '',
+			'path'      => $path,
+		);
+	}
+
+	private static function format_push_summary_messages( $push_summary ) {
+		if ( empty( $push_summary ) ) {
+			return array();
+		}
+
+		$messages   = array();
+		$messages[] = sprintf(
+			'WP Origin applied %d content %s:',
+			count( $push_summary ),
+			1 === count( $push_summary ) ? 'change' : 'changes'
+		);
+
+		foreach ( $push_summary as $change ) {
+			$messages[] = sprintf(
+				'- %s %s: %s',
+				ucfirst( $change['action'] ),
+				$change['post_type'],
+				self::sanitize_push_summary_text( $change['url'] ? $change['url'] : $change['path'] )
+			);
+		}
+
+		return $messages;
+	}
+
+	private static function sanitize_push_summary_text( $text ) {
+		return str_replace( array( "\r", "\n" ), ' ', (string) $text );
 	}
 
 	private static function get_repository_identity( GitRepository $repository ) {


### PR DESCRIPTION
## Summary

- Emit Git receive-pack progress messages after WP Origin applies a push, so `git push` shows a `remote:` summary of changed content.
- Include created, updated, and trashed post/page permalinks in that summary so authors can immediately inspect the published result.
- Extend the WP Origin git-action smoke script to assert that push output contains the summary and changed URLs.

## Testing

- `php -l plugins/wp-origin/class-wp-origin-plugin.php && php -l plugins/wp-origin/class-wp-origin-buffering-response.php`
- `vendor/bin/phpcs -d memory_limit=1G plugins/wp-origin/class-wp-origin-plugin.php plugins/wp-origin/class-wp-origin-buffering-response.php`
- `vendor/bin/phpunit components/Git/Tests/ProtocolDemultiplexerTest.php components/Git/Tests/GitServerTest.php`
- `git diff --check origin/trunk...HEAD`
- `bash -n bin/test-wp-origin-git-actions.sh`

Note: the full WP Origin e2e harness could not complete locally because this checkout does not have `@wp-playground/cli` installed for the script's `npx --no-install` fallback.