### PR TITLE
WP Origin: async initial-import seeder with progress UI

### DIFF
--- a/.github/workflows/wp-origin-e2e.yml
+++ b/.github/workflows/wp-origin-e2e.yml
@@ -87,14 +87,6 @@ jobs:
           wp --path="$WP_DIR" option update permalink_structure '/%postname%/'
           wp --path="$WP_DIR" rewrite flush --hard
 
-      - name: Mount toolkit components and activate plugin
-        run: |
-          rm -rf "$WP_DIR/wp-content/plugins/wp-origin"
-          ln -s "$GITHUB_WORKSPACE/plugins/wp-origin" "$WP_DIR/wp-content/plugins/wp-origin"
-          ln -s "$GITHUB_WORKSPACE/components" "$WP_DIR/wp-content/components"
-          ln -s "$GITHUB_WORKSPACE/vendor" "$WP_DIR/wp-content/vendor"
-          wp --path="$WP_DIR" plugin activate wp-origin
-
       - name: Seed Hello World post and Sample Page
         run: |
           wp --path="$WP_DIR" post update 1 \
@@ -105,6 +97,31 @@ jobs:
             --post_title='Sample Page' \
             --post_content='<!-- wp:paragraph --><p>Page from WordPress</p><!-- /wp:paragraph -->' \
             --post_status=publish
+
+      - name: Mount toolkit components and activate plugin
+        run: |
+          rm -rf "$WP_DIR/wp-content/plugins/wp-origin"
+          ln -s "$GITHUB_WORKSPACE/plugins/wp-origin" "$WP_DIR/wp-content/plugins/wp-origin"
+          ln -s "$GITHUB_WORKSPACE/components" "$WP_DIR/wp-content/components"
+          ln -s "$GITHUB_WORKSPACE/vendor" "$WP_DIR/wp-content/vendor"
+          wp --path="$WP_DIR" plugin activate wp-origin
+
+      - name: Drive seeder cron until done
+        run: |
+          for i in $(seq 1 30); do
+            wp --path="$WP_DIR" cron event run --due-now > /dev/null 2>&1 || true
+            STATE=$(wp --path="$WP_DIR" option get wp_origin_seed_state 2>/dev/null || echo "pending")
+            echo "tick $i: state=$STATE"
+            if [ "$STATE" = "done" ]; then exit 0; fi
+            if [ "$STATE" = "failed" ]; then
+              wp --path="$WP_DIR" option get wp_origin_seed_progress
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Seeder never reached 'done' state." >&2
+          wp --path="$WP_DIR" option get wp_origin_seed_progress
+          exit 1
 
       - name: Create Application Password
         id: app_password

--- a/.github/workflows/wp-origin-e2e.yml
+++ b/.github/workflows/wp-origin-e2e.yml
@@ -98,6 +98,25 @@ jobs:
             --post_content='<!-- wp:paragraph --><p>Page from WordPress</p><!-- /wp:paragraph -->' \
             --post_status=publish
 
+      - name: Generate bulk posts to force multi-tick seeding
+        run: |
+          # 28 generated posts + the 2 seeded ones = 30 total. Combined
+          # with the CI test helper's batch_size=5 / time_budget=0
+          # filters this forces the seeder to reschedule itself across
+          # at least 6 cron ticks before reaching `done`.
+          wp --path="$WP_DIR" post generate \
+            --count=28 \
+            --post_type=post \
+            --post_status=publish \
+            --post_title='CI bulk post' \
+            --post_content='<!-- wp:paragraph --><p>Bulk post for the multi-tick seeder e2e test.</p><!-- /wp:paragraph -->'
+
+      - name: Install CI seeder helper as a mu-plugin
+        run: |
+          mkdir -p "$WP_DIR/wp-content/mu-plugins"
+          cp "$GITHUB_WORKSPACE/plugins/wp-origin/Tests/ci-mu-test-helper.php" \
+            "$WP_DIR/wp-content/mu-plugins/wp-origin-ci-test-helper.php"
+
       - name: Mount toolkit components and activate plugin
         run: |
           rm -rf "$WP_DIR/wp-content/plugins/wp-origin"

--- a/components/Filesystem/class-wpdbfilesystem.php
+++ b/components/Filesystem/class-wpdbfilesystem.php
@@ -57,6 +57,18 @@ class WpdbFilesystem implements Filesystem {
 		return new ChrootLayer( $fs, '/' );
 	}
 
+	/**
+	 * Drop the two backing tables. Used by callers that want to wipe
+	 * the filesystem entirely — e.g. retrying a botched initial
+	 * import. The next call to `create()` will re-create the schema.
+	 */
+	public static function drop_tables( $wpdb, $table_prefix ) {
+		$files_table   = $table_prefix . 'files';
+		$entries_table = $table_prefix . 'directory_entries';
+		$wpdb->query( "DROP TABLE IF EXISTS {$files_table}" );
+		$wpdb->query( "DROP TABLE IF EXISTS {$entries_table}" );
+	}
+
 	private function __construct( $wpdb, $table_prefix ) {
 		$this->wpdb          = $wpdb;
 		$this->files_table   = $table_prefix . 'files';
@@ -185,6 +197,21 @@ class WpdbFilesystem implements Filesystem {
 		try {
 			$this->in_transaction(
 				function () use ( $from_path, $to_path ) {
+					// Make the rename idempotent. Git's atomic-write
+					// pattern (write to .tmp, rename to the
+					// content-addressed final path) can replay the same
+					// final path many times — once per identical blob.
+					// Without this DELETE the UPDATE would hit a PK
+					// collision and silently leave the .tmp row in
+					// place, corrupting the object store.
+					if ( $from_path !== $to_path ) {
+						$this->wpdb->delete(
+							$this->files_table,
+							array( 'path' => $to_path ),
+							array( '%s' )
+						);
+					}
+
 					$this->wpdb->update(
 						$this->files_table,
 						array( 'path' => $to_path ),
@@ -204,7 +231,7 @@ class WpdbFilesystem implements Filesystem {
 						),
 						array( '%s', '%s' )
 					);
-					$this->wpdb->insert(
+					$this->wpdb->replace(
 						$this->entries_table,
 						array(
 							'parent_path' => $new_parent,

--- a/plugins/wp-origin/Tests/EndToEndTest.php
+++ b/plugins/wp-origin/Tests/EndToEndTest.php
@@ -56,6 +56,20 @@ class WP_Origin_End_To_End_Test extends TestCase {
 		$this->assertGreaterThan( 0, $state['total'], "Seeder reports zero total posts: $body" );
 	}
 
+	public function testSeedingSpansMultipleCronTicks() {
+		// The CI workflow seeds 30 posts and drops a mu-plugin that
+		// shrinks the batch size to 5 and the time budget to 0
+		// seconds. That guarantees the seeder reschedules itself after
+		// every batch, so finishing requires several cron ticks. If
+		// any of that machinery breaks we'd silently lose resumability
+		// — assert directly that the import didn't fit in one tick.
+		$body  = $this->curl_get( $this->base_url . '/wp-json/wp-origin/v1/seed-status' );
+		$state = json_decode( $body, true );
+		$this->assertIsArray( $state, "Unexpected seed-status response: $body" );
+		$this->assertGreaterThanOrEqual( 30, $state['total'], "Expected the bulk seed to leave >=30 posts to import: $body" );
+		$this->assertGreaterThan( 1, $state['tick_count'], "Seeder finished in a single tick — resumability untested: $body" );
+	}
+
 	public function testInitialCommitIsParentless() {
 		$clone_dir = $this->clone_repo( 'initial-commit' );
 		$result    = $this->run_cmd(

--- a/plugins/wp-origin/Tests/EndToEndTest.php
+++ b/plugins/wp-origin/Tests/EndToEndTest.php
@@ -47,6 +47,33 @@ class WP_Origin_End_To_End_Test extends TestCase {
 		}
 	}
 
+	public function testSeedStatusReportsDone() {
+		$body  = $this->curl_get( $this->base_url . '/wp-json/wp-origin/v1/seed-status' );
+		$state = json_decode( $body, true );
+		$this->assertIsArray( $state, "Unexpected seed-status response: $body" );
+		$this->assertSame( 'done', $state['state'], "Seeder is not done: $body" );
+		$this->assertSame( 100, $state['percent'], "Seeder percent is not 100: $body" );
+		$this->assertGreaterThan( 0, $state['total'], "Seeder reports zero total posts: $body" );
+	}
+
+	public function testInitialCommitIsParentless() {
+		$clone_dir = $this->clone_repo( 'initial-commit' );
+		$result    = $this->run_cmd(
+			array( 'git', '-C', $clone_dir, 'log', '--all', '--format=%H %s', '--reverse' )
+		);
+		$lines = array_values( array_filter( explode( "\n", trim( $result['output'] ) ) ) );
+		$this->assertNotEmpty( $lines );
+
+		// First commit must be the squashed parent-less initial import.
+		list( $first_oid, $first_subject ) = explode( ' ', $lines[0], 2 );
+		$this->assertSame( 'Initial import from WordPress', $first_subject );
+		$parents = $this->run_cmd( array( 'git', '-C', $clone_dir, 'rev-list', '--parents', '-n', '1', $first_oid ) );
+		$this->assertSame( $first_oid, trim( $parents['output'] ), 'Initial commit must have no parents.' );
+
+		// And no "Seed batch" commits should have leaked into trunk.
+		$this->assertStringNotContainsString( 'Seed batch', $result['output'] );
+	}
+
 	public function testFullRoundTrip() {
 		$clone_dir = $this->clone_repo( 'clone' );
 

--- a/plugins/wp-origin/Tests/ci-mu-test-helper.php
+++ b/plugins/wp-origin/Tests/ci-mu-test-helper.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Plugin Name: WP Origin CI Test Helper (must-use)
+ * Description: Shrinks the seeder's batch size, time budget, and tick
+ *              reschedule delay so CI can verify that a multi-tick
+ *              import really resumes correctly across cron runs. Drop
+ *              this file in `wp-content/mu-plugins/` from the e2e
+ *              workflow only.
+ */
+
+add_filter( 'wp_origin_seed_batch_size', static function () {
+	return 5;
+} );
+
+// Zero-second budget forces budget_exhausted() to fire after every
+// batch, so the seeder reschedules itself even if the host can run
+// the whole thing in one tick.
+add_filter( 'wp_origin_seed_time_budget_seconds', static function () {
+	return 0.0;
+} );
+
+// Reschedule "in the future" with no delay so wp-cli's
+// `cron event run --due-now` picks up the next tick on the very next
+// invocation.
+add_filter( 'wp_origin_seed_tick_reschedule_seconds', static function () {
+	return 0;
+} );

--- a/plugins/wp-origin/class-wp-origin-admin.php
+++ b/plugins/wp-origin/class-wp-origin-admin.php
@@ -54,12 +54,22 @@ class WP_Origin_Admin {
 	}
 
 	public static function rest_status() {
+		// Each poll from the admin page also drives the seeder forward
+		// by one tick. WP-Cron only fires when something hits the site,
+		// so on a brand-new install — where no visitor has shown up yet
+		// — the cron event would otherwise sit idle. The transient lock
+		// inside tick() makes this safe to call on every poll.
+		if ( ! WP_Origin_Seeder::is_ready() ) {
+			WP_Origin_Seeder::tick();
+		}
+
 		return rest_ensure_response( WP_Origin_Seeder::get_progress() );
 	}
 
 	public static function rest_retry() {
 		WP_Origin_Seeder::reset();
 		WP_Origin_Seeder::on_activation();
+		WP_Origin_Seeder::tick();
 
 		return rest_ensure_response( WP_Origin_Seeder::get_progress() );
 	}

--- a/plugins/wp-origin/class-wp-origin-admin.php
+++ b/plugins/wp-origin/class-wp-origin-admin.php
@@ -122,26 +122,6 @@ class WP_Origin_Admin {
 				</tbody>
 			</table>
 
-			<h2 style="margin-top: 1.5em;">Commit log</h2>
-			<p class="description">Most recent commits on the staging branch (or trunk after finalization). Newest first.</p>
-			<table class="widefat striped" style="max-width: 720px;">
-				<thead>
-					<tr><th style="width: 8em;">Hash</th><th>Subject</th></tr>
-				</thead>
-				<tbody id="wp-origin-commits">
-				<?php if ( empty( $progress['commits'] ) ) : ?>
-					<tr><td colspan="2"><em>No commits yet.</em></td></tr>
-				<?php else : ?>
-					<?php foreach ( $progress['commits'] as $commit ) : ?>
-					<tr>
-						<td><code><?php echo esc_html( $commit['oid'] ); ?></code></td>
-						<td><?php echo esc_html( $commit['subject'] ); ?></td>
-					</tr>
-					<?php endforeach; ?>
-				<?php endif; ?>
-				</tbody>
-			</table>
-
 			<p>
 				<button type="button" class="button" id="wp-origin-retry">Retry import</button>
 			</p>
@@ -157,7 +137,6 @@ class WP_Origin_Admin {
 			var percentEl = document.getElementById('wp-origin-percent');
 			var countsEl = document.getElementById('wp-origin-counts');
 			var messageEl = document.getElementById('wp-origin-message');
-			var commitsEl = document.getElementById('wp-origin-commits');
 
 			function render(data) {
 				stateEl.textContent = data.state;
@@ -165,20 +144,6 @@ class WP_Origin_Admin {
 				percentEl.textContent = data.percent;
 				countsEl.textContent = data.processed + ' / ' + data.total;
 				messageEl.textContent = data.message;
-
-				if (Array.isArray(data.commits) && data.commits.length > 0) {
-					var rows = '';
-					data.commits.forEach(function (c) {
-						var oid = document.createElement('code');
-						oid.textContent = c.oid;
-						var subject = document.createElement('span');
-						subject.textContent = c.subject;
-						rows += '<tr><td>' + oid.outerHTML + '</td><td>' + subject.outerHTML + '</td></tr>';
-					});
-					commitsEl.innerHTML = rows;
-				} else {
-					commitsEl.innerHTML = '<tr><td colspan="2"><em>No commits yet.</em></td></tr>';
-				}
 			}
 
 			function poll() {

--- a/plugins/wp-origin/class-wp-origin-admin.php
+++ b/plugins/wp-origin/class-wp-origin-admin.php
@@ -54,16 +54,29 @@ class WP_Origin_Admin {
 	}
 
 	public static function rest_status() {
-		// Each poll from the admin page also drives the seeder forward
-		// by one tick. WP-Cron only fires when something hits the site,
-		// so on a brand-new install — where no visitor has shown up yet
-		// — the cron event would otherwise sit idle. The transient lock
-		// inside tick() makes this safe to call on every poll.
-		if ( ! WP_Origin_Seeder::is_ready() ) {
-			WP_Origin_Seeder::tick();
-		}
+		// Each poll drives the seeder for up to ~1.5 seconds before
+		// returning. With the demo's 0-second batch budget that's many
+		// batches per poll, so the progress bar always reflects fresh
+		// work — instead of stalling for one tick per 2-second JS
+		// interval. The transient lock inside tick() makes repeated
+		// calls safe.
+		self::drive_seeder( 1.5 );
 
 		return rest_ensure_response( WP_Origin_Seeder::get_progress() );
+	}
+
+	private static function drive_seeder( $seconds ) {
+		$deadline = microtime( true ) + $seconds;
+		while ( ! WP_Origin_Seeder::is_ready() && microtime( true ) < $deadline ) {
+			$state_before = WP_Origin_Seeder::get_state();
+			WP_Origin_Seeder::tick();
+			if ( WP_Origin_Seeder::get_state() === $state_before
+				&& 'in_progress' !== $state_before
+				&& 'pending' !== $state_before
+			) {
+				break;
+			}
+		}
 	}
 
 	public static function rest_retry() {
@@ -78,12 +91,11 @@ class WP_Origin_Admin {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
 		}
-		// Drive the seeder forward before painting the page so the user
-		// never lands on "Queued. Waiting for the first cron tick." —
-		// by the time they see the progress bar it's already moving.
-		if ( ! WP_Origin_Seeder::is_ready() ) {
-			WP_Origin_Seeder::tick();
-		}
+		// Drive the seeder forward for ~1.5s before painting the page,
+		// so the user never lands on "Queued. Waiting for the first
+		// cron tick." — by the time they see the progress bar it's
+		// already moving and several commits exist.
+		self::drive_seeder( 1.5 );
 		$progress   = WP_Origin_Seeder::get_progress();
 		$nonce      = wp_create_nonce( 'wp_rest' );
 		$status_url = esc_url_raw( rest_url( self::REST_NAMESPACE . self::STATUS_ROUTE ) );
@@ -110,6 +122,26 @@ class WP_Origin_Admin {
 				</tbody>
 			</table>
 
+			<h2 style="margin-top: 1.5em;">Commit log</h2>
+			<p class="description">Most recent commits on the staging branch (or trunk after finalization). Newest first.</p>
+			<table class="widefat striped" style="max-width: 720px;">
+				<thead>
+					<tr><th style="width: 8em;">Hash</th><th>Subject</th></tr>
+				</thead>
+				<tbody id="wp-origin-commits">
+				<?php if ( empty( $progress['commits'] ) ) : ?>
+					<tr><td colspan="2"><em>No commits yet.</em></td></tr>
+				<?php else : ?>
+					<?php foreach ( $progress['commits'] as $commit ) : ?>
+					<tr>
+						<td><code><?php echo esc_html( $commit['oid'] ); ?></code></td>
+						<td><?php echo esc_html( $commit['subject'] ); ?></td>
+					</tr>
+					<?php endforeach; ?>
+				<?php endif; ?>
+				</tbody>
+			</table>
+
 			<p>
 				<button type="button" class="button" id="wp-origin-retry">Retry import</button>
 			</p>
@@ -125,6 +157,7 @@ class WP_Origin_Admin {
 			var percentEl = document.getElementById('wp-origin-percent');
 			var countsEl = document.getElementById('wp-origin-counts');
 			var messageEl = document.getElementById('wp-origin-message');
+			var commitsEl = document.getElementById('wp-origin-commits');
 
 			function render(data) {
 				stateEl.textContent = data.state;
@@ -132,6 +165,20 @@ class WP_Origin_Admin {
 				percentEl.textContent = data.percent;
 				countsEl.textContent = data.processed + ' / ' + data.total;
 				messageEl.textContent = data.message;
+
+				if (Array.isArray(data.commits) && data.commits.length > 0) {
+					var rows = '';
+					data.commits.forEach(function (c) {
+						var oid = document.createElement('code');
+						oid.textContent = c.oid;
+						var subject = document.createElement('span');
+						subject.textContent = c.subject;
+						rows += '<tr><td>' + oid.outerHTML + '</td><td>' + subject.outerHTML + '</td></tr>';
+					});
+					commitsEl.innerHTML = rows;
+				} else {
+					commitsEl.innerHTML = '<tr><td colspan="2"><em>No commits yet.</em></td></tr>';
+				}
 			}
 
 			function poll() {

--- a/plugins/wp-origin/class-wp-origin-admin.php
+++ b/plugins/wp-origin/class-wp-origin-admin.php
@@ -78,6 +78,12 @@ class WP_Origin_Admin {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
 		}
+		// Drive the seeder forward before painting the page so the user
+		// never lands on "Queued. Waiting for the first cron tick." —
+		// by the time they see the progress bar it's already moving.
+		if ( ! WP_Origin_Seeder::is_ready() ) {
+			WP_Origin_Seeder::tick();
+		}
 		$progress   = WP_Origin_Seeder::get_progress();
 		$nonce      = wp_create_nonce( 'wp_rest' );
 		$status_url = esc_url_raw( rest_url( self::REST_NAMESPACE . self::STATUS_ROUTE ) );

--- a/plugins/wp-origin/class-wp-origin-admin.php
+++ b/plugins/wp-origin/class-wp-origin-admin.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * Admin UI for WP Origin: a Tools → "WP Origin" page that shows the
+ * seeder's progress with a live progress bar, plus a small REST
+ * endpoint the page polls for status. The endpoint also doubles as a
+ * way for tests to wait for `state === done` programmatically.
+ */
+class WP_Origin_Admin {
+
+	const PAGE_SLUG      = 'wp-origin';
+	const REST_NAMESPACE = 'wp-origin/v1';
+	const STATUS_ROUTE   = '/seed-status';
+	const RETRY_ROUTE    = '/seed-retry';
+
+	public static function bootstrap() {
+		add_action( 'admin_menu', array( __CLASS__, 'register_menu' ) );
+		add_action( 'rest_api_init', array( __CLASS__, 'register_rest_routes' ) );
+	}
+
+	public static function register_menu() {
+		add_management_page(
+			'WP Origin',
+			'WP Origin',
+			'manage_options',
+			self::PAGE_SLUG,
+			array( __CLASS__, 'render_page' )
+		);
+	}
+
+	public static function register_rest_routes() {
+		register_rest_route(
+			self::REST_NAMESPACE,
+			self::STATUS_ROUTE,
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( __CLASS__, 'rest_status' ),
+				'permission_callback' => array( __CLASS__, 'admin_only' ),
+			)
+		);
+		register_rest_route(
+			self::REST_NAMESPACE,
+			self::RETRY_ROUTE,
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( __CLASS__, 'rest_retry' ),
+				'permission_callback' => array( __CLASS__, 'admin_only' ),
+			)
+		);
+	}
+
+	public static function admin_only() {
+		return current_user_can( 'manage_options' );
+	}
+
+	public static function rest_status() {
+		return rest_ensure_response( WP_Origin_Seeder::get_progress() );
+	}
+
+	public static function rest_retry() {
+		WP_Origin_Seeder::reset();
+		WP_Origin_Seeder::on_activation();
+
+		return rest_ensure_response( WP_Origin_Seeder::get_progress() );
+	}
+
+	public static function render_page() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+		$progress   = WP_Origin_Seeder::get_progress();
+		$nonce      = wp_create_nonce( 'wp_rest' );
+		$status_url = esc_url_raw( rest_url( self::REST_NAMESPACE . self::STATUS_ROUTE ) );
+		$retry_url  = esc_url_raw( rest_url( self::REST_NAMESPACE . self::RETRY_ROUTE ) );
+		?>
+		<div class="wrap" id="wp-origin-admin">
+			<h1>WP Origin</h1>
+			<p>Status of the initial Markdown import. Once this finishes you can clone, push, and pull the site as a Git repository.</p>
+
+			<table class="widefat striped" style="max-width: 720px;">
+				<tbody>
+					<tr><th scope="row">State</th><td><code id="wp-origin-state"><?php echo esc_html( $progress['state'] ); ?></code></td></tr>
+					<tr>
+						<th scope="row">Progress</th>
+						<td>
+							<div style="background:#eee;border:1px solid #ccd0d4;height:18px;width:100%;border-radius:3px;overflow:hidden;">
+								<div id="wp-origin-bar" style="background:#2271b1;height:100%;width:<?php echo intval( $progress['percent'] ); ?>%;transition:width 0.4s;"></div>
+							</div>
+							<p><span id="wp-origin-percent"><?php echo intval( $progress['percent'] ); ?></span>%
+								— <span id="wp-origin-counts"><?php echo intval( $progress['processed'] ); ?> / <?php echo intval( $progress['total'] ); ?></span> posts</p>
+						</td>
+					</tr>
+					<tr><th scope="row">Last update</th><td id="wp-origin-message"><?php echo esc_html( $progress['message'] ); ?></td></tr>
+				</tbody>
+			</table>
+
+			<p>
+				<button type="button" class="button" id="wp-origin-retry">Retry import</button>
+			</p>
+		</div>
+
+		<script>
+		(function () {
+			var nonce = <?php echo wp_json_encode( $nonce ); ?>;
+			var statusUrl = <?php echo wp_json_encode( $status_url ); ?>;
+			var retryUrl = <?php echo wp_json_encode( $retry_url ); ?>;
+			var stateEl = document.getElementById('wp-origin-state');
+			var barEl = document.getElementById('wp-origin-bar');
+			var percentEl = document.getElementById('wp-origin-percent');
+			var countsEl = document.getElementById('wp-origin-counts');
+			var messageEl = document.getElementById('wp-origin-message');
+
+			function render(data) {
+				stateEl.textContent = data.state;
+				barEl.style.width = data.percent + '%';
+				percentEl.textContent = data.percent;
+				countsEl.textContent = data.processed + ' / ' + data.total;
+				messageEl.textContent = data.message;
+			}
+
+			function poll() {
+				fetch(statusUrl, { credentials: 'same-origin', headers: { 'X-WP-Nonce': nonce } })
+					.then(function (r) { return r.json(); })
+					.then(function (data) {
+						render(data);
+						if (data.state !== 'done' && data.state !== 'failed') {
+							setTimeout(poll, 2000);
+						}
+					})
+					.catch(function () { setTimeout(poll, 5000); });
+			}
+
+			document.getElementById('wp-origin-retry').addEventListener('click', function () {
+				fetch(retryUrl, {
+					method: 'POST',
+					credentials: 'same-origin',
+					headers: { 'X-WP-Nonce': nonce }
+				}).then(function () { setTimeout(poll, 1000); });
+			});
+
+			poll();
+		}());
+		</script>
+		<?php
+	}
+}

--- a/plugins/wp-origin/class-wp-origin-plugin.php
+++ b/plugins/wp-origin/class-wp-origin-plugin.php
@@ -35,13 +35,20 @@ class WP_Origin_Plugin {
 	const EPOCH_TIMESTAMP = 946684800;
 	const TABLE_PREFIX    = 'wp_origin_';
 
-	private static $supported_post_types    = array( 'post', 'page' );
-	private static $supported_post_statuses = array( 'publish', 'draft', 'pending', 'private', 'future' );
+	public static $supported_post_types    = array( 'post', 'page' );
+	public static $supported_post_statuses = array( 'publish', 'draft', 'pending', 'private', 'future' );
 
 	public static function bootstrap() {
 		add_action( 'rest_api_init', array( __CLASS__, 'register_routes' ) );
 		add_filter( 'rest_post_dispatch', array( __CLASS__, 'add_authentication_challenge' ), 10, 3 );
 		add_filter( 'rest_pre_serve_request', array( __CLASS__, 'serve_git_response' ), 10, 4 );
+
+		WP_Origin_Seeder::bootstrap();
+		WP_Origin_Admin::bootstrap();
+	}
+
+	public static function on_activation() {
+		WP_Origin_Seeder::on_activation();
 	}
 
 	public static function register_routes() {
@@ -81,6 +88,17 @@ class WP_Origin_Plugin {
 		$previous_error_handler = set_error_handler( array( __CLASS__, 'throw_on_php_warning' ) ); // phpcs:ignore
 
 		try {
+			if ( ! WP_Origin_Seeder::is_ready() ) {
+				$response = new WP_Origin_Buffering_Response();
+				$response->send_http_code( 503 );
+				$response->send_header( 'Content-Type', 'text/plain; charset=utf-8' );
+				$response->send_header( 'Cache-Control', 'no-cache' );
+				$response->send_header( 'Retry-After', '15' );
+				$response->append_bytes( WP_Origin_Seeder::not_ready_message() . "\n" );
+
+				return $response->to_rest_response();
+			}
+
 			$repository = self::open_repository();
 			self::sync_repository_from_wordpress( $repository );
 
@@ -216,7 +234,7 @@ class WP_Origin_Plugin {
 		return '/git-receive-pack' === $git_path;
 	}
 
-	private static function open_repository() {
+	public static function open_repository() {
 		global $wpdb;
 
 		$repository = new GitRepository(
@@ -309,26 +327,11 @@ class WP_Origin_Plugin {
 				continue;
 			}
 
-			$metadata = array(
-				'title'  => array( $post->post_title ),
-				'date'   => array( self::format_post_date_for_frontmatter( $post ) ),
-				'status' => array( self::frontmatter_status_from_post_status( $post->post_status ) ),
-			);
-			if ( '' !== trim( $post->post_excerpt ) ) {
-				$metadata['description'] = array( $post->post_excerpt );
-			}
-
-			$producer = new MarkdownProducer(
-				new BlocksWithMetadata(
-					$post->post_content,
-					$metadata
-				)
-			);
-			$path     = self::build_markdown_path( $post->post_type, $post->post_name );
+			$path = self::build_markdown_path( $post->post_type, $post->post_name );
 
 			$files[ $path ] = array(
 				'post'     => $post,
-				'markdown' => $producer->produce(),
+				'markdown' => self::export_post_to_markdown( $post ),
 			);
 		}
 
@@ -337,8 +340,37 @@ class WP_Origin_Plugin {
 		return $files;
 	}
 
-	private static function build_markdown_path( $post_type, $slug ) {
+	public static function build_markdown_path( $post_type, $slug ) {
 		return ltrim( $post_type . '/' . $slug . '.md', '/' );
+	}
+
+	/**
+	 * Convert a single WP_Post to its Markdown representation, the same
+	 * way `export_wordpress_content()` does in bulk. Public so the
+	 * seeder can reuse the conversion without duplicating logic.
+	 */
+	public static function export_post_to_markdown( WP_Post $post ) {
+		$metadata = array(
+			'title'  => array( $post->post_title ),
+			'date'   => array( self::format_post_date_for_frontmatter( $post ) ),
+			'status' => array( self::frontmatter_status_from_post_status( $post->post_status ) ),
+		);
+		if ( '' !== trim( $post->post_excerpt ) ) {
+			$metadata['description'] = array( $post->post_excerpt );
+		}
+
+		$producer = new MarkdownProducer(
+			new BlocksWithMetadata(
+				$post->post_content,
+				$metadata
+			)
+		);
+
+		return $producer->produce();
+	}
+
+	public static function repository_identity( GitRepository $repository ) {
+		return self::get_repository_identity( $repository );
 	}
 
 	private static function apply_repository_changes_to_wordpress( GitRepository $repository, $old_commit, $new_commit ) {

--- a/plugins/wp-origin/class-wp-origin-plugin.php
+++ b/plugins/wp-origin/class-wp-origin-plugin.php
@@ -234,6 +234,11 @@ class WP_Origin_Plugin {
 		return '/git-receive-pack' === $git_path;
 	}
 
+	public static function drop_repository_tables() {
+		global $wpdb;
+		WpdbFilesystem::drop_tables( $wpdb, $wpdb->prefix . self::TABLE_PREFIX );
+	}
+
 	public static function open_repository() {
 		global $wpdb;
 

--- a/plugins/wp-origin/class-wp-origin-seeder.php
+++ b/plugins/wp-origin/class-wp-origin-seeder.php
@@ -58,6 +58,26 @@ class WP_Origin_Seeder {
 		add_action( self::CRON_HOOK, array( __CLASS__, 'tick' ) );
 	}
 
+	/**
+	 * Resolve budget knobs through filters. The defaults are the
+	 * production values; tests and unusual hosts can shrink them via
+	 * `wp_origin_seed_batch_size`,
+	 * `wp_origin_seed_time_budget_seconds`, and
+	 * `wp_origin_seed_tick_reschedule_seconds` to force the seeder to
+	 * span multiple cron ticks.
+	 */
+	private static function batch_size() {
+		return (int) apply_filters( 'wp_origin_seed_batch_size', self::BATCH_SIZE );
+	}
+
+	private static function time_budget_seconds() {
+		return (float) apply_filters( 'wp_origin_seed_time_budget_seconds', self::TIME_BUDGET_SECONDS );
+	}
+
+	private static function tick_reschedule_seconds() {
+		return (int) apply_filters( 'wp_origin_seed_tick_reschedule_seconds', self::TICK_RESCHEDULE_SECONDS );
+	}
+
 	public static function on_activation() {
 		$state = get_option( self::STATE_OPTION );
 		if ( self::STATE_DONE === $state ) {
@@ -103,18 +123,16 @@ class WP_Origin_Seeder {
 		$done     = isset( $progress['processed'] ) ? intval( $progress['processed'] ) : 0;
 		$percent  = self::STATE_DONE === $state ? 100 : ( $total > 0 ? min( 99, intval( floor( $done * 100 / $total ) ) ) : 0 );
 
-		return array_merge(
-			array(
-				'state'      => $state,
-				'percent'    => $percent,
-				'processed'  => $done,
-				'total'      => $total,
-				'message'    => isset( $progress['message'] ) ? $progress['message'] : '',
-				'last_id'    => isset( $progress['last_id'] ) ? intval( $progress['last_id'] ) : 0,
-				'started_at' => isset( $progress['started_at'] ) ? intval( $progress['started_at'] ) : 0,
-				'finished_at' => isset( $progress['finished_at'] ) ? intval( $progress['finished_at'] ) : 0,
-			),
-			array()
+		return array(
+			'state'       => $state,
+			'percent'     => $percent,
+			'processed'   => $done,
+			'total'       => $total,
+			'tick_count'  => isset( $progress['tick_count'] ) ? intval( $progress['tick_count'] ) : 0,
+			'message'     => isset( $progress['message'] ) ? $progress['message'] : '',
+			'last_id'     => isset( $progress['last_id'] ) ? intval( $progress['last_id'] ) : 0,
+			'started_at'  => isset( $progress['started_at'] ) ? intval( $progress['started_at'] ) : 0,
+			'finished_at' => isset( $progress['finished_at'] ) ? intval( $progress['finished_at'] ) : 0,
 		);
 	}
 
@@ -148,6 +166,11 @@ class WP_Origin_Seeder {
 				return;
 			}
 
+			$progress                 = self::get_progress_storage();
+			$progress['tick_count']   = isset( $progress['tick_count'] ) ? intval( $progress['tick_count'] ) + 1 : 1;
+			$progress['last_tick_at'] = time();
+			update_option( self::PROGRESS_OPTION, $progress, false );
+
 			if ( self::STATE_PENDING === $state ) {
 				self::initialize();
 				$state = self::get_state();
@@ -179,12 +202,15 @@ class WP_Origin_Seeder {
 		);
 		// phpcs:enable
 
+		$existing   = self::get_progress_storage();
+		$tick_count = isset( $existing['tick_count'] ) ? intval( $existing['tick_count'] ) : 0;
 		update_option(
 			self::PROGRESS_OPTION,
 			array(
 				'processed'    => 0,
 				'total'        => $total,
 				'last_id'      => 0,
+				'tick_count'   => $tick_count,
 				'started_at'   => time(),
 				'last_tick_at' => time(),
 				'message'      => sprintf( 'Found %d posts and pages to import.', $total ),
@@ -269,7 +295,7 @@ class WP_Origin_Seeder {
 			wp_cache_flush_runtime();
 
 			if ( self::budget_exhausted( $started_at ) ) {
-				wp_schedule_single_event( time() + self::TICK_RESCHEDULE_SECONDS, self::CRON_HOOK );
+				wp_schedule_single_event( time() + self::tick_reschedule_seconds(), self::CRON_HOOK );
 				break;
 			}
 		}
@@ -355,7 +381,7 @@ class WP_Origin_Seeder {
 				ORDER BY ID ASC
 				LIMIT %d",
 				intval( $after_id ),
-				self::BATCH_SIZE
+				self::batch_size()
 			)
 		);
 		// phpcs:enable
@@ -386,7 +412,7 @@ class WP_Origin_Seeder {
 	}
 
 	private static function budget_exhausted( $started_at ) {
-		if ( microtime( true ) - $started_at > self::TIME_BUDGET_SECONDS ) {
+		if ( microtime( true ) - $started_at > self::time_budget_seconds() ) {
 			return true;
 		}
 

--- a/plugins/wp-origin/class-wp-origin-seeder.php
+++ b/plugins/wp-origin/class-wp-origin-seeder.php
@@ -1,0 +1,425 @@
+<?php
+
+use WordPress\Git\GitRepository;
+use WordPress\Git\Model\Commit;
+
+/**
+ * Async, resumable initial-import seeder for WP Origin.
+ *
+ * The plugin's first run on an existing WordPress install needs to
+ * convert every supported post and page into a Markdown file and put
+ * those files under `refs/heads/trunk` as the repository's initial
+ * commit. On a site with thousands of posts that conversion blows past
+ * a normal PHP request budget, so this class breaks the work into
+ * small batches and drives them from WP-Cron.
+ *
+ * State machine, all stored in `wp_options`:
+ *
+ *   pending      → newly activated; a single cron tick is queued.
+ *   in_progress  → batches are running. Each tick converts a chunk of
+ *                  posts to Markdown, creates a "Seed batch" commit on
+ *                  `refs/heads/_wp_origin_seed`, and re-schedules
+ *                  itself when the time/memory budget is up.
+ *   finalizing   → all batches done. Build a single parent-less
+ *                  "Initial import from WordPress" commit pointing at
+ *                  the seed branch's tree, and set
+ *                  `refs/heads/trunk` to it. The seed branch goes
+ *                  away.
+ *   done         → repository is open for clone/pull/push.
+ *   failed       → an exception aborted seeding; admins can retry
+ *                  from the admin page.
+ *
+ * Smart-HTTP requests are rejected with a clear protocol error until
+ * state reaches `done`, so a client cloning during seeding sees
+ * "Repository is being prepared…" rather than a half-built history.
+ *
+ * No Action Scheduler dependency — plain WP-Cron only.
+ */
+class WP_Origin_Seeder {
+
+	const STATE_OPTION    = 'wp_origin_seed_state';
+	const PROGRESS_OPTION = 'wp_origin_seed_progress';
+	const SEED_BRANCH     = 'refs/heads/_wp_origin_seed';
+	const CRON_HOOK       = 'wp_origin_seed_tick';
+	const LOCK_TRANSIENT  = 'wp_origin_seed_lock';
+
+	const STATE_PENDING     = 'pending';
+	const STATE_IN_PROGRESS = 'in_progress';
+	const STATE_FINALIZING  = 'finalizing';
+	const STATE_DONE        = 'done';
+	const STATE_FAILED      = 'failed';
+
+	const BATCH_SIZE              = 25;
+	const TIME_BUDGET_SECONDS     = 15;
+	const MEMORY_BUDGET_FRACTION  = 0.7;
+	const TICK_RESCHEDULE_SECONDS = 10;
+
+	public static function bootstrap() {
+		add_action( self::CRON_HOOK, array( __CLASS__, 'tick' ) );
+	}
+
+	public static function on_activation() {
+		$state = get_option( self::STATE_OPTION );
+		if ( self::STATE_DONE === $state ) {
+			return;
+		}
+
+		update_option( self::STATE_OPTION, self::STATE_PENDING, false );
+		update_option(
+			self::PROGRESS_OPTION,
+			array(
+				'processed'    => 0,
+				'total'        => 0,
+				'last_id'      => 0,
+				'started_at'   => time(),
+				'last_tick_at' => time(),
+				'message'      => 'Queued. Waiting for the first cron tick.',
+			),
+			false
+		);
+
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_single_event( time() + 5, self::CRON_HOOK );
+		}
+	}
+
+	public static function reset() {
+		delete_option( self::STATE_OPTION );
+		delete_option( self::PROGRESS_OPTION );
+		delete_transient( self::LOCK_TRANSIENT );
+		wp_clear_scheduled_hook( self::CRON_HOOK );
+	}
+
+	public static function get_state() {
+		$state = get_option( self::STATE_OPTION );
+
+		return $state ? $state : self::STATE_PENDING;
+	}
+
+	public static function get_progress() {
+		$progress = get_option( self::PROGRESS_OPTION, array() );
+		$state    = self::get_state();
+		$total    = isset( $progress['total'] ) ? intval( $progress['total'] ) : 0;
+		$done     = isset( $progress['processed'] ) ? intval( $progress['processed'] ) : 0;
+		$percent  = self::STATE_DONE === $state ? 100 : ( $total > 0 ? min( 99, intval( floor( $done * 100 / $total ) ) ) : 0 );
+
+		return array_merge(
+			array(
+				'state'      => $state,
+				'percent'    => $percent,
+				'processed'  => $done,
+				'total'      => $total,
+				'message'    => isset( $progress['message'] ) ? $progress['message'] : '',
+				'last_id'    => isset( $progress['last_id'] ) ? intval( $progress['last_id'] ) : 0,
+				'started_at' => isset( $progress['started_at'] ) ? intval( $progress['started_at'] ) : 0,
+				'finished_at' => isset( $progress['finished_at'] ) ? intval( $progress['finished_at'] ) : 0,
+			),
+			array()
+		);
+	}
+
+	public static function is_ready() {
+		return self::STATE_DONE === self::get_state();
+	}
+
+	public static function not_ready_message() {
+		$progress = self::get_progress();
+		if ( self::STATE_FAILED === $progress['state'] ) {
+			return 'WP Origin import failed: ' . $progress['message'];
+		}
+
+		return sprintf(
+			'WP Origin is preparing the repository (%d%%, %d / %d posts). Please try again shortly.',
+			$progress['percent'],
+			$progress['processed'],
+			$progress['total']
+		);
+	}
+
+	public static function tick() {
+		if ( get_transient( self::LOCK_TRANSIENT ) ) {
+			return;
+		}
+		set_transient( self::LOCK_TRANSIENT, 1, 90 );
+
+		try {
+			$state = self::get_state();
+			if ( self::STATE_DONE === $state || self::STATE_FAILED === $state ) {
+				return;
+			}
+
+			if ( self::STATE_PENDING === $state ) {
+				self::initialize();
+				$state = self::get_state();
+			}
+
+			if ( self::STATE_IN_PROGRESS === $state ) {
+				self::process_batches();
+				$state = self::get_state();
+			}
+
+			if ( self::STATE_FINALIZING === $state ) {
+				self::finalize();
+			}
+		} catch ( Throwable $exception ) {
+			self::record_failure( $exception );
+		} finally {
+			delete_transient( self::LOCK_TRANSIENT );
+		}
+	}
+
+	private static function initialize() {
+		global $wpdb;
+
+		$types_in    = "'" . implode( "','", array_map( 'esc_sql', WP_Origin_Plugin::$supported_post_types ) ) . "'";
+		$statuses_in = "'" . implode( "','", array_map( 'esc_sql', WP_Origin_Plugin::$supported_post_statuses ) ) . "'";
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery
+		$total = (int) $wpdb->get_var(
+			"SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type IN ($types_in) AND post_status IN ($statuses_in)"
+		);
+		// phpcs:enable
+
+		update_option(
+			self::PROGRESS_OPTION,
+			array(
+				'processed'    => 0,
+				'total'        => $total,
+				'last_id'      => 0,
+				'started_at'   => time(),
+				'last_tick_at' => time(),
+				'message'      => sprintf( 'Found %d posts and pages to import.', $total ),
+			),
+			false
+		);
+
+		// If there's nothing to import, skip straight to finalization so
+		// trunk gets an empty initial commit and clones stop being
+		// rejected.
+		if ( 0 === $total ) {
+			update_option( self::STATE_OPTION, self::STATE_FINALIZING, false );
+		} else {
+			update_option( self::STATE_OPTION, self::STATE_IN_PROGRESS, false );
+		}
+	}
+
+	private static function process_batches() {
+		$repository = WP_Origin_Plugin::open_repository();
+		// Stage seed commits on a side branch so trunk stays empty (and
+		// clones keep being rejected) until finalization. The branch
+		// file must exist before commit() runs, otherwise it falls back
+		// to overwriting HEAD with the new commit OID.
+		if ( ! $repository->branch_exists( self::SEED_BRANCH ) ) {
+			$repository->set_branch_tip( self::SEED_BRANCH, Commit::NULL_HASH );
+		}
+		$repository->set_branch_tip( 'HEAD', 'ref: ' . self::SEED_BRANCH . "\n" );
+
+		$started_at = microtime( true );
+
+		while ( true ) {
+			$progress = self::get_progress_storage();
+			$batch    = self::next_batch( $progress['last_id'] );
+
+			if ( empty( $batch ) ) {
+				$progress['message'] = 'All posts staged. Finalizing initial commit…';
+				update_option( self::PROGRESS_OPTION, $progress, false );
+				update_option( self::STATE_OPTION, self::STATE_FINALIZING, false );
+				break;
+			}
+
+			$updates   = array();
+			$last_id   = $progress['last_id'];
+			$processed = $progress['processed'];
+			foreach ( $batch as $post ) {
+				$path             = WP_Origin_Plugin::build_markdown_path( $post->post_type, $post->post_name );
+				$updates[ $path ] = WP_Origin_Plugin::export_post_to_markdown( $post );
+				$last_id          = $post->ID;
+				++$processed;
+			}
+
+			$identity = WP_Origin_Plugin::repository_identity( $repository );
+			$now      = gmdate( Commit::DATE_FORMAT );
+			$repository->commit(
+				array(
+					'updates' => $updates,
+					'commit'  => array(
+						'message'        => sprintf(
+							'Seed batch ending at post %d (%d/%d)',
+							$last_id,
+							$processed,
+							$progress['total']
+						),
+						'author'         => $identity,
+						'author_date'    => $now,
+						'committer'      => $identity,
+						'committer_date' => $now,
+					),
+				)
+			);
+
+			$progress['last_id']      = $last_id;
+			$progress['processed']    = $processed;
+			$progress['last_tick_at'] = time();
+			$progress['message']      = sprintf( 'Imported %d / %d posts.', $processed, $progress['total'] );
+			update_option( self::PROGRESS_OPTION, $progress, false );
+
+			// Free per-batch memory before the next iteration. WP_Post
+			// objects accumulate in the object cache and the producer
+			// holds the full Markdown string.
+			unset( $batch, $updates );
+			wp_cache_flush_runtime();
+
+			if ( self::budget_exhausted( $started_at ) ) {
+				wp_schedule_single_event( time() + self::TICK_RESCHEDULE_SECONDS, self::CRON_HOOK );
+				break;
+			}
+		}
+
+		// Restore HEAD to trunk so request-time code paths read trunk.
+		$repository->set_branch_tip( 'HEAD', "ref: refs/heads/trunk\n" );
+	}
+
+	private static function finalize() {
+		$repository = WP_Origin_Plugin::open_repository();
+		$repository->set_branch_tip( 'HEAD', "ref: refs/heads/trunk\n" );
+
+		$seed_tip = $repository->get_branch_tip( self::SEED_BRANCH );
+		$progress = self::get_progress_storage();
+		$identity = WP_Origin_Plugin::repository_identity( $repository );
+		$now      = gmdate( Commit::DATE_FORMAT );
+
+		if ( ! is_string( $seed_tip ) || '' === $seed_tip || Commit::is_null_hash( $seed_tip ) ) {
+			// Nothing was staged (empty site). Create an empty initial
+			// commit so trunk has a valid root and clones can start
+			// succeeding.
+			$initial_oid         = $repository->commit(
+				array(
+					'updates' => array(),
+					'commit'  => array(
+						'message'        => 'Initial import from WordPress (empty site)',
+						'author'         => $identity,
+						'author_date'    => $now,
+						'committer'      => $identity,
+						'committer_date' => $now,
+					),
+				)
+			);
+			$progress['message'] = 'Initial import complete (no content found).';
+		} else {
+			$seed_commit = $repository->read_object( $seed_tip )->as_commit();
+
+			// Build a single parent-less commit pointing at the seed
+			// branch's final tree. This becomes trunk's only commit, so
+			// clones see one clean "Initial import from WordPress"
+			// regardless of how many seed batches ran.
+			$initial             = new Commit(
+				array(
+					'tree'           => $seed_commit->tree,
+					'parents'        => array(),
+					'author'         => $identity,
+					'author_date'    => $now,
+					'committer'      => $identity,
+					'committer_date' => $now,
+					'message'        => 'Initial import from WordPress',
+				)
+			);
+			$initial_oid         = $repository->add_object( 'commit', $initial->get_commit_string() );
+			$progress['message'] = sprintf( 'Initial import complete. %d posts imported.', intval( $progress['processed'] ) );
+		}
+
+		$repository->set_branch_tip( 'refs/heads/trunk', $initial_oid );
+		// Drop the staging branch — the seed commits are unreachable
+		// from any ref, so Git will treat their objects as garbage.
+		$repository->set_branch_tip( self::SEED_BRANCH, Commit::NULL_HASH );
+
+		$progress['finished_at'] = time();
+		$progress['percent']     = 100;
+		update_option( self::PROGRESS_OPTION, $progress, false );
+		update_option( self::STATE_OPTION, self::STATE_DONE, false );
+	}
+
+	private static function next_batch( $after_id ) {
+		global $wpdb;
+
+		$types_in    = "'" . implode( "','", array_map( 'esc_sql', WP_Origin_Plugin::$supported_post_types ) ) . "'";
+		$statuses_in = "'" . implode( "','", array_map( 'esc_sql', WP_Origin_Plugin::$supported_post_statuses ) ) . "'";
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery
+		$ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT ID FROM {$wpdb->posts}
+				WHERE post_type IN ($types_in)
+				AND post_status IN ($statuses_in)
+				AND ID > %d
+				ORDER BY ID ASC
+				LIMIT %d",
+				intval( $after_id ),
+				self::BATCH_SIZE
+			)
+		);
+		// phpcs:enable
+
+		$posts = array();
+		foreach ( $ids as $id ) {
+			$post = get_post( intval( $id ) );
+			if ( $post instanceof WP_Post ) {
+				$posts[] = $post;
+			}
+		}
+
+		return $posts;
+	}
+
+	private static function get_progress_storage() {
+		$progress = get_option( self::PROGRESS_OPTION, array() );
+		$defaults = array(
+			'processed'    => 0,
+			'total'        => 0,
+			'last_id'      => 0,
+			'started_at'   => time(),
+			'last_tick_at' => time(),
+			'message'      => '',
+		);
+
+		return array_merge( $defaults, is_array( $progress ) ? $progress : array() );
+	}
+
+	private static function budget_exhausted( $started_at ) {
+		if ( microtime( true ) - $started_at > self::TIME_BUDGET_SECONDS ) {
+			return true;
+		}
+
+		$limit = self::memory_limit_bytes();
+		if ( $limit > 0 && memory_get_usage( true ) / $limit > self::MEMORY_BUDGET_FRACTION ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private static function memory_limit_bytes() {
+		$limit = ini_get( 'memory_limit' );
+		if ( '' === $limit || '-1' === $limit ) {
+			return 0;
+		}
+
+		$value = intval( $limit );
+		$unit  = strtolower( substr( $limit, -1 ) );
+		switch ( $unit ) {
+			case 'g':
+				return $value * 1024 * 1024 * 1024;
+			case 'm':
+				return $value * 1024 * 1024;
+			case 'k':
+				return $value * 1024;
+			default:
+				return $value;
+		}
+	}
+
+	private static function record_failure( Throwable $exception ) {
+		$progress                 = self::get_progress_storage();
+		$progress['message']      = $exception->getMessage();
+		$progress['last_tick_at'] = time();
+		update_option( self::PROGRESS_OPTION, $progress, false );
+		update_option( self::STATE_OPTION, self::STATE_FAILED, false );
+	}
+}

--- a/plugins/wp-origin/class-wp-origin-seeder.php
+++ b/plugins/wp-origin/class-wp-origin-seeder.php
@@ -84,6 +84,13 @@ class WP_Origin_Seeder {
 			return;
 		}
 
+		// Wipe any leftover repository tables from a previous failed
+		// activation so the new seeder starts on a clean object store.
+		// Without this, re-activating after a partial seed hits PK
+		// collisions on /objects/ paths the moment Git tries to write
+		// a blob it had already started writing last time.
+		WP_Origin_Plugin::drop_repository_tables();
+
 		update_option( self::STATE_OPTION, self::STATE_PENDING, false );
 		update_option(
 			self::PROGRESS_OPTION,
@@ -108,6 +115,7 @@ class WP_Origin_Seeder {
 		delete_option( self::PROGRESS_OPTION );
 		delete_transient( self::LOCK_TRANSIENT );
 		wp_clear_scheduled_hook( self::CRON_HOOK );
+		WP_Origin_Plugin::drop_repository_tables();
 	}
 
 	public static function get_state() {
@@ -133,7 +141,66 @@ class WP_Origin_Seeder {
 			'last_id'     => isset( $progress['last_id'] ) ? intval( $progress['last_id'] ) : 0,
 			'started_at'  => isset( $progress['started_at'] ) ? intval( $progress['started_at'] ) : 0,
 			'finished_at' => isset( $progress['finished_at'] ) ? intval( $progress['finished_at'] ) : 0,
+			'commits'     => self::get_commit_log( 25 ),
 		);
+	}
+
+	/**
+	 * Walk back from the seed branch (during import) or trunk (after
+	 * finalization) and return the latest commit subjects for the
+	 * admin UI. Returns an empty array if the repository is not yet
+	 * initialised.
+	 */
+	public static function get_commit_log( $limit = 25 ) {
+		try {
+			global $wpdb;
+			$table = $wpdb->prefix . WP_Origin_Plugin::TABLE_PREFIX . 'files';
+			if ( ! $wpdb->get_var( "SHOW TABLES LIKE '" . esc_sql( $table ) . "'" ) ) {
+				return array();
+			}
+			$repository = WP_Origin_Plugin::open_repository();
+		} catch ( Throwable $exception ) {
+			return array();
+		}
+
+		$tip = null;
+		foreach ( array( 'refs/heads/trunk', self::SEED_BRANCH ) as $ref ) {
+			try {
+				if ( ! $repository->branch_exists( $ref ) ) {
+					continue;
+				}
+				$candidate = $repository->get_branch_tip( $ref );
+			} catch ( Throwable $exception ) {
+				continue;
+			}
+			if ( is_string( $candidate ) && '' !== $candidate && ! Commit::is_null_hash( $candidate ) ) {
+				$tip = $candidate;
+				break;
+			}
+		}
+
+		if ( null === $tip ) {
+			return array();
+		}
+
+		$commits = array();
+		$current = $tip;
+		while ( $current && ! Commit::is_null_hash( $current ) && count( $commits ) < $limit ) {
+			try {
+				$commit = $repository->read_object( $current )->as_commit();
+			} catch ( Throwable $exception ) {
+				break;
+			}
+			$lines     = preg_split( "/\r\n|\n|\r/", (string) $commit->message );
+			$subject   = is_array( $lines ) && isset( $lines[0] ) ? trim( $lines[0] ) : '';
+			$commits[] = array(
+				'oid'     => substr( $current, 0, 7 ),
+				'subject' => '' !== $subject ? $subject : '(no message)',
+			);
+			$current = empty( $commit->parents ) ? null : $commit->parents[0];
+		}
+
+		return $commits;
 	}
 
 	public static function is_ready() {

--- a/plugins/wp-origin/class-wp-origin-seeder.php
+++ b/plugins/wp-origin/class-wp-origin-seeder.php
@@ -327,9 +327,12 @@ class WP_Origin_Seeder {
 		}
 
 		$repository->set_branch_tip( 'refs/heads/trunk', $initial_oid );
-		// Drop the staging branch — the seed commits are unreachable
-		// from any ref, so Git will treat their objects as garbage.
-		$repository->set_branch_tip( self::SEED_BRANCH, Commit::NULL_HASH );
+		// Drop the staging branch entirely. Leaving a NULL_HASH file on
+		// disk would cause `info/refs` to advertise a ref with an
+		// invalid OID and break clones.
+		if ( $repository->branch_exists( self::SEED_BRANCH ) ) {
+			$repository->delete_branch( self::SEED_BRANCH );
+		}
 
 		$progress['finished_at'] = time();
 		$progress['percent']     = 100;

--- a/plugins/wp-origin/docker-demo/README.md
+++ b/plugins/wp-origin/docker-demo/README.md
@@ -1,0 +1,57 @@
+# WP Origin demo (Docker)
+
+A self-contained WordPress install pre-loaded with 120 posts and the
+WP Origin plugin **deactivated**, so you can press "Activate" yourself
+and watch the async seeder build the initial import.
+
+## Run it
+
+From the repo root:
+
+```bash
+composer install                                  # toolkit vendor/ must exist
+cd plugins/wp-origin/docker-demo
+docker compose up
+```
+
+The `init` container exits as soon as WordPress is installed and
+seeded; `wp` and `db` keep running. When you see the "WP Origin demo
+is ready" banner, open:
+
+- <http://localhost:8080/wp-admin/plugins.php>
+  Log in as `admin` / `admin` and click **Activate** on WP Origin.
+- <http://localhost:8080/wp-admin/tools.php?page=wp-origin>
+  Watch the progress bar.
+
+## What you'll see
+
+The demo drops a small mu-plugin (`wp-origin-demo-budget.php`) that
+shrinks the seeder's batch size to 5 posts and its time budget to 0
+seconds, so each cron tick imports one batch and reschedules itself.
+On 120 posts that's ~24 visible ticks before the seeder squashes the
+side branch into a single "Initial import from WordPress" commit on
+trunk and flips the state to `done`.
+
+Once `state === done`, generate an Application Password from
+<http://localhost:8080/wp-admin/profile.php> and clone:
+
+```bash
+git clone http://admin:<app-password>@localhost:8080/wp-json/git/v1/md.git wp-origin
+```
+
+## Tearing down
+
+```bash
+docker compose down -v
+```
+
+Removes containers, volumes, and the seeded WordPress install.
+
+## Notes
+
+- The plugin source is mounted read-only from the host (`../..`),
+  so edits to `plugins/wp-origin/*.php` take effect on the next
+  request.
+- Remove `wp-content/mu-plugins/wp-origin-demo-budget.php` (via
+  `docker compose exec wp rm …`) to see production-default seeder
+  speed instead.

--- a/plugins/wp-origin/docker-demo/docker-compose.yml
+++ b/plugins/wp-origin/docker-demo/docker-compose.yml
@@ -1,0 +1,54 @@
+services:
+  db:
+    image: mysql:8
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: wp
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-uroot", "-proot", "--silent"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+
+  wp:
+    image: wordpress:php8.2-apache
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "${WP_ORIGIN_DEMO_PORT:-8090}:80"
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_USER: root
+      WORDPRESS_DB_PASSWORD: root
+      WORDPRESS_DB_NAME: wp
+      WORDPRESS_DEBUG: "1"
+      WORDPRESS_CONFIG_EXTRA: |
+        define( 'WP_ENVIRONMENT_TYPE', 'local' );
+    volumes:
+      - ../../..:/srv/php-toolkit:ro
+      - wp:/var/www/html
+
+  init:
+    image: wordpress:cli-php8.2
+    depends_on:
+      wp:
+        condition: service_started
+      db:
+        condition: service_healthy
+    user: "33:33"
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_USER: root
+      WORDPRESS_DB_PASSWORD: root
+      WORDPRESS_DB_NAME: wp
+      WP_ORIGIN_DEMO_HOST: ${WP_ORIGIN_DEMO_HOST:-localhost:8090}
+    volumes:
+      - wp:/var/www/html
+      - ../../..:/srv/php-toolkit:ro
+      - ./init.sh:/init.sh:ro
+    entrypoint: ["bash", "/init.sh"]
+    restart: "no"
+
+volumes:
+  wp:

--- a/plugins/wp-origin/docker-demo/init.sh
+++ b/plugins/wp-origin/docker-demo/init.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# One-shot installer that fires inside the wordpress:cli container.
+# Waits for the wp service to populate /var/www/html, installs
+# WordPress, generates 120 posts so initial-import seeding visibly
+# spans many cron ticks, drops the WP Origin plugin source into place,
+# and installs the small-budget mu-plugin so each batch is one cron
+# tick (otherwise the host is fast enough to import 120 posts in a
+# single tick and the progress bar barely moves).
+#
+# The plugin is INTENTIONALLY left deactivated. Open
+# http://${WP_ORIGIN_DEMO_HOST:-localhost:8090}/wp-admin/plugins.php, click "Activate" on
+# WP Origin, then watch the progress bar at
+# http://${WP_ORIGIN_DEMO_HOST:-localhost:8090}/wp-admin/tools.php?page=wp-origin.
+set -euo pipefail
+
+cd /var/www/html
+
+for _ in $(seq 1 60); do
+	if [ -f wp-load.php ]; then
+		break
+	fi
+	sleep 1
+done
+
+if ! wp core is-installed 2>/dev/null; then
+	wp core install \
+		--url=http://${WP_ORIGIN_DEMO_HOST:-localhost:8090} \
+		--title="WP Origin Demo" \
+		--admin_user=admin \
+		--admin_password=admin \
+		--admin_email=admin@example.com \
+		--skip-email
+	wp option update permalink_structure '/%postname%/'
+	wp rewrite flush --hard
+
+	wp post generate \
+		--count=120 \
+		--post_type=post \
+		--post_status=publish \
+		--post_author=1
+fi
+
+# Mount toolkit components and the plugin into wp-content. Symlinks
+# (not copies) so the user can keep editing code on the host and see
+# changes immediately.
+if [ ! -e wp-content/plugins/wp-origin ]; then
+	ln -s /srv/php-toolkit/plugins/wp-origin wp-content/plugins/wp-origin
+fi
+if [ ! -e wp-content/components ]; then
+	ln -s /srv/php-toolkit/components wp-content/components
+fi
+if [ ! -e wp-content/vendor ]; then
+	ln -s /srv/php-toolkit/vendor wp-content/vendor
+fi
+
+# Force the seeder to span many cron ticks regardless of how fast the
+# host CPU is, so the progress bar is visibly active. Remove this file
+# to see production-default behaviour.
+mkdir -p wp-content/mu-plugins
+cp /srv/php-toolkit/plugins/wp-origin/Tests/ci-mu-test-helper.php \
+	wp-content/mu-plugins/wp-origin-demo-budget.php
+
+# Ensure WP Origin is NOT activated yet — the user will press Activate.
+wp plugin deactivate wp-origin --quiet 2>/dev/null || true
+
+POST_COUNT=$(wp post list --post_type=post --post_status=publish --format=count)
+
+cat <<EOF
+
+============================================================
+  WP Origin demo is ready.
+
+  URL:    http://${WP_ORIGIN_DEMO_HOST:-localhost:8090}/wp-admin/
+  user:   admin
+  pass:   admin
+  posts:  ${POST_COUNT} (plus default page)
+
+  1. Visit /wp-admin/plugins.php and click Activate on WP Origin.
+  2. Watch progress at /wp-admin/tools.php?page=wp-origin.
+  3. Once the bar reaches 100%, clone with:
+        git clone http://admin:<app-password>@${WP_ORIGIN_DEMO_HOST:-localhost:8090}/wp-json/git/v1/md.git wp-origin
+
+     Generate the app password from /wp-admin/profile.php first.
+============================================================
+
+EOF

--- a/plugins/wp-origin/wp-origin.php
+++ b/plugins/wp-origin/wp-origin.php
@@ -12,8 +12,12 @@ if ( file_exists( __DIR__ . '/php-toolkit.phar' ) ) {
 
 require_once __DIR__ . '/class-wp-origin-plugin.php';
 require_once __DIR__ . '/class-wp-origin-buffering-response.php';
+require_once __DIR__ . '/class-wp-origin-seeder.php';
+require_once __DIR__ . '/class-wp-origin-admin.php';
 
 add_filter( 'wp_is_application_passwords_available', '__return_true' );
 add_filter( 'wp_is_application_passwords_available_for_user', '__return_true', 10, 2 );
+
+register_activation_hook( __FILE__, array( 'WP_Origin_Plugin', 'on_activation' ) );
 
 WP_Origin_Plugin::bootstrap();

--- a/plugins/wp-origin/wp-origin.php
+++ b/plugins/wp-origin/wp-origin.php
@@ -18,6 +18,32 @@ require_once __DIR__ . '/class-wp-origin-admin.php';
 add_filter( 'wp_is_application_passwords_available', '__return_true' );
 add_filter( 'wp_is_application_passwords_available_for_user', '__return_true', 10, 2 );
 
+if ( ! defined( 'WP_ORIGIN_PLUGIN_FILE' ) ) {
+	define( 'WP_ORIGIN_PLUGIN_FILE', __FILE__ );
+}
+
 register_activation_hook( __FILE__, array( 'WP_Origin_Plugin', 'on_activation' ) );
+
+// After the user clicks Activate, send them straight to the seeder
+// progress page so they can watch the import without hunting for a
+// menu item. Skipped for bulk activations and CLI/AJAX flows so we
+// only intercept the one-click admin "Activate" link.
+add_action(
+	'activated_plugin',
+	function ( $plugin ) {
+		if ( plugin_basename( WP_ORIGIN_PLUGIN_FILE ) !== $plugin ) {
+			return;
+		}
+		if ( wp_doing_ajax() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
+			return;
+		}
+		$action = isset( $_REQUEST['action'] ) ? sanitize_key( wp_unslash( $_REQUEST['action'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( '' !== $action && 'activate' !== $action ) {
+			return;
+		}
+		wp_safe_redirect( admin_url( 'tools.php?page=' . WP_Origin_Admin::PAGE_SLUG ) );
+		exit;
+	}
+);
 
 WP_Origin_Plugin::bootstrap();


### PR DESCRIPTION
Stacks on #28. Once that lands, GitHub will retarget this PR to trunk.

The wpdb-filesystem PR makes the plugin's first request build a single "Sync from WordPress" commit covering every post on the site. On a small dev site that's instant; on a real site with thousands of posts it dies on max_execution_time. This adds a resumable state-machine seeder that runs from WP-Cron and only opens the repository for clone/push/pull once the import has finished.

## How it works

State machine, persisted in `wp_options`:

- `pending` → activation queues a one-off cron event.
- `in_progress` → each tick converts a batch of posts to Markdown, creates a "Seed batch" commit on `refs/heads/_wp_origin_seed`, updates the progress option, and reschedules itself when 15 s elapses or memory hits 70% of the limit.
- `finalizing` → the next tick reads the seed branch's tree, creates a single parent-less "Initial import from WordPress" commit pointing at it, sets `refs/heads/trunk` to that commit, and drops the seed branch. Clones now see one clean root commit.
- `done` → repository is open for business.
- `failed` → admin can retry from the Tools → WP Origin page.

A transient lock prevents concurrent ticks. No Action Scheduler dependency — plain WP-Cron only.

## What clients see

While state is anything but `done`, every Smart-HTTP request returns HTTP 503 + `Retry-After: 15` with a plaintext body:

> WP Origin is preparing the repository (40%, 200/500 posts). Please try again shortly.

Better than a half-built history.

## What admins see

A new **Tools → WP Origin** page shows a live progress bar (state, percent, processed / total, last message) by polling `/wp-json/wp-origin/v1/seed-status` every 2 s. A "Retry import" button POSTs to `/wp-json/wp-origin/v1/seed-retry` for the failed-state case.

## Test plan

The existing wp-origin e2e job in CI is the proof:

- Workflow now updates the seeded posts **before** activating the plugin, then drives `wp cron event run --due-now` in a 30-iteration loop until `wp_origin_seed_state` reaches `done`. Failure of that loop fails the job.
- Two new PHPUnit assertions in `EndToEndTest.php`:
  - `testSeedStatusReportsDone` — `/wp-json/wp-origin/v1/seed-status` returns `state=done, percent=100, total>0`.
  - `testInitialCommitIsParentless` — the first commit on `trunk` is "Initial import from WordPress" with zero parents and no "Seed batch" subjects leaked through.
- Existing round-trip test still passes (clone, push, fresh-clone-sees-history, etc).