### PR TITLE
Fix WP Origin clone failures from binary wpdb writes

### DIFF
--- a/components/Filesystem/Tests/WpdbFilesystemTest.php
+++ b/components/Filesystem/Tests/WpdbFilesystemTest.php
@@ -31,6 +31,20 @@ class WpdbFilesystemTest extends FilesystemTestCase {
 		$this->assertSame( $binary, $this->fs->get_contents( '/blob.bin' ) );
 	}
 
+	public function testOpenWriteStreamRoundTripsBinaryContents() {
+		$binary = '';
+		for ( $i = 0; $i < 256; $i++ ) {
+			$binary .= chr( $i );
+		}
+
+		$writer = $this->fs->open_write_stream( '/streamed.bin' );
+		$writer->append_bytes( substr( $binary, 0, 128 ) );
+		$writer->append_bytes( substr( $binary, 128 ) );
+		$writer->close_writing();
+
+		$this->assertSame( $binary, $this->fs->get_contents( '/streamed.bin' ) );
+	}
+
 	public function testReplacingFileContentsOverwritesBytes() {
 		$this->fs->put_contents( '/object', 'first' );
 		$this->fs->put_contents( '/object', 'second' );

--- a/components/Filesystem/class-wpdbfilesystem.php
+++ b/components/Filesystem/class-wpdbfilesystem.php
@@ -99,15 +99,7 @@ class WpdbFilesystem implements Filesystem {
 			)
 		);
 		if ( ! $root_exists ) {
-			$this->wpdb->insert(
-				$this->files_table,
-				array(
-					'path'     => '/',
-					'type'     => 'dir',
-					'contents' => null,
-				),
-				array( '%s', '%s', '%s' )
-			);
+			$this->replace_file_record( '/', 'dir', null );
 		}
 	}
 
@@ -252,22 +244,17 @@ class WpdbFilesystem implements Filesystem {
 				function () use ( $path ) {
 					$parent = wp_unix_dirname( $path );
 
-					$this->wpdb->insert(
-						$this->files_table,
-						array(
-							'path'     => $path,
-							'type'     => 'dir',
-							'contents' => null,
+					$this->replace_file_record( $path, 'dir', null );
+					$this->assert_db_result(
+						$this->wpdb->insert(
+							$this->entries_table,
+							array(
+								'parent_path' => $parent,
+								'name'        => basename( $path ),
+							),
+							array( '%s', '%s' )
 						),
-						array( '%s', '%s', '%s' )
-					);
-					$this->wpdb->insert(
-						$this->entries_table,
-						array(
-							'parent_path' => $parent,
-							'name'        => basename( $path ),
-						),
-						array( '%s', '%s' )
+						'Failed to create directory entry: ' . $path
 					);
 				}
 			);
@@ -380,22 +367,17 @@ class WpdbFilesystem implements Filesystem {
 				function () use ( $path, $data ) {
 					$parent = wp_unix_dirname( $path );
 
-					$this->wpdb->replace(
-						$this->files_table,
-						array(
-							'path'     => $path,
-							'type'     => 'file',
-							'contents' => $data,
+					$this->replace_file_record( $path, 'file', $data );
+					$this->assert_db_result(
+						$this->wpdb->replace(
+							$this->entries_table,
+							array(
+								'parent_path' => $parent,
+								'name'        => basename( $path ),
+							),
+							array( '%s', '%s' )
 						),
-						array( '%s', '%s', '%s' )
-					);
-					$this->wpdb->replace(
-						$this->entries_table,
-						array(
-							'parent_path' => $parent,
-							'name'        => basename( $path ),
-						),
-						array( '%s', '%s' )
+						'Failed to write directory entry: ' . $path
 					);
 				}
 			);
@@ -408,6 +390,34 @@ class WpdbFilesystem implements Filesystem {
 				$e
 			);
 		}
+	}
+
+	private function replace_file_record( $path, $type, $contents ) {
+		$contents_sql = null === $contents ? 'NULL' : "X'" . bin2hex( $contents ) . "'";
+		$result       = $this->wpdb->query(
+			$this->wpdb->prepare(
+				"REPLACE INTO {$this->files_table} (path, type, contents) VALUES (%s, %s, {$contents_sql})",
+				$path,
+				$type
+			)
+		);
+
+		$this->assert_db_result(
+			$result,
+			'Failed to write file record: ' . $path
+		);
+	}
+
+	private function assert_db_result( $result, $message ) {
+		if ( false !== $result ) {
+			return;
+		}
+
+		if ( isset( $this->wpdb->last_error ) && '' !== $this->wpdb->last_error ) {
+			$message .= ': ' . $this->wpdb->last_error;
+		}
+
+		throw new FilesystemException( $message );
 	}
 
 	private function in_transaction( $callback ) {


### PR DESCRIPTION
## Problem

WP Origin stores its Git repository in `WpdbFilesystem`. When the Git object writer creates an object, it writes compressed binary bytes to `objects/.tmp` through `open_write_stream()`, then renames that temporary file to the final SHA-addressed object path.

`WpdbFilesystem::put_contents()` was sending file contents through `$wpdb->replace()` as a `%s` value. That path is fine for ordinary text, but Git object bytes are deflated binary data and may contain NUL and other non-text bytes. In the Desktop/Playground database layer, that temporary object write was not reliably persisted, and the failure was not surfaced. The next step then tried to rename `objects/.tmp`, found no file, and the REST Git endpoint returned a 500 during `git clone`:

```text
File not found: /objects/.tmp
```

## Fix

This PR makes `WpdbFilesystem` write file records in a binary-safe way:

- stores file contents using a SQL hex binary literal instead of passing blob bytes through a text placeholder
- keeps directory records as `NULL` contents
- checks wpdb write results and reports `last_error` instead of allowing silent DB write failures
- adds a streamed binary round-trip test that exercises the same `open_write_stream()` path used by Git object writes

## User impact

Cloning the WP Origin Git remote from Desktop now gets past repository sync and fetches the Markdown files instead of failing with an HTTP 500.

## Validation

- `vendor/bin/phpunit components/Filesystem/Tests/WpdbFilesystemTest.php`
- `vendor/bin/phpunit components/Git/Tests/GitRepositoryTest.php components/Git/Tests/GitObjectWriteStreamTest.php`
- `composer test` outside the sandbox: 5427 tests, 2014 skipped
- `vendor/bin/phpcs -d memory_limit=1G components/Filesystem/class-wpdbfilesystem.php`
- Retried the Desktop clone URL and confirmed `git clone` succeeds

Note: full-repo `composer lint` is not currently a clean signal in this checkout. The default 1G run exhausts memory in PHPCS's JS tokenizer, and a 4G run scans unrelated generated/dependency paths such as `node_modules` and `dist` and reports pre-existing issues.
