### PR TITLE
WP Origin: export Guidelines skills for coding agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ vendor/
 opfs/
 node_modules
 .cursor
+.context/
 rest/
 dist/
 outdir/

--- a/bin/test-wp-origin-git-actions.sh
+++ b/bin/test-wp-origin-git-actions.sh
@@ -90,16 +90,50 @@ assert_push_summary_contains() {
 	fi
 }
 
+wait_for_seed_done() {
+	for _ in $(seq 1 120); do
+		STATUS_JSON="$(curl -sS -f -H "Authorization: Basic $AUTH_HEADER" "$BASE_URL/wp-json/wp-origin/v1/seed-status" || true)"
+		STATE="$(printf '%s' "$STATUS_JSON" | php -r '$state = json_decode(stream_get_contents(STDIN), true); echo is_array($state) && isset($state["state"]) ? $state["state"] : "";')"
+		if [ "$STATE" = "done" ]; then
+			return
+		fi
+		sleep 1
+	done
+
+	cat "$PLAYGROUND_LOG"
+	echo "WP Origin seeder did not finish." >&2
+	exit 1
+}
+
+wait_for_seed_done
 git -c protocol.version=2 clone "$REMOTE_AUTH_URL" "$CLONE_DIR"
 
 test -f "$CLONE_DIR/post/hello-world.md"
 test -f "$CLONE_DIR/page/sample-page.md"
+test -f "$CLONE_DIR/wp_guideline/skills/wp-origin/SKILL.md"
+test -L "$CLONE_DIR/.agents/skills"
+test -L "$CLONE_DIR/.claude/skills"
+test -L "$CLONE_DIR/AGENTS.md"
+test -L "$CLONE_DIR/CLAUDE.md"
 grep -q 'Hello from WordPress' "$CLONE_DIR/post/hello-world.md"
 grep -Fq 'title: "Hello World"' "$CLONE_DIR/post/hello-world.md"
 grep -Fq 'status: "published"' "$CLONE_DIR/post/hello-world.md"
 grep -Fq 'description: "Hand-authored summary."' "$CLONE_DIR/post/hello-world.md"
 grep -Eq '^date: "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z"$' "$CLONE_DIR/post/hello-world.md"
 ! grep -Eq '^(id|type|slug|date_gmt|modified_gmt):' "$CLONE_DIR/post/hello-world.md"
+head -n 1 "$CLONE_DIR/wp_guideline/skills/wp-origin/SKILL.md" | grep -Fxq -- '---'
+grep -Fq 'name: "wp-origin"' "$CLONE_DIR/wp_guideline/skills/wp-origin/SKILL.md"
+grep -Fq 'description: "Guide for coding agents working in a WP Origin checkout of a WordPress site."' "$CLONE_DIR/wp_guideline/skills/wp-origin/SKILL.md"
+grep -Fq '# WP Origin AGENTS.md' "$CLONE_DIR/wp_guideline/skills/wp-origin/SKILL.md"
+grep -Fq 'This repository is a Git checkout of a WordPress site' "$CLONE_DIR/wp_guideline/skills/wp-origin/SKILL.md"
+grep -Fq 'This repository is a Git checkout of a WordPress site' "$CLONE_DIR/.agents/skills/wp-origin/SKILL.md"
+grep -Fq 'This repository is a Git checkout of a WordPress site' "$CLONE_DIR/.claude/skills/wp-origin/SKILL.md"
+grep -Fq 'This repository is a Git checkout of a WordPress site' "$CLONE_DIR/AGENTS.md"
+grep -Fq 'This repository is a Git checkout of a WordPress site' "$CLONE_DIR/CLAUDE.md"
+[ "$(readlink "$CLONE_DIR/.agents/skills")" = "../wp_guideline/skills" ]
+[ "$(readlink "$CLONE_DIR/.claude/skills")" = "../wp_guideline/skills" ]
+[ "$(readlink "$CLONE_DIR/AGENTS.md")" = "wp_guideline/skills/wp-origin/SKILL.md" ]
+[ "$(readlink "$CLONE_DIR/CLAUDE.md")" = "wp_guideline/skills/wp-origin/SKILL.md" ]
 
 POST_ID="$(curl -sS -f -H "Authorization: Basic $AUTH_HEADER" "$BASE_URL/wp-json/wp/v2/posts?slug=hello-world&context=edit" | php -r '
 $posts = json_decode(stream_get_contents(STDIN), true);

--- a/components/Git/Tests/GitRepositoryTest.php
+++ b/components/Git/Tests/GitRepositoryTest.php
@@ -4,6 +4,7 @@ namespace WordPress\Git\Tests;
 
 use PHPUnit\Framework\TestCase;
 use WordPress\Filesystem\InMemoryFilesystem;
+use WordPress\Git\GitException;
 use WordPress\Git\GitRepository;
 use WordPress\Git\Model\Commit;
 use WordPress\Git\Model\Tree;
@@ -171,6 +172,88 @@ COMMIT
 			)
 		);
 		$this->assertEquals( $commit_oid, $repo->get_branch_tip() );
+	}
+
+	public function test_commit_symbolic_link() {
+		$repo = new GitRepository( InMemoryFilesystem::create() );
+		$repo->set_branch_tip( 'refs/heads/trunk', Commit::NULL_HASH );
+		$repo->set_branch_tip( 'HEAD', 'ref: refs/heads/trunk' );
+
+		$repo->commit(
+			array(
+				'updates'         => array(
+					'target/file.txt' => 'Hello, world!',
+				),
+				'create_symlinks' => array(
+					'alias/file-link'       => '../target/file.txt',
+					'alias/second-file-link' => '../target/file.txt',
+				),
+			)
+		);
+
+		$tree              = $repo->read_object_by_path( '/alias' )->as_tree();
+		$link_entry        = $tree->entries['file-link'];
+		$second_link_entry = $tree->entries['second-file-link'];
+
+		$this->assertSame( TreeEntry::FILE_MODE_SYMBOLIC_LINK, $link_entry->get_mode_bucket() );
+		$this->assertSame( TreeEntry::FILE_MODE_SYMBOLIC_LINK, $second_link_entry->get_mode_bucket() );
+		$this->assertSame( '../target/file.txt', $repo->read_object( $link_entry->hash )->consume_all() );
+		$this->assertSame( '../target/file.txt', $repo->read_object( $second_link_entry->hash )->consume_all() );
+	}
+
+	public function test_commit_can_replace_directory_with_symbolic_link() {
+		$repo = new GitRepository( InMemoryFilesystem::create() );
+		$repo->set_branch_tip( 'refs/heads/trunk', Commit::NULL_HASH );
+		$repo->set_branch_tip( 'HEAD', 'ref: refs/heads/trunk' );
+
+		$repo->commit(
+			array(
+				'updates' => array(
+					'.agents/skills/wordpress-content-review' => 'wp_guideline/skills/wordpress-content-review',
+				),
+			)
+		);
+		$repo->commit(
+			array(
+				'create_symlinks' => array(
+					'.agents/skills' => '../wp_guideline/skills',
+				),
+				'deletes'         => array(
+					'.agents/skills/wordpress-content-review',
+				),
+			)
+		);
+
+		$tree       = $repo->read_object_by_path( '/.agents' )->as_tree();
+		$link_entry = $tree->entries['skills'];
+
+		$this->assertSame( TreeEntry::FILE_MODE_SYMBOLIC_LINK, $link_entry->get_mode_bucket() );
+		$this->assertSame( '../wp_guideline/skills', $repo->read_object( $link_entry->hash )->consume_all() );
+	}
+
+	public function test_commit_rejects_child_update_under_regular_file() {
+		$repo = new GitRepository( InMemoryFilesystem::create() );
+		$repo->set_branch_tip( 'refs/heads/trunk', Commit::NULL_HASH );
+		$repo->set_branch_tip( 'HEAD', 'ref: refs/heads/trunk' );
+
+		$repo->commit(
+			array(
+				'updates' => array(
+					'agent' => 'regular file',
+				),
+			)
+		);
+
+		$this->expectException( GitException::class );
+		$this->expectExceptionMessage( 'Cannot update child entries under a non-directory path' );
+
+		$repo->commit(
+			array(
+				'updates' => array(
+					'agent/skill.md' => 'child',
+				),
+			)
+		);
 	}
 
 	public function test_initial_commit_has_no_null_parent() {

--- a/components/Git/class-gitobjectencoder.php
+++ b/components/Git/class-gitobjectencoder.php
@@ -58,6 +58,14 @@ class GitObjectEncoder implements ByteWriteStream {
 		if ( ! $fs->is_dir( $target_dir ) ) {
 			$fs->mkdir( $target_dir, array( 'recursive' => true ) );
 		}
+		if ( $fs->is_file( $target_path ) ) {
+			// Git objects are content-addressed. If this path already
+			// exists, the temporary object has identical contents and can
+			// be discarded instead of replacing the canonical object file.
+			$fs->rm( 'objects/.tmp' );
+
+			return;
+		}
 		$fs->rename( 'objects/.tmp', $target_path );
 	}
 }

--- a/components/Git/class-gitrepository.php
+++ b/components/Git/class-gitrepository.php
@@ -639,9 +639,10 @@ class GitRepository {
 	 */
 	public function commit( $options = array() ) {
 		// First process all blob updates.
-		$updates    = $options['updates'] ?? array();
-		$deletes    = $options['deletes'] ?? array();
-		$move_trees = $options['move_trees'] ?? array();
+		$updates         = $options['updates'] ?? array();
+		$create_symlinks = $options['create_symlinks'] ?? array();
+		$deletes         = $options['deletes'] ?? array();
+		$move_trees      = $options['move_trees'] ?? array();
 
 		// Track which trees need updating.
 		$changed_trees = array(
@@ -661,6 +662,24 @@ class GitRepository {
 				array(
 					'name' => $basename,
 					'mode' => TreeEntry::FILE_MODE_REGULAR_NON_EXECUTABLE,
+					'hash' => $blob_oid,
+				)
+			);
+		}
+
+		// Process symbolic link updates.
+		foreach ( $create_symlinks as $path => $target ) {
+			$path     = '/' . ltrim( $path, '/' );
+			$blob_oid = $this->add_object( 'blob', $target );
+			$this->mark_tree_path_changed( $changed_trees, wp_unix_dirname( $path ) );
+			$basename = basename( $path );
+			if ( '' === $basename ) {
+				throw new GitException( 'Cannot commit a symlink with an empty filename' );
+			}
+			$changed_trees[ wp_unix_dirname( $path ) ]->entries[ basename( $path ) ] = new TreeEntry(
+				array(
+					'name' => $basename,
+					'mode' => TreeEntry::FILE_MODE_SYMBOLIC_LINK,
 					'hash' => $blob_oid,
 				)
 			);
@@ -1024,10 +1043,25 @@ class GitRepository {
 		// Recursively process child trees.
 		foreach ( $changed_trees as $child_path => $child_tree ) {
 			if ( wp_unix_dirname( $child_path ) === $path && '/' !== $child_path ) {
-				$child_oid                               = $this->commit_tree( $child_path, $changed_trees );
-				$tree_objects[ basename( $child_path ) ] = new TreeEntry(
+				$child_name = basename( $child_path );
+				if (
+					isset( $tree_objects[ $child_name ] ) &&
+					TreeEntry::FILE_MODE_SYMBOLIC_LINK === $tree_objects[ $child_name ]->get_mode_bucket()
+				) {
+					// The parent path became a symlink, so the old
+					// directory descendants are intentionally ignored.
+					continue;
+				}
+				if (
+					isset( $tree_objects[ $child_name ] ) &&
+					TreeEntry::FILE_MODE_DIRECTORY !== $tree_objects[ $child_name ]->get_mode_bucket()
+				) {
+					throw new GitException( 'Cannot update child entries under a non-directory path' );
+				}
+				$child_oid                   = $this->commit_tree( $child_path, $changed_trees );
+				$tree_objects[ $child_name ] = new TreeEntry(
 					array(
-						'name' => basename( $child_path ),
+						'name' => $child_name,
 						'mode' => TreeEntry::FILE_MODE_DIRECTORY,
 						'hash' => $child_oid,
 					)

--- a/plugins/wp-origin/blueprint-e2e.json
+++ b/plugins/wp-origin/blueprint-e2e.json
@@ -2,7 +2,7 @@
 	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
 	"meta": {
 		"title": "WP Origin E2E",
-		"description": "Boot a WordPress site with WP Origin active and seeded content.",
+		"description": "Boot a WordPress site with WP Origin, Gutenberg Guidelines, and seeded content active.",
 		"author": "adamziel"
 	},
 	"preferredVersions": {
@@ -11,6 +11,24 @@
 	},
 	"steps": [
 		{
+			"step": "setSiteOptions",
+			"options": {
+				"gutenberg-experiments": {
+					"gutenberg-guidelines": true
+				}
+			}
+		},
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "gutenberg"
+			},
+			"options": {
+				"activate": true
+			}
+		},
+		{
 			"step": "activatePlugin",
 			"pluginPath": "/wordpress/wp-content/plugins/wp-origin"
 		},
@@ -18,7 +36,7 @@
 			"step": "runPHP",
 			"code": {
 				"filename": "seed-wp-origin-e2e.php",
-					"content": "<?php\nrequire '/wordpress/wp-load.php';\n$admins = get_users( array( 'role' => 'Administrator', 'number' => 1 ) );\n$admin = $admins[0];\nupdate_option( 'permalink_structure', '/%postname%/' );\nflush_rewrite_rules();\n$hello = get_page_by_path( 'hello-world', OBJECT, 'post' );\nif ( $hello ) {\n\twp_update_post( array(\n\t\t'ID' => $hello->ID,\n\t\t'post_title' => 'Hello World',\n\t\t'post_content' => '<!-- wp:paragraph --><p>Hello from WordPress</p><!-- /wp:paragraph -->',\n\t\t'post_excerpt' => 'Hand-authored summary.',\n\t\t'post_status' => 'publish',\n\t) );\n}\n$page = get_page_by_path( 'sample-page', OBJECT, 'page' );\nif ( $page ) {\n\twp_update_post( array(\n\t\t'ID' => $page->ID,\n\t\t'post_title' => 'Sample Page',\n\t\t'post_content' => '<!-- wp:paragraph --><p>Page from WordPress</p><!-- /wp:paragraph -->',\n\t\t'post_status' => 'publish',\n\t) );\n}\nlist( $raw_password ) = WP_Application_Passwords::create_new_application_password( $admin->ID, array( 'name' => 'WP Origin E2E' ) );\n$password = preg_replace( '/\\s+/', '', $raw_password );\nfile_put_contents(\n\t'__WP_ORIGIN_CREDENTIALS_FILE__',\n\twp_json_encode(\n\t\tarray(\n\t\t\t'username' => $admin->user_login,\n\t\t\t'password' => $password,\n\t\t\t'post_slug' => 'hello-world',\n\t\t\t'page_slug' => 'sample-page',\n\t\t)\n\t)\n);\n"
+				"content": "<?php\nrequire '/wordpress/wp-load.php';\n$admins = get_users( array( 'role' => 'Administrator', 'number' => 1 ) );\n$admin = $admins[0];\n$experiments = get_option( 'gutenberg-experiments' );\nif ( ! is_array( $experiments ) ) {\n\t$experiments = array();\n}\n$experiments['gutenberg-guidelines'] = true;\nupdate_option( 'gutenberg-experiments', $experiments );\nif ( class_exists( 'WP_Origin_Plugin' ) ) {\n\tWP_Origin_Plugin::install_default_agent_skill();\n}\nupdate_option( 'permalink_structure', '/%postname%/' );\nflush_rewrite_rules();\n$hello = get_page_by_path( 'hello-world', OBJECT, 'post' );\nif ( $hello ) {\n\twp_update_post( array(\n\t\t'ID' => $hello->ID,\n\t\t'post_title' => 'Hello World',\n\t\t'post_content' => '<!-- wp:paragraph --><p>Hello from WordPress</p><!-- /wp:paragraph -->',\n\t\t'post_excerpt' => 'Hand-authored summary.',\n\t\t'post_status' => 'publish',\n\t) );\n}\n$page = get_page_by_path( 'sample-page', OBJECT, 'page' );\nif ( $page ) {\n\twp_update_post( array(\n\t\t'ID' => $page->ID,\n\t\t'post_title' => 'Sample Page',\n\t\t'post_content' => '<!-- wp:paragraph --><p>Page from WordPress</p><!-- /wp:paragraph -->',\n\t\t'post_status' => 'publish',\n\t) );\n}\nlist( $raw_password ) = WP_Application_Passwords::create_new_application_password( $admin->ID, array( 'name' => 'WP Origin E2E' ) );\n$password = preg_replace( '/\\s+/', '', $raw_password );\nfile_put_contents(\n\t'__WP_ORIGIN_CREDENTIALS_FILE__',\n\twp_json_encode(\n\t\tarray(\n\t\t\t'username' => $admin->user_login,\n\t\t\t'password' => $password,\n\t\t\t'post_slug' => 'hello-world',\n\t\t\t'page_slug' => 'sample-page',\n\t\t\t'guideline_skill_slug' => 'wp-origin',\n\t\t)\n\t)\n);\n"
 			}
 		}
 	]

--- a/plugins/wp-origin/class-wp-origin-admin.php
+++ b/plugins/wp-origin/class-wp-origin-admin.php
@@ -60,23 +60,9 @@ class WP_Origin_Admin {
 		// work — instead of stalling for one tick per 2-second JS
 		// interval. The transient lock inside tick() makes repeated
 		// calls safe.
-		self::drive_seeder( 1.5 );
+		WP_Origin_Seeder::drive( 1.5 );
 
 		return rest_ensure_response( WP_Origin_Seeder::get_progress() );
-	}
-
-	private static function drive_seeder( $seconds ) {
-		$deadline = microtime( true ) + $seconds;
-		while ( ! WP_Origin_Seeder::is_ready() && microtime( true ) < $deadline ) {
-			$state_before = WP_Origin_Seeder::get_state();
-			WP_Origin_Seeder::tick();
-			if ( WP_Origin_Seeder::get_state() === $state_before
-				&& 'in_progress' !== $state_before
-				&& 'pending' !== $state_before
-			) {
-				break;
-			}
-		}
 	}
 
 	public static function rest_retry() {

--- a/plugins/wp-origin/class-wp-origin-plugin.php
+++ b/plugins/wp-origin/class-wp-origin-plugin.php
@@ -29,16 +29,29 @@ use WordPress\Markdown\MarkdownProducer;
  *      changes back to WordPress.
  */
 class WP_Origin_Plugin {
-	const DEFAULT_BRANCH  = 'trunk';
-	const ROUTE_NAMESPACE = 'git/v1';
-	const ROUTE_PATTERN   = '/md\.git(?P<path>/.*)?';
-	const EPOCH_TIMESTAMP = 946684800;
-	const TABLE_PREFIX    = 'wp_origin_';
+	const DEFAULT_BRANCH     = 'trunk';
+	const ROUTE_NAMESPACE    = 'git/v1';
+	const ROUTE_PATTERN      = '/md\.git(?P<path>/.*)?';
+	const EPOCH_TIMESTAMP    = 946684800;
+	const TABLE_PREFIX       = 'wp_origin_';
+	const AGENT_SKILL_SOURCE = 'wp-origin';
+	const AGENT_SKILL_SLUG   = 'wp-origin';
+	const AGENT_SKILL_TITLE  = 'WP Origin AGENTS.md';
 
 	public static $supported_post_types    = array( 'post', 'page' );
 	public static $supported_post_statuses = array( 'publish', 'draft', 'pending', 'private', 'future' );
 
+	private static $guideline_type_directories = array(
+		'artifact'    => 'artifacts',
+		'content'     => 'content',
+		'instruction' => 'instructions',
+		'memory'      => 'memories',
+		'plan'        => 'plans',
+		'skill'       => 'skills',
+	);
+
 	public static function bootstrap() {
+		add_action( 'init', array( __CLASS__, 'install_default_agent_skill' ), 20 );
 		add_action( 'rest_api_init', array( __CLASS__, 'register_routes' ) );
 		add_filter( 'rest_post_dispatch', array( __CLASS__, 'add_authentication_challenge' ), 10, 3 );
 		add_filter( 'rest_pre_serve_request', array( __CLASS__, 'serve_git_response' ), 10, 4 );
@@ -48,7 +61,71 @@ class WP_Origin_Plugin {
 	}
 
 	public static function on_activation() {
+		self::install_default_agent_skill();
 		WP_Origin_Seeder::on_activation();
+	}
+
+	public static function install_default_agent_skill() {
+		if ( ! self::guidelines_available() || ! function_exists( 'wp_install_skill' ) ) {
+			return;
+		}
+
+		wp_install_skill(
+			self::AGENT_SKILL_SOURCE,
+			self::AGENT_SKILL_TITLE,
+			'Guide for coding agents working in a WP Origin checkout of a WordPress site.',
+			self::get_default_agent_skill_content(),
+			array(
+				'post_name' => self::AGENT_SKILL_SLUG,
+			)
+		);
+	}
+
+	public static function get_supported_post_types() {
+		$post_types = self::$supported_post_types;
+		if ( self::guidelines_available() ) {
+			$post_types[] = 'wp_guideline';
+		}
+
+		return $post_types;
+	}
+
+	private static function guidelines_available() {
+		return post_type_exists( 'wp_guideline' ) && taxonomy_exists( 'wp_guideline_type' );
+	}
+
+	private static function get_default_agent_skill_content() {
+		return <<<'SKILL'
+# WP Origin AGENTS.md
+
+## What This Repository Is
+
+This repository is a Git checkout of a WordPress site exposed by WP Origin. WordPress remains the source of truth. The Git history in this clone is a working view for review, editing, and agent workflows.
+
+## Repository Layout
+
+- `post/{slug}.md` contains WordPress posts.
+- `page/{slug}.md` contains WordPress pages.
+- `wp_guideline/skills/{slug}/SKILL.md` contains coding-agent skills stored as Gutenberg Guidelines.
+- `.agents/skills` and `.claude/skills` point to `wp_guideline/skills` for agent discovery.
+- `AGENTS.md` and `CLAUDE.md` point to this guide.
+
+## Pulling And Pushing
+
+- `git pull` refreshes the checkout from the current WordPress site.
+- `git push` applies supported Markdown changes back to WordPress.
+- Pushed post and page changes create WordPress revisions.
+- Deleted post or page files are trashed in WordPress rather than permanently deleted.
+- If WordPress changed after your last pull, the push is rejected. Pull, review the diff, and then push again.
+
+## Editing Rules
+
+- Preserve post and page front matter unless you are intentionally changing that WordPress metadata.
+- Guideline skill front matter is generated from WordPress fields. Keep the body focused on the guideline content.
+- Preserve unsupported block markup, fenced `gutenberg` blocks, custom blocks, and raw HTML unless the user asks for a conversion.
+- Use forward slashes in paths.
+- Keep changes scoped to site content. This checkout does not represent plugin code, themes, uploads, or the full database.
+SKILL;
 	}
 
 	public static function register_routes() {
@@ -88,6 +165,10 @@ class WP_Origin_Plugin {
 		$previous_error_handler = set_error_handler( array( __CLASS__, 'throw_on_php_warning' ) ); // phpcs:ignore
 
 		try {
+			if ( ! WP_Origin_Seeder::is_ready() ) {
+				WP_Origin_Seeder::drive( 5 );
+			}
+
 			if ( ! WP_Origin_Seeder::is_ready() ) {
 				$response = new WP_Origin_Buffering_Response();
 				$response->send_http_code( 503 );
@@ -263,19 +344,29 @@ class WP_Origin_Plugin {
 		$exported_files = self::export_wordpress_content();
 		$head_oid       = $repository->get_branch_tip( 'refs/heads/' . self::DEFAULT_BRANCH );
 		$existing_files = ( is_string( $head_oid ) && '' !== $head_oid && ! Commit::is_null_hash( $head_oid ) )
-			? self::read_markdown_files_from_commit( $repository, $head_oid )
+			? self::read_repository_entries_from_commit( $repository, $head_oid )
 			: array();
 
 		$updates          = array();
+		$symlinks         = array();
 		$deletes          = array();
 		$commit_timestamp = self::EPOCH_TIMESTAMP;
 
 		foreach ( $exported_files as $path => $entry ) {
-			$markdown = $entry['markdown'];
-			$post     = $entry['post'];
+			$content = $entry['content'];
+			$mode    = $entry['mode'];
+			$post    = $entry['post'];
 
-			if ( ! isset( $existing_files[ $path ] ) || $existing_files[ $path ] !== $markdown ) {
-				$updates[ $path ] = $markdown;
+			if ( ! isset( $existing_files[ $path ] ) || ! self::repository_entries_match( $existing_files[ $path ], $entry ) ) {
+				if ( TreeEntry::FILE_MODE_SYMBOLIC_LINK === $mode ) {
+					$symlinks[ $path ] = $content;
+				} else {
+					$updates[ $path ] = $content;
+				}
+			}
+
+			if ( ! $post ) {
+				continue;
 			}
 
 			$maybe_timestamp = self::timestamp_from_gmt_string( $post->post_modified_gmt );
@@ -294,7 +385,7 @@ class WP_Origin_Plugin {
 			}
 		}
 
-		if ( empty( $updates ) && empty( $deletes ) ) {
+		if ( empty( $updates ) && empty( $symlinks ) && empty( $deletes ) ) {
 			return;
 		}
 
@@ -302,9 +393,10 @@ class WP_Origin_Plugin {
 		$date     = gmdate( Commit::DATE_FORMAT, $commit_timestamp );
 		$repository->commit(
 			array(
-				'updates' => $updates,
-				'deletes' => $deletes,
-				'commit'  => array(
+				'updates'         => $updates,
+				'create_symlinks' => $symlinks,
+				'deletes'         => $deletes,
+				'commit'          => array(
 					'message'        => 'Sync from WordPress',
 					'author'         => $identity,
 					'author_date'    => $date,
@@ -318,7 +410,7 @@ class WP_Origin_Plugin {
 	private static function export_wordpress_content() {
 		$posts = get_posts(
 			array(
-				'post_type'      => self::$supported_post_types,
+				'post_type'      => self::get_export_post_types(),
 				'post_status'    => self::$supported_post_statuses,
 				'posts_per_page' => -1,
 				'orderby'        => 'ID',
@@ -326,18 +418,49 @@ class WP_Origin_Plugin {
 			)
 		);
 
-		$files = array();
+		$files                  = array();
+		$has_guideline_skills   = false;
+		$agent_guide_skill_path = null;
 		foreach ( $posts as $post ) {
 			if ( ! current_user_can( 'read_post', $post->ID ) ) {
 				continue;
 			}
 
-			$path = self::build_markdown_path( $post->post_type, $post->post_name );
+			$path    = self::build_markdown_path( $post );
+			$content = self::export_post_to_markdown( $post );
 
 			$files[ $path ] = array(
-				'post'     => $post,
-				'markdown' => self::export_post_to_markdown( $post ),
+				'post'    => $post,
+				'mode'    => TreeEntry::FILE_MODE_REGULAR_NON_EXECUTABLE,
+				'content' => $content,
 			);
+
+			if ( 'wp_guideline' === $post->post_type && self::is_guideline_skill_path( $path ) ) {
+				$has_guideline_skills = true;
+				if ( self::AGENT_SKILL_SOURCE === get_post_meta( $post->ID, 'guideline_source', true ) ) {
+					$agent_guide_skill_path = $path;
+				}
+			}
+		}
+
+		if ( $has_guideline_skills ) {
+			foreach ( self::get_agent_skills_directory_symlink_paths() as $symlink_path => $target ) {
+				$files[ $symlink_path ] = array(
+					'post'    => null,
+					'mode'    => TreeEntry::FILE_MODE_SYMBOLIC_LINK,
+					'content' => $target,
+				);
+			}
+		}
+
+		if ( $agent_guide_skill_path ) {
+			foreach ( self::get_agent_entrypoint_symlink_paths( $agent_guide_skill_path ) as $symlink_path => $target ) {
+				$files[ $symlink_path ] = array(
+					'post'    => null,
+					'mode'    => TreeEntry::FILE_MODE_SYMBOLIC_LINK,
+					'content' => $target,
+				);
+			}
 		}
 
 		ksort( $files );
@@ -345,8 +468,20 @@ class WP_Origin_Plugin {
 		return $files;
 	}
 
-	public static function build_markdown_path( $post_type, $slug ) {
-		return ltrim( $post_type . '/' . $slug . '.md', '/' );
+	private static function get_export_post_types() {
+		return self::get_supported_post_types();
+	}
+
+	public static function build_markdown_path( $post_or_type, $slug = null ) {
+		if ( $post_or_type instanceof WP_Post ) {
+			if ( 'wp_guideline' === $post_or_type->post_type ) {
+				return self::build_guideline_markdown_path( $post_or_type );
+			}
+
+			return ltrim( $post_or_type->post_type . '/' . $post_or_type->post_name . '.md', '/' );
+		}
+
+		return ltrim( $post_or_type . '/' . $slug . '.md', '/' );
 	}
 
 	/**
@@ -355,6 +490,14 @@ class WP_Origin_Plugin {
 	 * seeder can reuse the conversion without duplicating logic.
 	 */
 	public static function export_post_to_markdown( WP_Post $post ) {
+		if ( 'wp_guideline' === $post->post_type ) {
+			if ( 'skill' === self::get_guideline_type_slug( $post->ID ) ) {
+				return self::export_guideline_skill_to_markdown( $post );
+			}
+
+			return $post->post_content;
+		}
+
 		$metadata = array(
 			'title'  => array( $post->post_title ),
 			'date'   => array( self::format_post_date_for_frontmatter( $post ) ),
@@ -372,6 +515,91 @@ class WP_Origin_Plugin {
 		);
 
 		return $producer->produce();
+	}
+
+	private static function export_guideline_skill_to_markdown( WP_Post $post ) {
+		$frontmatter = array(
+			'---',
+			'name: ' . self::quote_yaml_scalar( $post->post_name ),
+			'description: ' . self::quote_yaml_scalar( trim( $post->post_excerpt ) ),
+			'---',
+			'',
+		);
+
+		return implode( "\n", $frontmatter ) . ltrim( $post->post_content, "\r\n" );
+	}
+
+	private static function quote_yaml_scalar( $value ) {
+		$encoded = wp_json_encode( (string) $value );
+		if ( false === $encoded ) {
+			return '""';
+		}
+
+		return $encoded;
+	}
+
+	private static function build_guideline_markdown_path( WP_Post $post ) {
+		$type_slug = self::get_guideline_type_slug( $post->ID );
+		$directory = self::guideline_type_to_directory( $type_slug );
+
+		if ( 'skill' === $type_slug ) {
+			return 'wp_guideline/' . $directory . '/' . $post->post_name . '/SKILL.md';
+		}
+
+		return 'wp_guideline/' . $directory . '/' . $post->post_name . '.md';
+	}
+
+	private static function get_guideline_type_slug( $post_id ) {
+		if ( ! taxonomy_exists( 'wp_guideline_type' ) ) {
+			return 'artifact';
+		}
+
+		$terms = get_the_terms( $post_id, 'wp_guideline_type' );
+		if ( is_wp_error( $terms ) || empty( $terms ) ) {
+			return 'artifact';
+		}
+
+		$known_types = array_keys( self::$guideline_type_directories );
+		foreach ( $known_types as $known_type ) {
+			foreach ( $terms as $term ) {
+				if ( $known_type === $term->slug ) {
+					return $term->slug;
+				}
+			}
+		}
+
+		return $terms[0]->slug;
+	}
+
+	private static function guideline_type_to_directory( $type_slug ) {
+		if ( isset( self::$guideline_type_directories[ $type_slug ] ) ) {
+			return self::$guideline_type_directories[ $type_slug ];
+		}
+
+		return sanitize_title( $type_slug ) . 's';
+	}
+
+	private static function guideline_directory_to_type( $directory ) {
+		$type_slug = array_search( $directory, self::$guideline_type_directories, true );
+		if ( false !== $type_slug ) {
+			return $type_slug;
+		}
+
+		throw new Exception( 'Push rejected because the guideline type directory is not supported yet.' );
+	}
+
+	private static function get_agent_skills_directory_symlink_paths() {
+		return array(
+			'.agents/skills' => '../wp_guideline/skills',
+			'.claude/skills' => '../wp_guideline/skills',
+		);
+	}
+
+	private static function get_agent_entrypoint_symlink_paths( $skill_path ) {
+		return array(
+			'AGENTS.md' => $skill_path,
+			'CLAUDE.md' => $skill_path,
+		);
 	}
 
 	public static function repository_identity( GitRepository $repository ) {
@@ -404,20 +632,23 @@ class WP_Origin_Plugin {
 		$parent_hash = empty( $commit->parents ) ? Commit::NULL_HASH : $commit->get_first_parent_hash();
 		$old_files   = Commit::is_null_hash( $parent_hash )
 			? array()
-			: self::read_markdown_files_from_commit( $repository, $parent_hash );
-		$new_files   = self::read_markdown_files_from_commit( $repository, $commit_hash );
+			: self::read_repository_entries_from_commit( $repository, $parent_hash );
+		$new_files   = self::read_repository_entries_from_commit( $repository, $commit_hash );
 
 		$updated_post_ids = array();
 		$changes          = array();
 
-		foreach ( $new_files as $path => $contents ) {
-			if ( isset( $old_files[ $path ] ) && $old_files[ $path ] === $contents ) {
+		foreach ( $new_files as $path => $entry ) {
+			if ( isset( $old_files[ $path ] ) && self::repository_entries_match( $old_files[ $path ], $entry ) ) {
+				continue;
+			}
+			if ( TreeEntry::FILE_MODE_SYMBOLIC_LINK === $entry['mode'] ) {
 				continue;
 			}
 
 			$applied = self::upsert_post_from_markdown(
 				$path,
-				$contents,
+				$entry['content'],
 				array( 'skip_modified_check' => $skip_modified_checks )
 			);
 			$post_id = $applied['post_id'];
@@ -427,12 +658,15 @@ class WP_Origin_Plugin {
 			}
 		}
 
-		foreach ( $old_files as $path => $contents ) {
+		foreach ( $old_files as $path => $entry ) {
 			if ( isset( $new_files[ $path ] ) ) {
 				continue;
 			}
+			if ( TreeEntry::FILE_MODE_SYMBOLIC_LINK === $entry['mode'] ) {
+				continue;
+			}
 
-			$metadata = self::parse_markdown_metadata( $contents );
+			$metadata = self::parse_markdown_metadata( $entry['content'] );
 			$post_id  = isset( $metadata['id'] ) ? intval( $metadata['id'] ) : 0;
 			if ( ! $post_id ) {
 				$post_id = self::find_post_id_by_path_metadata( $path, $metadata );
@@ -507,9 +741,13 @@ class WP_Origin_Plugin {
 	private static function upsert_post_from_markdown( $path, $markdown, $options = array() ) {
 		$post_type = self::path_to_post_type( $path );
 		$slug      = self::path_to_slug( $path );
-		$consumer  = new MarkdownConsumer( $markdown );
-		$result    = $consumer->consume();
-		$metadata  = array();
+		if ( 'wp_guideline' === $post_type ) {
+			return self::upsert_guideline_from_markdown( $path, $markdown, $options );
+		}
+
+		$consumer = new MarkdownConsumer( $markdown );
+		$result   = $consumer->consume();
+		$metadata = array();
 		foreach ( $result->get_all_metadata() as $key => $value ) {
 			$metadata[ $key ] = is_array( $value ) ? reset( $value ) : $value;
 		}
@@ -573,6 +811,92 @@ class WP_Origin_Plugin {
 
 		if ( is_wp_error( $post_id ) ) {
 			throw new Exception( $post_id->get_error_message() );
+		}
+
+		$post = get_post( $post_id );
+
+		return array(
+			'post_id' => $post_id,
+			'change'  => self::build_push_summary_item(
+				$existing_post ? 'updated' : 'created',
+				$post,
+				$path
+			),
+		);
+	}
+
+	private static function upsert_guideline_from_markdown( $path, $markdown, $options = array() ) {
+		if ( ! self::guidelines_available() ) {
+			throw new Exception( 'Push rejected because Gutenberg Guidelines are not available on this site.' );
+		}
+
+		$slug                = self::path_to_slug( $path );
+		$guideline_type_slug = self::path_to_guideline_type_slug( $path );
+		$metadata            = array();
+		if ( 'skill' === $guideline_type_slug ) {
+			$skill_document = self::split_guideline_skill_markdown( $markdown );
+			$metadata       = $skill_document['metadata'];
+			$markdown       = $skill_document['content'];
+			if ( isset( $metadata['name'] ) && $metadata['name'] !== $slug ) {
+				throw new Exception( 'Push rejected because the skill name front matter does not match its directory.' );
+			}
+		}
+
+		$post_id = isset( $metadata['id'] ) ? intval( $metadata['id'] ) : 0;
+		if ( $post_id && get_post( $post_id ) ) {
+			$existing_post = get_post( $post_id );
+		} else {
+			$post_id       = self::find_post_id_by_path_metadata( $path, $metadata );
+			$existing_post = $post_id ? get_post( $post_id ) : null;
+		}
+
+		$post_status = self::normalize_frontmatter_status(
+			isset( $metadata['status'] ) ? $metadata['status'] : ( $existing_post ? $existing_post->post_status : 'draft' )
+		);
+		self::validate_post_status( $post_status, 'wp_guideline' );
+
+		if (
+			$existing_post &&
+			empty( $options['skip_modified_check'] ) &&
+			isset( $metadata['modified_gmt'] ) &&
+			$existing_post->post_modified_gmt !== $metadata['modified_gmt']
+		) {
+			throw new Exception( 'Push rejected because WordPress content changed since the last pull.' );
+		}
+
+		if ( $existing_post ) {
+			self::assert_can_edit_post( $existing_post->ID );
+		} else {
+			self::assert_can_create_post_type( 'wp_guideline' );
+		}
+
+		$postarr = array(
+			'post_type'    => 'wp_guideline',
+			'post_name'    => $slug,
+			'post_title'   => self::guideline_title_from_metadata( $metadata, $slug, $existing_post ),
+			'post_status'  => $post_status,
+			'post_content' => $markdown,
+		);
+
+		if ( array_key_exists( 'description', $metadata ) ) {
+			$postarr['post_excerpt'] = $metadata['description'];
+		}
+
+		if ( $existing_post ) {
+			$postarr['ID'] = $existing_post->ID;
+			$post_id       = wp_update_post( wp_slash( $postarr ), true );
+		} else {
+			$post_id = wp_insert_post( wp_slash( $postarr ), true );
+		}
+
+		if ( is_wp_error( $post_id ) ) {
+			throw new Exception( $post_id->get_error_message() );
+		}
+
+		$term_id   = self::get_or_create_guideline_type_term_id( $guideline_type_slug );
+		$set_terms = wp_set_object_terms( $post_id, array( $term_id ), 'wp_guideline_type' );
+		if ( is_wp_error( $set_terms ) ) {
+			throw new Exception( $set_terms->get_error_message() );
 		}
 
 		$post = get_post( $post_id );
@@ -738,20 +1062,66 @@ class WP_Origin_Plugin {
 
 	private static function path_to_post_type( $path ) {
 		$segments = explode( '/', ltrim( $path, '/' ) );
-		if ( empty( $segments[0] ) || ! in_array( $segments[0], self::$supported_post_types, true ) ) {
+		if ( ! empty( $segments[0] ) && 'wp_guideline' === $segments[0] && ! self::guidelines_available() ) {
+			throw new Exception( 'Push rejected because Gutenberg Guidelines are not available on this site.' );
+		}
+		if ( empty( $segments[0] ) || ! in_array( $segments[0], self::get_supported_post_types(), true ) ) {
 			throw new Exception( 'Push rejected because the file path is outside the supported post type directories.' );
+		}
+		if ( 'wp_guideline' === $segments[0] ) {
+			self::path_to_guideline_type_slug( $path );
 		}
 
 		return $segments[0];
 	}
 
 	private static function path_to_slug( $path ) {
+		if ( self::is_guideline_skill_path( $path ) ) {
+			$segments = explode( '/', ltrim( $path, '/' ) );
+			return $segments[2];
+		}
+
 		$basename = basename( $path );
 		if ( 'md' !== pathinfo( $basename, PATHINFO_EXTENSION ) ) {
 			throw new Exception( 'Push rejected because only Markdown files are supported.' );
 		}
 
 		return pathinfo( $basename, PATHINFO_FILENAME );
+	}
+
+	private static function path_to_guideline_type_slug( $path ) {
+		$segments = explode( '/', ltrim( $path, '/' ) );
+		if (
+			count( $segments ) < 3 ||
+			'wp_guideline' !== $segments[0] ||
+			! in_array( $segments[1], self::$guideline_type_directories, true )
+		) {
+			throw new Exception( 'Push rejected because guideline files must live under wp_guideline/<type> directories.' );
+		}
+
+		$type_slug = self::guideline_directory_to_type( $segments[1] );
+		if ( 'skill' === $type_slug ) {
+			if ( 4 !== count( $segments ) || 'SKILL.md' !== $segments[3] ) {
+				throw new Exception( 'Push rejected because guideline skills must use wp_guideline/skills/<name>/SKILL.md.' );
+			}
+			return $type_slug;
+		}
+
+		if ( 3 !== count( $segments ) || 'md' !== pathinfo( $segments[2], PATHINFO_EXTENSION ) ) {
+			throw new Exception( 'Push rejected because guideline files must be Markdown files.' );
+		}
+
+		return $type_slug;
+	}
+
+	private static function is_guideline_skill_path( $path ) {
+		$segments = explode( '/', ltrim( $path, '/' ) );
+
+		return 4 === count( $segments )
+			&& 'wp_guideline' === $segments[0]
+			&& 'skills' === $segments[1]
+			&& '' !== $segments[2]
+			&& 'SKILL.md' === $segments[3];
 	}
 
 	private static function parse_markdown_metadata( $markdown ) {
@@ -763,6 +1133,54 @@ class WP_Origin_Plugin {
 		}
 
 		return $metadata;
+	}
+
+	private static function split_guideline_skill_markdown( $markdown ) {
+		$metadata = array();
+		$content  = $markdown;
+
+		if ( preg_match( '/\A---\r?\n.*?\r?\n---(?:\r?\n|\z)/s', $markdown, $matches ) ) {
+			$metadata = self::parse_markdown_metadata( $markdown );
+			$content  = substr( $markdown, strlen( $matches[0] ) );
+		}
+
+		return array(
+			'metadata' => $metadata,
+			'content'  => $content,
+		);
+	}
+
+	private static function guideline_title_from_metadata( $metadata, $slug, $existing_post = null ) {
+		if ( isset( $metadata['title'] ) && '' !== trim( (string) $metadata['title'] ) ) {
+			return $metadata['title'];
+		}
+		if ( $existing_post ) {
+			return $existing_post->post_title;
+		}
+		if ( isset( $metadata['name'] ) && '' !== trim( (string) $metadata['name'] ) ) {
+			return ucwords( str_replace( '-', ' ', $metadata['name'] ) );
+		}
+
+		return ucwords( str_replace( '-', ' ', $slug ) );
+	}
+
+	private static function get_or_create_guideline_type_term_id( $slug ) {
+		$term = get_term_by( 'slug', $slug, 'wp_guideline_type' );
+		if ( $term ) {
+			return (int) $term->term_id;
+		}
+
+		$inserted = wp_insert_term(
+			ucwords( str_replace( '-', ' ', $slug ) ),
+			'wp_guideline_type',
+			array( 'slug' => $slug )
+		);
+
+		if ( is_wp_error( $inserted ) ) {
+			throw new Exception( $inserted->get_error_message() );
+		}
+
+		return (int) $inserted['term_id'];
 	}
 
 	private static function validate_post_status( $post_status, $post_type ) {
@@ -779,7 +1197,7 @@ class WP_Origin_Plugin {
 		);
 	}
 
-	private static function read_markdown_files_from_commit( GitRepository $repository, $commit_hash ) {
+	private static function read_repository_entries_from_commit( GitRepository $repository, $commit_hash ) {
 		$commit = $repository->read_object( $commit_hash )->as_commit();
 		$files  = array();
 
@@ -787,24 +1205,37 @@ class WP_Origin_Plugin {
 			return $files;
 		}
 
-		self::collect_tree_files( $repository, $commit->tree, '', $files );
+		self::collect_tree_entries( $repository, $commit->tree, '', $files );
 		ksort( $files );
 
 		return $files;
 	}
 
-	private static function collect_tree_files( GitRepository $repository, $tree_hash, $prefix, &$files ) {
+	private static function repository_entries_match( $a, $b ) {
+		return isset( $a['mode'], $a['content'], $b['mode'], $b['content'] )
+			&& $a['mode'] === $b['mode']
+			&& $a['content'] === $b['content'];
+	}
+
+	private static function collect_tree_entries( GitRepository $repository, $tree_hash, $prefix, &$files ) {
 		$tree = $repository->read_object( $tree_hash )->as_tree();
 		foreach ( $tree->entries as $entry ) {
 			$path = ltrim( $prefix . '/' . $entry->name, '/' );
 			if ( TreeEntry::FILE_MODE_DIRECTORY === $entry->get_mode_bucket() ) {
-				self::collect_tree_files( $repository, $entry->hash, $path, $files );
+				self::collect_tree_entries( $repository, $entry->hash, $path, $files );
 				continue;
 			}
-			if ( 'md' !== pathinfo( $path, PATHINFO_EXTENSION ) ) {
-				throw new Exception( 'Push rejected because only Markdown files are supported.' );
+			if (
+				TreeEntry::FILE_MODE_REGULAR_NON_EXECUTABLE !== $entry->get_mode_bucket() &&
+				TreeEntry::FILE_MODE_REGULAR_EXECUTABLE !== $entry->get_mode_bucket() &&
+				TreeEntry::FILE_MODE_SYMBOLIC_LINK !== $entry->get_mode_bucket()
+			) {
+				throw new Exception( 'Push rejected because one or more repository entries use an unsupported Git file mode.' );
 			}
-			$files[ $path ] = $repository->read_object( $entry->hash )->consume_all();
+			$files[ $path ] = array(
+				'mode'    => $entry->get_mode_bucket(),
+				'content' => $repository->read_object( $entry->hash )->consume_all(),
+			);
 		}
 	}
 

--- a/plugins/wp-origin/class-wp-origin-seeder.php
+++ b/plugins/wp-origin/class-wp-origin-seeder.php
@@ -155,6 +155,7 @@ class WP_Origin_Seeder {
 		try {
 			global $wpdb;
 			$table = $wpdb->prefix . WP_Origin_Plugin::TABLE_PREFIX . 'files';
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			if ( ! $wpdb->get_var( "SHOW TABLES LIKE '" . esc_sql( $table ) . "'" ) ) {
 				return array();
 			}
@@ -197,7 +198,7 @@ class WP_Origin_Seeder {
 				'oid'     => substr( $current, 0, 7 ),
 				'subject' => '' !== $subject ? $subject : '(no message)',
 			);
-			$current = empty( $commit->parents ) ? null : $commit->parents[0];
+			$current   = empty( $commit->parents ) ? null : $commit->parents[0];
 		}
 
 		return $commits;
@@ -219,6 +220,20 @@ class WP_Origin_Seeder {
 			$progress['processed'],
 			$progress['total']
 		);
+	}
+
+	public static function drive( $seconds ) {
+		$deadline = microtime( true ) + $seconds;
+		while ( ! self::is_ready() && microtime( true ) < $deadline ) {
+			$state_before = self::get_state();
+			self::tick();
+			if ( self::get_state() === $state_before
+				&& self::STATE_IN_PROGRESS !== $state_before
+				&& self::STATE_PENDING !== $state_before
+			) {
+				break;
+			}
+		}
 	}
 
 	public static function tick() {
@@ -261,7 +276,7 @@ class WP_Origin_Seeder {
 	private static function initialize() {
 		global $wpdb;
 
-		$types_in    = "'" . implode( "','", array_map( 'esc_sql', WP_Origin_Plugin::$supported_post_types ) ) . "'";
+		$types_in    = "'" . implode( "','", array_map( 'esc_sql', WP_Origin_Plugin::get_supported_post_types() ) ) . "'";
 		$statuses_in = "'" . implode( "','", array_map( 'esc_sql', WP_Origin_Plugin::$supported_post_statuses ) ) . "'";
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery
 		$total = (int) $wpdb->get_var(
@@ -280,7 +295,7 @@ class WP_Origin_Seeder {
 				'tick_count'   => $tick_count,
 				'started_at'   => time(),
 				'last_tick_at' => time(),
-				'message'      => sprintf( 'Found %d posts and pages to import.', $total ),
+				'message'      => sprintf( 'Found %d content items to import.', $total ),
 			),
 			false
 		);
@@ -323,7 +338,7 @@ class WP_Origin_Seeder {
 			$last_id   = $progress['last_id'];
 			$processed = $progress['processed'];
 			foreach ( $batch as $post ) {
-				$path             = WP_Origin_Plugin::build_markdown_path( $post->post_type, $post->post_name );
+				$path             = WP_Origin_Plugin::build_markdown_path( $post );
 				$updates[ $path ] = WP_Origin_Plugin::export_post_to_markdown( $post );
 				$last_id          = $post->ID;
 				++$processed;
@@ -436,7 +451,7 @@ class WP_Origin_Seeder {
 	private static function next_batch( $after_id ) {
 		global $wpdb;
 
-		$types_in    = "'" . implode( "','", array_map( 'esc_sql', WP_Origin_Plugin::$supported_post_types ) ) . "'";
+		$types_in    = "'" . implode( "','", array_map( 'esc_sql', WP_Origin_Plugin::get_supported_post_types() ) ) . "'";
 		$statuses_in = "'" . implode( "','", array_map( 'esc_sql', WP_Origin_Plugin::$supported_post_statuses ) ) . "'";
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery
 		$ids = $wpdb->get_col(

--- a/plugins/wp-origin/docs/prd.md
+++ b/plugins/wp-origin/docs/prd.md
@@ -73,6 +73,14 @@ The guiding rule is that users must not lose data. If a conversion cannot preser
   - Preserve unsupported block markup as fenced `gutenberg` code blocks, or inline HTML when Markdown cannot represent it safely.
   - Keep Markdown human-editable and compatible with common editors such as Obsidian wherever that does not weaken round-trip fidelity.
 
+- **Guidelines and agent portability** (Priority: Medium)
+  - When Gutenberg's Guidelines experiment is available, export `wp_guideline` posts under `wp_guideline/{type}/`.
+  - Store guideline skills as agent-portable skill directories, such as `wp_guideline/skills/{slug}/SKILL.md`.
+  - Expose guideline skills through `.agents/skills` and `.claude/skills` directory symlinks so agents can discover the same canonical skill content.
+  - Install a default WP Origin coding-agent skill when Guidelines is available and expose `AGENTS.md` and `CLAUDE.md` as symlinks to it.
+  - Store guideline skill bodies as content only in WordPress, and generate agent-required YAML front matter from WordPress title, slug, and excerpt on export.
+  - Keep the canonical `wp_guideline/` tree aligned with `wp_guideline_type` taxonomy terms, including `artifact`, `skill`, `plan`, and future instruction-like types.
+
 - **Markdown import to WordPress** (Priority: High)
   - Convert pushed Markdown back into WordPress post content.
   - Update existing posts by stable metadata when possible, then by path or slug as a fallback.

--- a/plugins/wp-origin/functions.php
+++ b/plugins/wp-origin/functions.php
@@ -1,0 +1,60 @@
+<?php
+
+if ( ! function_exists( 'wp_install_skill' ) ) {
+	function wp_install_skill( string $source_identifier, string $title, string $excerpt, string $content, array $extras = array() ) {
+		if ( '' === $source_identifier ) {
+			return new WP_Error( 'missing_source_identifier', 'A non-empty $source_identifier is required.' );
+		}
+
+		if ( ! post_type_exists( 'wp_guideline' ) || ! taxonomy_exists( 'wp_guideline_type' ) ) {
+			return new WP_Error( 'guidelines_unavailable', 'Guidelines CPT/taxonomy are not registered on this blog.' );
+		}
+
+		$existing = get_posts(
+			array(
+				'post_type'      => 'wp_guideline',
+				'post_status'    => array( 'publish', 'draft', 'pending', 'future', 'private', 'trash' ),
+				'meta_key'       => 'guideline_source', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value'     => $source_identifier, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'posts_per_page' => 1,
+				'no_found_rows'  => true,
+			)
+		);
+
+		if ( ! empty( $existing ) ) {
+			return array(
+				'id'      => (int) $existing[0]->ID,
+				'created' => false,
+			);
+		}
+
+		$insert_args = array(
+			'post_type'    => 'wp_guideline',
+			'post_status'  => 'publish',
+			'post_author'  => get_current_user_id(),
+			'post_title'   => $title,
+			'post_excerpt' => $excerpt,
+			'post_content' => wp_kses_post( $content ),
+		);
+
+		$protected = array( 'post_type', 'post_status', 'post_author', 'post_title', 'post_excerpt', 'post_content' );
+		foreach ( $protected as $key ) {
+			unset( $extras[ $key ] );
+		}
+		$insert_args = array_merge( $extras, $insert_args );
+
+		$post_id = wp_insert_post( $insert_args, true );
+
+		if ( is_wp_error( $post_id ) ) {
+			return $post_id;
+		}
+
+		wp_set_object_terms( $post_id, 'skill', 'wp_guideline_type' );
+		update_post_meta( $post_id, 'guideline_source', sanitize_text_field( $source_identifier ) );
+
+		return array(
+			'id'      => (int) $post_id,
+			'created' => true,
+		);
+	}
+}

--- a/plugins/wp-origin/wp-origin.php
+++ b/plugins/wp-origin/wp-origin.php
@@ -10,6 +10,7 @@ if ( file_exists( __DIR__ . '/php-toolkit.phar' ) ) {
 	require_once __DIR__ . '/wp-origin-dev-bootstrap.php';
 }
 
+require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/class-wp-origin-plugin.php';
 require_once __DIR__ . '/class-wp-origin-buffering-response.php';
 require_once __DIR__ . '/class-wp-origin-seeder.php';


### PR DESCRIPTION
## Summary

- Gate WP Origin Guidelines support on the `wp_guideline` CPT and `wp_guideline_type` taxonomy being available.
- Install a default coding-agent skill titled `WP Origin AGENTS.md` with slug/source `wp-origin` when Guidelines are enabled.
- Export Guidelines content under `wp_guideline/<type>/...`; skills export as `wp_guideline/skills/<slug>/SKILL.md` with Codex-compatible frontmatter generated from WordPress fields.
- Expose agent discovery paths with `.agents/skills`, `.claude/skills`, `AGENTS.md`, and `CLAUDE.md` symlinks only when the Guidelines skill exists.
- Add Git repository support and tests for symbolic-link entries used by the exported agent paths.

## Validation

- `vendor/bin/phpcs -d memory_limit=1G plugins/wp-origin/class-wp-origin-plugin.php plugins/wp-origin/functions.php plugins/wp-origin/wp-origin.php plugins/wp-origin/class-wp-origin-seeder.php bin/test-wp-origin-git-actions.sh`
- `vendor/bin/phpunit components/Git/Tests/GitRepositoryTest.php`
- `bin/test-wp-origin-git-actions.sh`
