### PR TITLE
Harden WP Origin Git content flows

### DIFF
--- a/bin/test-wp-origin-git-actions.sh
+++ b/bin/test-wp-origin-git-actions.sh
@@ -19,6 +19,7 @@ fi
 
 CREDENTIALS_FILE="$ROOT_DIR/.context/wp-origin-e2e-$PORT.json"
 BLUEPRINT_FILE="$WORK_DIR/blueprint-e2e.json"
+MU_PLUGINS_DIR="$WORK_DIR/mu-plugins"
 
 if command -v wp-playground >/dev/null 2>&1; then
 	PLAYGROUND_CMD="wp-playground"
@@ -39,7 +40,13 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 mkdir -p "$ROOT_DIR/.context"
+mkdir -p "$MU_PLUGINS_DIR"
 rm -f "$PLAYGROUND_LOG" "$CREDENTIALS_FILE"
+cp "$ROOT_DIR/plugins/wp-origin/Tests/ci-mu-test-helper.php" "$MU_PLUGINS_DIR/wp-origin-ci-test-helper.php"
+cat > "$MU_PLUGINS_DIR/wp-origin-e2e-auth.php" <<'PHP'
+<?php
+add_filter( 'wp_is_application_passwords_available', '__return_true' );
+PHP
 
 cd "$ROOT_DIR"
 sed "s|__WP_ORIGIN_CREDENTIALS_FILE__|/workspace/.context/$(basename "$CREDENTIALS_FILE")|g" "$BLUEPRINT_TEMPLATE" > "$BLUEPRINT_FILE"
@@ -56,6 +63,7 @@ $PLAYGROUND_CMD server \
 	--mount="$ROOT_DIR/vendor:/wordpress/wp-content/vendor" \
 	--mount="$ROOT_DIR/components:/wordpress/wp-content/components" \
 	--mount="$ROOT_DIR/plugins/wp-origin:/wordpress/wp-content/plugins/wp-origin" \
+	--mount="$MU_PLUGINS_DIR:/wordpress/wp-content/mu-plugins" \
 	>"$PLAYGROUND_LOG" 2>&1 &
 PLAYGROUND_PID=$!
 
@@ -105,7 +113,68 @@ wait_for_seed_done() {
 	exit 1
 }
 
+create_page() {
+	SLUG_ARG="$1"
+	TITLE_ARG="$2"
+	PARENT_ARG="$3"
+	CONTENT_ARG="$4"
+	RESPONSE="$(
+		php -r '
+		$payload = array(
+			"slug"    => $argv[1],
+			"title"   => $argv[2],
+			"status"  => "publish",
+			"content" => "<!-- wp:paragraph --><p>" . $argv[4] . "</p><!-- /wp:paragraph -->",
+		);
+		if ("0" !== $argv[3]) {
+			$payload["parent"] = (int) $argv[3];
+		}
+		echo json_encode($payload);
+		' "$SLUG_ARG" "$TITLE_ARG" "$PARENT_ARG" "$CONTENT_ARG" |
+			curl -sS -f \
+				-X POST \
+				-H "Authorization: Basic $AUTH_HEADER" \
+				-H "Content-Type: application/json" \
+				--data-binary @- \
+				"$BASE_URL/wp-json/wp/v2/pages?context=edit"
+	)"
+	printf '%s' "$RESPONSE" | php -r '
+	$page = json_decode(stream_get_contents(STDIN), true);
+	if (!is_array($page) || !isset($page["id"])) {
+		exit(1);
+	}
+	echo (int) $page["id"];
+	'
+}
+
 wait_for_seed_done
+HIERARCHY_SUFFIX="hierarchy-$(date +%s)-$$"
+PARENT_A_SLUG="parent-a-$HIERARCHY_SUFFIX"
+PARENT_B_SLUG="parent-b-$HIERARCHY_SUFFIX"
+SHARED_CHILD_SLUG="shared-child-$HIERARCHY_SUFFIX"
+PARENT_A_ID="$(create_page "$PARENT_A_SLUG" "Parent A $HIERARCHY_SUFFIX" 0 "Parent A $HIERARCHY_SUFFIX")"
+PARENT_B_ID="$(create_page "$PARENT_B_SLUG" "Parent B $HIERARCHY_SUFFIX" 0 "Parent B $HIERARCHY_SUFFIX")"
+create_page "$SHARED_CHILD_SLUG" "Shared Child A $HIERARCHY_SUFFIX" "$PARENT_A_ID" "Shared Child A $HIERARCHY_SUFFIX" >/dev/null
+create_page "$SHARED_CHILD_SLUG" "Shared Child B $HIERARCHY_SUFFIX" "$PARENT_B_ID" "Shared Child B $HIERARCHY_SUFFIX" >/dev/null
+
+TRASHED_PARENT_SUFFIX="trashed-parent-$(date +%s)-$$"
+TRASHED_PARENT_ID="$(create_page "parent-$TRASHED_PARENT_SUFFIX" "Parent $TRASHED_PARENT_SUFFIX" 0 "Parent $TRASHED_PARENT_SUFFIX")"
+create_page "child-$TRASHED_PARENT_SUFFIX" "Child $TRASHED_PARENT_SUFFIX" "$TRASHED_PARENT_ID" "Child $TRASHED_PARENT_SUFFIX" >/dev/null
+curl -sS -f \
+	-X DELETE \
+	-H "Authorization: Basic $AUTH_HEADER" \
+	"$BASE_URL/wp-json/wp/v2/pages/$TRASHED_PARENT_ID?context=edit" >/dev/null
+if git -c protocol.version=2 ls-remote "$REMOTE_AUTH_URL" >/dev/null 2>&1; then
+	echo "Expected clone advertisement to fail while a published page has a trashed parent." >&2
+	exit 1
+fi
+curl -sS -f \
+	-X POST \
+	-H "Authorization: Basic $AUTH_HEADER" \
+	-H "Content-Type: application/json" \
+	-d '{"status":"publish"}' \
+	"$BASE_URL/wp-json/wp/v2/pages/$TRASHED_PARENT_ID?context=edit" >/dev/null
+
 git -c protocol.version=2 clone "$REMOTE_AUTH_URL" "$CLONE_DIR"
 if [ -n "$(git -C "$CLONE_DIR" status --porcelain)" ]; then
 	git -C "$CLONE_DIR" status --short >&2
@@ -115,6 +184,10 @@ fi
 
 test -f "$CLONE_DIR/post/hello-world.md"
 test -f "$CLONE_DIR/page/sample-page.md"
+test -f "$CLONE_DIR/page/$PARENT_A_SLUG/$SHARED_CHILD_SLUG.md"
+test -f "$CLONE_DIR/page/$PARENT_B_SLUG/$SHARED_CHILD_SLUG.md"
+grep -Fq "Shared Child A $HIERARCHY_SUFFIX" "$CLONE_DIR/page/$PARENT_A_SLUG/$SHARED_CHILD_SLUG.md"
+grep -Fq "Shared Child B $HIERARCHY_SUFFIX" "$CLONE_DIR/page/$PARENT_B_SLUG/$SHARED_CHILD_SLUG.md"
 test -f "$CLONE_DIR/wp_template/blog-home.html"
 find "$CLONE_DIR/wp_template" -mindepth 2 -name '*.html' | grep -q .
 find "$CLONE_DIR/wp_template_part" -mindepth 2 -name '*.html' | grep -q .
@@ -179,6 +252,44 @@ echo count($revisions);
 cd "$CLONE_DIR"
 git config user.name "WP Origin E2E"
 git config user.email "wp-origin-e2e@example.com"
+
+GIT_CHILD_SLUG="git-child-$HIERARCHY_SUFFIX"
+cat > "$CLONE_DIR/page/$PARENT_A_SLUG/$GIT_CHILD_SLUG.md" <<MARKDOWN
+---
+status: "publish"
+title: "Git Child $HIERARCHY_SUFFIX"
+---
+
+Nested child from Git.
+MARKDOWN
+git add "page/$PARENT_A_SLUG/$GIT_CHILD_SLUG.md"
+git commit -m "Create nested child page from Git"
+PUSH_OUTPUT="$(git push origin trunk 2>&1)"
+assert_push_summary_contains "$PUSH_OUTPUT" 'WP Origin applied 1 content change:'
+assert_push_summary_contains "$PUSH_OUTPUT" "$GIT_CHILD_SLUG"
+curl -sS -f -H "Authorization: Basic $AUTH_HEADER" "$BASE_URL/wp-json/wp/v2/pages?slug=$GIT_CHILD_SLUG&context=edit" | php -r '
+$pages = json_decode(stream_get_contents(STDIN), true);
+if (!is_array($pages) || empty($pages)) {
+	exit(1);
+}
+if ((int) $argv[1] !== (int) $pages[0]["parent"]) {
+	exit(1);
+}
+if (false === strpos($pages[0]["content"]["raw"], "Nested child from Git")) {
+	exit(1);
+}
+' "$PARENT_A_ID"
+git pull --rebase origin trunk
+
+rm "$CLONE_DIR/page/$PARENT_A_SLUG.md"
+git add -A
+git commit -m "Reject parent page delete with children"
+if PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
+	echo "Expected parent page deletion with remaining children to fail." >&2
+	exit 1
+fi
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because deleting a parent page while keeping nested child page files would move child content.'
+git reset --hard HEAD~1 >/dev/null
 
 THEME_JSON_PATH="$(find "$CLONE_DIR/wp_theme" -mindepth 2 -maxdepth 2 -name theme.json | head -n 1)"
 printf '\n' >> "$THEME_JSON_PATH"
@@ -466,6 +577,142 @@ fi
 assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because Markdown front matter must not include a type.'
 git reset --hard HEAD~1 >/dev/null
 
+mkdir -p "$CLONE_DIR/post/nested-path"
+php -r '
+file_put_contents(
+	$argv[1],
+	"---\nstatus: \"publish\"\ntitle: \"Rejected Nested Path\"\n---\n\nThis push must be rejected.\n"
+);
+' "$CLONE_DIR/post/nested-path/rejected-nested-path.md"
+git add post/nested-path/rejected-nested-path.md
+git commit -m "Reject nested post path"
+if PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
+	echo "Expected nested post path push to fail." >&2
+	exit 1
+fi
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because post Markdown files must use post/<slug>.md paths.'
+git reset --hard HEAD~1 >/dev/null
+
+php -r '
+file_put_contents(
+	$argv[1],
+	"---\nstatus: \"publish\"\ntitle: \"Rejected Upper Slug\"\n---\n\nThis push must be rejected.\n"
+);
+' "$CLONE_DIR/post/Rejected Upper Slug.md"
+git add "post/Rejected Upper Slug.md"
+git commit -m "Reject noncanonical post slug"
+if PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
+	echo "Expected noncanonical post slug push to fail." >&2
+	exit 1
+fi
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because Markdown file slugs must already match WordPress slug formatting.'
+git reset --hard HEAD~1 >/dev/null
+
+mkdir -p "$CLONE_DIR/wp_template/Bad Theme"
+printf '%s' '<!-- wp:paragraph --><p>This push must be rejected.</p><!-- /wp:paragraph -->' > "$CLONE_DIR/wp_template/Bad Theme/rejected-raw-path.html"
+git add "wp_template/Bad Theme/rejected-raw-path.html"
+git commit -m "Reject noncanonical template theme path"
+if PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
+	echo "Expected noncanonical template theme path push to fail." >&2
+	exit 1
+fi
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because template theme path segments must already match WordPress slug formatting.'
+git reset --hard HEAD~1 >/dev/null
+
+printf '%s' '<!-- wp:paragraph --><p>This push must be rejected.</p><!-- /wp:paragraph -->' > "$CLONE_DIR/wp_template/Rejected Raw Slug.html"
+git add "wp_template/Rejected Raw Slug.html"
+git commit -m "Reject noncanonical template slug path"
+if PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
+	echo "Expected noncanonical template slug path push to fail." >&2
+	exit 1
+fi
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because template file slugs must already match WordPress slug formatting.'
+git reset --hard HEAD~1 >/dev/null
+
+printf '%s\n' '<div>This push must be rejected.</div>' > "$CLONE_DIR/wp_template/rejected-plain-html.html"
+git add wp_template/rejected-plain-html.html
+git commit -m "Reject plain template HTML"
+if PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
+	echo "Expected plain template HTML push to fail." >&2
+	exit 1
+fi
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because template HTML files must contain serialized Gutenberg block markup.'
+git reset --hard HEAD~1 >/dev/null
+
+printf '%s\n' '{"version":3,"settings":{},"styles":{}}' > "$CLONE_DIR/wp_global_styles/Bad-Theme.json"
+git add wp_global_styles/Bad-Theme.json
+git commit -m "Reject noncanonical Global Styles path"
+if PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
+	echo "Expected noncanonical Global Styles path push to fail." >&2
+	exit 1
+fi
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because the Global Styles theme filename must already match WordPress slug formatting.'
+git reset --hard HEAD~1 >/dev/null
+
+ln -s ../post/hello-world.md "$CLONE_DIR/post/rejected-symlink.md"
+git add post/rejected-symlink.md
+git commit -m "Reject arbitrary symlink"
+if PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
+	echo "Expected arbitrary symlink push to fail." >&2
+	exit 1
+fi
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because symlink files are generated by WP Origin and cannot be created or modified.'
+git reset --hard HEAD~1 >/dev/null
+
+if [ -L "$CLONE_DIR/AGENTS.md" ]; then
+	git rm AGENTS.md
+	git commit -m "Reject generated symlink deletion"
+	if PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
+		echo "Expected generated symlink deletion push to fail." >&2
+		exit 1
+	fi
+	assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because symlink files are generated by WP Origin and cannot be deleted or modified.'
+	git reset --hard HEAD~1 >/dev/null
+fi
+
+php -r '
+file_put_contents(
+	$argv[1],
+	"---\nstatus: \"publish\"\ntitle: \"Rejected Executable\"\n---\n\nThis push must be rejected.\n"
+);
+' "$CLONE_DIR/post/rejected-executable.md"
+git add post/rejected-executable.md
+git update-index --chmod=+x post/rejected-executable.md
+git commit -m "Reject executable content file"
+if PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
+	echo "Expected executable content file push to fail." >&2
+	exit 1
+fi
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because executable file modes are not supported by WP Origin content exports.'
+git reset --hard HEAD~1 >/dev/null
+
+php -r '
+file_put_contents(
+	$argv[1],
+	"---\nstatus: \"publish\"\ntitle: \"Rejected Multi Ref\"\n---\n\nThis push must be rejected before WordPress writes.\n"
+);
+' "$CLONE_DIR/post/rejected-multi-ref.md"
+git add post/rejected-multi-ref.md
+git commit -m "Reject multi-ref push"
+if PUSH_OUTPUT="$(git push origin HEAD:trunk HEAD:refs/heads/rejected-multi-ref 2>&1)"; then
+	echo "Expected multi-ref push to fail." >&2
+	exit 1
+fi
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because WP Origin only accepts one ref update at a time.'
+curl -sS -f -H "Authorization: Basic $AUTH_HEADER" "$BASE_URL/wp-json/wp/v2/posts?slug=rejected-multi-ref&context=edit" | php -r '
+$posts = json_decode(stream_get_contents(STDIN), true);
+if (array() !== $posts) {
+	exit(1);
+}
+'
+git reset --hard HEAD~1 >/dev/null
+
+if PUSH_OUTPUT="$(git push origin :trunk 2>&1)"; then
+	echo "Expected trunk deletion push to fail." >&2
+	exit 1
+fi
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because deleting trunk is not supported.'
+
 php -r '
 file_put_contents(
 	$argv[1],
@@ -509,6 +756,126 @@ git reset --hard HEAD~1 >/dev/null
 php -r '
 file_put_contents(
 	$argv[1],
+	"---\nstatus: \"publish\"\ndate: \"not a date\"\ntitle: \"Rejected Invalid Date\"\n---\n\nThis push must be rejected.\n"
+);
+' "$CLONE_DIR/post/rejected-invalid-date.md"
+git add post/rejected-invalid-date.md
+git commit -m "Reject invalid front matter date"
+if PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
+	echo "Expected invalid date front matter push to fail." >&2
+	exit 1
+fi
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because Markdown front matter date is invalid.'
+git reset --hard HEAD~1 >/dev/null
+
+php -r '
+file_put_contents(
+	$argv[1],
+	"---\nstatus: \"scheduled\"\ntitle: \"Rejected Scheduled No Date\"\n---\n\nThis push must be rejected.\n"
+);
+' "$CLONE_DIR/post/rejected-scheduled-no-date.md"
+git add post/rejected-scheduled-no-date.md
+git commit -m "Reject scheduled post without date"
+if PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
+	echo "Expected scheduled post without date push to fail." >&2
+	exit 1
+fi
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because scheduled posts must include a future date.'
+git reset --hard HEAD~1 >/dev/null
+
+php -r '
+file_put_contents(
+	$argv[1],
+	"---\nstatus: \"scheduled\"\ndate: \"2000-01-01T00:00:00Z\"\ntitle: \"Rejected Scheduled Past Date\"\n---\n\nThis push must be rejected.\n"
+);
+' "$CLONE_DIR/post/rejected-scheduled-past-date.md"
+git add post/rejected-scheduled-past-date.md
+git commit -m "Reject scheduled post with past date"
+if PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
+	echo "Expected scheduled post with past date push to fail." >&2
+	exit 1
+fi
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because scheduled posts must include a date in the future.'
+git reset --hard HEAD~1 >/dev/null
+
+php -r '
+file_put_contents(
+	$argv[1],
+	"---\nstatus: \"publish\"\ndate: \"2099-01-01T00:00:00Z\"\ntitle: \"Rejected Published Future Date\"\n---\n\nThis push must be rejected.\n"
+);
+' "$CLONE_DIR/post/rejected-published-future-date.md"
+git add post/rejected-published-future-date.md
+git commit -m "Reject published post with future date"
+if PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
+	echo "Expected published post with future date push to fail." >&2
+	exit 1
+fi
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because published posts must not include a future date.'
+git reset --hard HEAD~1 >/dev/null
+
+php -r '
+file_put_contents(
+	$argv[1],
+	"---\nstatus: \"publish\"\ntitle: \"Rejected NUL Byte\"\n---\n\nBefore " . "\0" . " after.\n"
+);
+' "$CLONE_DIR/post/rejected-nul-byte.md"
+git add post/rejected-nul-byte.md
+git commit -m "Reject NUL byte content"
+if PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
+	echo "Expected NUL byte content push to fail." >&2
+	exit 1
+fi
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because content files must not contain NUL bytes.'
+git reset --hard HEAD~1 >/dev/null
+
+php -r '
+file_put_contents(
+	$argv[1],
+	"---\nstatus: \"publish\"\ndate: \"2024-02-31\"\ntitle: \"Rejected Impossible Date\"\n---\n\nThis push must be rejected.\n"
+);
+' "$CLONE_DIR/post/rejected-impossible-date.md"
+git add post/rejected-impossible-date.md
+git commit -m "Reject impossible front matter date"
+if PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
+	echo "Expected impossible date front matter push to fail." >&2
+	exit 1
+fi
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because Markdown front matter date is invalid.'
+git reset --hard HEAD~1 >/dev/null
+
+php -r '
+file_put_contents(
+	$argv[1],
+	"---\nstatus: \"publish\"\ntitle:\n  - \"Array Title\"\n---\n\nThis push must be rejected.\n"
+);
+' "$CLONE_DIR/post/rejected-array-title.md"
+git add post/rejected-array-title.md
+git commit -m "Reject array front matter title"
+if PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
+	echo "Expected array title front matter push to fail." >&2
+	exit 1
+fi
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because Markdown front matter field "title" must be a scalar string or number.'
+git reset --hard HEAD~1 >/dev/null
+
+php -r '
+file_put_contents(
+	$argv[1],
+	"---\nstatus: \"publish\"\nauthor: \"admin\"\ntitle: \"Rejected Unknown Front Matter\"\n---\n\nThis push must be rejected.\n"
+);
+' "$CLONE_DIR/post/rejected-unknown-frontmatter.md"
+git add post/rejected-unknown-frontmatter.md
+git commit -m "Reject unknown front matter"
+if PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
+	echo "Expected unknown front matter push to fail." >&2
+	exit 1
+fi
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because Markdown front matter field "author" is not supported.'
+git reset --hard HEAD~1 >/dev/null
+
+php -r '
+file_put_contents(
+	$argv[1],
 	"---\nstatus: \"publish\"\ntitle: \"Rejected Block Markup\"\n---\n\n<!-- wp:group {bad json} -->\nBroken block markup.\n<!-- /wp:group -->\n"
 );
 ' "$CLONE_DIR/post/rejected-block-markup.md"
@@ -535,6 +902,26 @@ if PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
 fi
 assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because the content contains mismatched Gutenberg block delimiters.'
 git reset --hard HEAD~1 >/dev/null
+
+php -r '
+file_put_contents(
+	$argv[1],
+	"---\nstatus: \"publish\"\ntitle: \"Rejected Raw Block In Markdown\"\n---\n\n<!-- wp:acme/custom-block-2 {\"flag\":true} /-->\n"
+);
+' "$CLONE_DIR/post/rejected-raw-block-in-markdown.md"
+git add post/rejected-raw-block-in-markdown.md
+git commit -m "Reject raw block in Markdown"
+if PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
+	echo "Expected raw block in Markdown push to fail." >&2
+	exit 1
+fi
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because Markdown content must not embed raw Gutenberg block delimiters inside HTML blocks.'
+git reset --hard HEAD~1 >/dev/null
+
+printf '%s' '<!-- wp:acme/custom-block-2 {"flag":true} /-->' > "$CLONE_DIR/wp_template/custom-acme-block.html"
+git add wp_template/custom-acme-block.html
+git commit -m "Accept custom block markup"
+git push origin trunk
 
 php -r '
 $path = $argv[1];

--- a/bin/test-wp-origin-git-actions.sh
+++ b/bin/test-wp-origin-git-actions.sh
@@ -356,8 +356,6 @@ file_put_contents($path, $markdown);
 php -r '
 $path = $argv[1];
 $markdown = "---\n"
-	. "type: \"page\"\n"
-	. "slug: \"page-from-git\"\n"
 	. "status: \"publish\"\n"
 	. "title: \"Page From Git\"\n"
 	. "---\n\n"
@@ -410,6 +408,133 @@ echo $page["status"];
 ')"
 [ "$TRASHED_PAGE_STATUS" = "trash" ]
 git pull --rebase origin trunk
+
+php -r '
+$path = $argv[1];
+$markdown = "---\n"
+	. "id: \"1\"\n"
+	. "status: \"publish\"\n"
+	. "title: \"Rejected ID Front Matter\"\n"
+	. "---\n\n"
+	. "This push must be rejected.\n";
+file_put_contents($path, $markdown);
+' "$CLONE_DIR/post/rejected-id-frontmatter.md"
+git add post/rejected-id-frontmatter.md
+git commit -m "Reject post id front matter"
+if PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
+	echo "Expected id front matter push to fail." >&2
+	exit 1
+fi
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because Markdown front matter must not include an id.'
+git reset --hard HEAD~1 >/dev/null
+
+php -r '
+$path = $argv[1];
+$markdown = "---\n"
+	. "slug: \"rejected-slug-frontmatter\"\n"
+	. "status: \"publish\"\n"
+	. "title: \"Rejected Slug Front Matter\"\n"
+	. "---\n\n"
+	. "This push must be rejected.\n";
+file_put_contents($path, $markdown);
+' "$CLONE_DIR/post/rejected-slug-frontmatter.md"
+git add post/rejected-slug-frontmatter.md
+git commit -m "Reject post slug front matter"
+if PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
+	echo "Expected slug front matter push to fail." >&2
+	exit 1
+fi
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because Markdown front matter must not include a slug.'
+git reset --hard HEAD~1 >/dev/null
+
+php -r '
+$path = $argv[1];
+$markdown = "---\n"
+	. "type: \"post\"\n"
+	. "status: \"publish\"\n"
+	. "title: \"Rejected Type Front Matter\"\n"
+	. "---\n\n"
+	. "This push must be rejected.\n";
+file_put_contents($path, $markdown);
+' "$CLONE_DIR/post/rejected-type-frontmatter.md"
+git add post/rejected-type-frontmatter.md
+git commit -m "Reject post type front matter"
+if PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
+	echo "Expected type front matter push to fail." >&2
+	exit 1
+fi
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because Markdown front matter must not include a type.'
+git reset --hard HEAD~1 >/dev/null
+
+php -r '
+file_put_contents(
+	$argv[1],
+	"---\nstatus: \"publish\"\ntitle: \"Atomic Valid Page\"\n---\n\nThis page must not be written if the push is rejected.\n"
+);
+file_put_contents(
+	$argv[2],
+	"---\nstatus: \"invalid-status\"\ntitle: \"Atomic Invalid Status\"\n---\n\nThis push must be rejected.\n"
+);
+' "$CLONE_DIR/page/atomic-valid-page.md" "$CLONE_DIR/post/atomic-invalid-status.md"
+git add page/atomic-valid-page.md post/atomic-invalid-status.md
+git commit -m "Reject atomic partial writes"
+if PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
+	echo "Expected atomic invalid status push to fail." >&2
+	exit 1
+fi
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because "invalid-status" is not a supported post status.'
+curl -sS -f -H "Authorization: Basic $AUTH_HEADER" "$BASE_URL/wp-json/wp/v2/pages?slug=atomic-valid-page&context=edit" | php -r '
+$pages = json_decode(stream_get_contents(STDIN), true);
+if (array() !== $pages) {
+	exit(1);
+}
+'
+git reset --hard HEAD~1 >/dev/null
+
+php -r '
+file_put_contents(
+	$argv[1],
+	"---\nstatus: \"publish\"\ntitle: \"Rejected Front Matter\"\n\nThis push must be rejected.\n"
+);
+' "$CLONE_DIR/post/rejected-frontmatter.md"
+git add post/rejected-frontmatter.md
+git commit -m "Reject malformed front matter"
+if PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
+	echo "Expected malformed front matter push to fail." >&2
+	exit 1
+fi
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because Markdown front matter is missing its closing --- fence.'
+git reset --hard HEAD~1 >/dev/null
+
+php -r '
+file_put_contents(
+	$argv[1],
+	"---\nstatus: \"publish\"\ntitle: \"Rejected Block Markup\"\n---\n\n<!-- wp:group {bad json} -->\nBroken block markup.\n<!-- /wp:group -->\n"
+);
+' "$CLONE_DIR/post/rejected-block-markup.md"
+git add post/rejected-block-markup.md
+git commit -m "Reject malformed block markup"
+if PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
+	echo "Expected malformed block markup push to fail." >&2
+	exit 1
+fi
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because the content contains malformed Gutenberg block'
+git reset --hard HEAD~1 >/dev/null
+
+php -r '
+file_put_contents(
+	$argv[1],
+	"---\nstatus: \"publish\"\ntitle: \"Rejected Mismatched Blocks\"\n---\n\n<!-- wp:paragraph -->\n<p>Broken block markup.</p>\n<!-- /wp:group -->\n"
+);
+' "$CLONE_DIR/post/rejected-mismatched-blocks.md"
+git add post/rejected-mismatched-blocks.md
+git commit -m "Reject mismatched block markup"
+if PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
+	echo "Expected mismatched block markup push to fail." >&2
+	exit 1
+fi
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because the content contains mismatched Gutenberg block delimiters.'
+git reset --hard HEAD~1 >/dev/null
 
 php -r '
 $path = $argv[1];

--- a/plugins/wp-origin/Tests/EndToEndTest.php
+++ b/plugins/wp-origin/Tests/EndToEndTest.php
@@ -100,11 +100,92 @@ class WP_Origin_End_To_End_Test extends TestCase {
 		$this->assertStringNotContainsString( 'Seed batch', $result['output'] );
 	}
 
+	public function testCloneFailsClosedWhenPageParentIsNotExported() {
+		$suffix    = uniqid( 'trashed-parent-' );
+		$parent_id = $this->create_page_via_rest(
+			array(
+				'slug'    => 'parent-' . $suffix,
+				'title'   => 'Parent ' . $suffix,
+				'status'  => 'publish',
+				'content' => '<!-- wp:paragraph --><p>Parent ' . $suffix . '</p><!-- /wp:paragraph -->',
+			)
+		);
+		$this->create_page_via_rest(
+			array(
+				'slug'    => 'child-' . $suffix,
+				'title'   => 'Child ' . $suffix,
+				'status'  => 'publish',
+				'parent'  => $parent_id,
+				'content' => '<!-- wp:paragraph --><p>Child ' . $suffix . '</p><!-- /wp:paragraph -->',
+			)
+		);
+
+		try {
+			$this->delete_page_via_rest( $parent_id );
+			$result = $this->run_cmd(
+				array( 'git', '-c', 'protocol.version=2', 'clone', $this->remote_url(), $this->work_dir . '/trashed-parent' ),
+				true
+			);
+			$this->assertNotSame( 0, $result['code'], 'Clone should fail closed when an exported page has a trashed parent.' );
+		} finally {
+			$this->update_page_via_rest( $parent_id, array( 'status' => 'publish' ) );
+		}
+	}
+
 	public function testFullRoundTrip() {
+		$hierarchy_suffix = uniqid( 'hierarchy-' );
+		$parent_a_slug    = 'parent-a-' . $hierarchy_suffix;
+		$parent_b_slug    = 'parent-b-' . $hierarchy_suffix;
+		$child_slug       = 'shared-child-' . $hierarchy_suffix;
+		$parent_a_id      = $this->create_page_via_rest(
+			array(
+				'slug'    => $parent_a_slug,
+				'title'   => 'Parent A ' . $hierarchy_suffix,
+				'status'  => 'publish',
+				'content' => '<!-- wp:paragraph --><p>Parent A ' . $hierarchy_suffix . '</p><!-- /wp:paragraph -->',
+			)
+		);
+		$parent_b_id      = $this->create_page_via_rest(
+			array(
+				'slug'    => $parent_b_slug,
+				'title'   => 'Parent B ' . $hierarchy_suffix,
+				'status'  => 'publish',
+				'content' => '<!-- wp:paragraph --><p>Parent B ' . $hierarchy_suffix . '</p><!-- /wp:paragraph -->',
+			)
+		);
+		$this->create_page_via_rest(
+			array(
+				'slug'    => $child_slug,
+				'title'   => 'Shared Child A ' . $hierarchy_suffix,
+				'status'  => 'publish',
+				'parent'  => $parent_a_id,
+				'content' => '<!-- wp:paragraph --><p>Shared Child A ' . $hierarchy_suffix . '</p><!-- /wp:paragraph -->',
+			)
+		);
+		$this->create_page_via_rest(
+			array(
+				'slug'    => $child_slug,
+				'title'   => 'Shared Child B ' . $hierarchy_suffix,
+				'status'  => 'publish',
+				'parent'  => $parent_b_id,
+				'content' => '<!-- wp:paragraph --><p>Shared Child B ' . $hierarchy_suffix . '</p><!-- /wp:paragraph -->',
+			)
+		);
+
 		$clone_dir = $this->clone_repo( 'clone' );
 
 		$this->assertFileExists( $clone_dir . '/post/hello-world.md' );
 		$this->assertFileExists( $clone_dir . '/page/sample-page.md' );
+		$this->assertFileExists( $clone_dir . '/page/' . $parent_a_slug . '/' . $child_slug . '.md' );
+		$this->assertFileExists( $clone_dir . '/page/' . $parent_b_slug . '/' . $child_slug . '.md' );
+		$this->assertStringContainsString(
+			'Shared Child A ' . $hierarchy_suffix,
+			file_get_contents( $clone_dir . '/page/' . $parent_a_slug . '/' . $child_slug . '.md' )
+		);
+		$this->assertStringContainsString(
+			'Shared Child B ' . $hierarchy_suffix,
+			file_get_contents( $clone_dir . '/page/' . $parent_b_slug . '/' . $child_slug . '.md' )
+		);
 		$this->assertFileExists( $clone_dir . '/wp_template/blog-home.html' );
 		$this->assertNotEmpty( glob( $clone_dir . '/wp_template/*/*.html' ), 'Expected active theme base templates to be exported.' );
 		$this->assertNotEmpty( glob( $clone_dir . '/wp_template_part/*/*.html' ), 'Expected active theme base template parts to be exported.' );
@@ -165,6 +246,33 @@ class WP_Origin_End_To_End_Test extends TestCase {
 		$sample_page_id = $this->fetch_id_by_slug( 'sample-page', 'pages' );
 
 		$this->configure_git( $clone_dir );
+
+		$git_child_slug = 'git-child-' . $hierarchy_suffix;
+		file_put_contents(
+			$clone_dir . '/page/' . $parent_a_slug . '/' . $git_child_slug . '.md',
+			"---\nstatus: \"publish\"\ntitle: \"Git Child $hierarchy_suffix\"\n---\n\nNested child from Git.\n"
+		);
+		$this->commit_and_push(
+			$clone_dir,
+			'page/' . $parent_a_slug . '/' . $git_child_slug . '.md',
+			'Create nested child page from Git'
+		);
+		$git_child_id = $this->fetch_id_by_slug( $git_child_slug, 'pages' );
+		$git_child    = $this->fetch_rest_item( $git_child_id, 'pages' );
+		$this->assertSame( $parent_a_id, intval( $git_child['parent'] ) );
+		$this->assertStringContainsString( 'Nested child from Git', $git_child['content']['raw'] );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'pull', '--rebase', 'origin', 'trunk' ) );
+
+		unlink( $clone_dir . '/page/' . $parent_a_slug . '.md' );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', '-A' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject parent page delete with children' ) );
+		$push_result = $this->run_cmd(
+			array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ),
+			true
+		);
+		$this->assertNotSame( 0, $push_result['code'], 'Parent page deletion with remaining children should have been rejected.' );
+		$this->assertStringContainsString( 'Push rejected because deleting a parent page while keeping nested child page files would move child content.', $push_result['output'] );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
 
 		// Theme source JSON is exported for context, not edited through
 		// WP Origin.
@@ -366,6 +474,153 @@ class WP_Origin_End_To_End_Test extends TestCase {
 		$this->assertStringContainsString( 'Push rejected because Markdown front matter must not include a type.', $push_result['output'] );
 		$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
 
+		mkdir( $clone_dir . '/post/nested-path' );
+		file_put_contents(
+			$clone_dir . '/post/nested-path/rejected-nested-path.md',
+			"---\nstatus: \"publish\"\ntitle: \"Rejected Nested Path\"\n---\n\nThis push must be rejected.\n"
+		);
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', 'post/nested-path/rejected-nested-path.md' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject nested post path' ) );
+		$push_result = $this->run_cmd(
+			array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ),
+			true
+		);
+		$this->assertNotSame( 0, $push_result['code'], 'Nested post paths should have been rejected.' );
+		$this->assertStringContainsString( 'Push rejected because post Markdown files must use post/<slug>.md paths.', $push_result['output'] );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
+
+		file_put_contents(
+			$clone_dir . '/post/Rejected Upper Slug.md',
+			"---\nstatus: \"publish\"\ntitle: \"Rejected Upper Slug\"\n---\n\nThis push must be rejected.\n"
+		);
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', 'post/Rejected Upper Slug.md' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject noncanonical post slug' ) );
+		$push_result = $this->run_cmd(
+			array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ),
+			true
+		);
+		$this->assertNotSame( 0, $push_result['code'], 'Noncanonical post slugs should have been rejected.' );
+		$this->assertStringContainsString( 'Push rejected because Markdown file slugs must already match WordPress slug formatting.', $push_result['output'] );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
+
+		mkdir( $clone_dir . '/wp_template/Bad Theme' );
+		file_put_contents(
+			$clone_dir . '/wp_template/Bad Theme/rejected-raw-path.html',
+			'<!-- wp:paragraph --><p>This push must be rejected.</p><!-- /wp:paragraph -->'
+		);
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', 'wp_template/Bad Theme/rejected-raw-path.html' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject noncanonical template theme path' ) );
+		$push_result = $this->run_cmd(
+			array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ),
+			true
+		);
+		$this->assertNotSame( 0, $push_result['code'], 'Noncanonical template theme paths should have been rejected.' );
+		$this->assertStringContainsString( 'Push rejected because template theme path segments must already match WordPress slug formatting.', $push_result['output'] );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
+
+		file_put_contents(
+			$clone_dir . '/wp_template/Rejected Raw Slug.html',
+			'<!-- wp:paragraph --><p>This push must be rejected.</p><!-- /wp:paragraph -->'
+		);
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', 'wp_template/Rejected Raw Slug.html' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject noncanonical template slug path' ) );
+		$push_result = $this->run_cmd(
+			array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ),
+			true
+		);
+		$this->assertNotSame( 0, $push_result['code'], 'Noncanonical template slug paths should have been rejected.' );
+		$this->assertStringContainsString( 'Push rejected because template file slugs must already match WordPress slug formatting.', $push_result['output'] );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
+
+		file_put_contents(
+			$clone_dir . '/wp_template/rejected-plain-html.html',
+			"<div>This push must be rejected.</div>\n"
+		);
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', 'wp_template/rejected-plain-html.html' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject plain template HTML' ) );
+		$push_result = $this->run_cmd(
+			array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ),
+			true
+		);
+		$this->assertNotSame( 0, $push_result['code'], 'Plain template HTML should have been rejected.' );
+		$this->assertStringContainsString( 'Push rejected because template HTML files must contain serialized Gutenberg block markup.', $push_result['output'] );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
+
+		file_put_contents(
+			$clone_dir . '/wp_global_styles/Bad-Theme.json',
+			"{\"version\":3,\"settings\":{},\"styles\":{}}\n"
+		);
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', 'wp_global_styles/Bad-Theme.json' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject noncanonical Global Styles path' ) );
+		$push_result = $this->run_cmd(
+			array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ),
+			true
+		);
+		$this->assertNotSame( 0, $push_result['code'], 'Noncanonical Global Styles filenames should have been rejected.' );
+		$this->assertStringContainsString( 'Push rejected because the Global Styles theme filename must already match WordPress slug formatting.', $push_result['output'] );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
+
+		if ( @symlink( '../post/hello-world.md', $clone_dir . '/post/rejected-symlink.md' ) ) {
+			$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', 'post/rejected-symlink.md' ) );
+			$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject arbitrary symlink' ) );
+			$push_result = $this->run_cmd(
+				array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ),
+				true
+			);
+			$this->assertNotSame( 0, $push_result['code'], 'Arbitrary symlinks should have been rejected.' );
+			$this->assertStringContainsString( 'Push rejected because symlink files are generated by WP Origin and cannot be created or modified.', $push_result['output'] );
+			$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
+		}
+
+		if ( is_link( $clone_dir . '/AGENTS.md' ) ) {
+			$this->run_cmd( array( 'git', '-C', $clone_dir, 'rm', 'AGENTS.md' ) );
+			$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject generated symlink deletion' ) );
+			$push_result = $this->run_cmd(
+				array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ),
+				true
+			);
+			$this->assertNotSame( 0, $push_result['code'], 'Generated symlink deletion should have been rejected.' );
+			$this->assertStringContainsString( 'Push rejected because symlink files are generated by WP Origin and cannot be deleted or modified.', $push_result['output'] );
+			$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
+		}
+
+		file_put_contents(
+			$clone_dir . '/post/rejected-executable.md',
+			"---\nstatus: \"publish\"\ntitle: \"Rejected Executable\"\n---\n\nThis push must be rejected.\n"
+		);
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', 'post/rejected-executable.md' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'update-index', '--chmod=+x', 'post/rejected-executable.md' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject executable content file' ) );
+		$push_result = $this->run_cmd(
+			array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ),
+			true
+		);
+		$this->assertNotSame( 0, $push_result['code'], 'Executable content files should have been rejected.' );
+		$this->assertStringContainsString( 'Push rejected because executable file modes are not supported by WP Origin content exports.', $push_result['output'] );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
+
+		file_put_contents(
+			$clone_dir . '/post/rejected-multi-ref.md',
+			"---\nstatus: \"publish\"\ntitle: \"Rejected Multi Ref\"\n---\n\nThis push must be rejected before WordPress writes.\n"
+		);
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', 'post/rejected-multi-ref.md' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject multi-ref push' ) );
+		$push_result = $this->run_cmd(
+			array( 'git', '-C', $clone_dir, 'push', 'origin', 'HEAD:trunk', 'HEAD:refs/heads/rejected-multi-ref' ),
+			true
+		);
+		$this->assertNotSame( 0, $push_result['code'], 'Multi-ref pushes should have been rejected.' );
+		$this->assertStringContainsString( 'Push rejected because WP Origin only accepts one ref update at a time.', $push_result['output'] );
+		$this->assert_slug_absent( 'rejected-multi-ref', 'posts' );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
+
+		$push_result = $this->run_cmd(
+			array( 'git', '-C', $clone_dir, 'push', 'origin', ':trunk' ),
+			true
+		);
+		$this->assertNotSame( 0, $push_result['code'], 'Deleting trunk should have been rejected.' );
+		$this->assertStringContainsString( 'Push rejected because deleting trunk is not supported.', $push_result['output'] );
+
 		// 8) Push validation must finish before any WordPress writes.
 		file_put_contents(
 			$clone_dir . '/page/atomic-valid-page.md',
@@ -401,6 +656,118 @@ class WP_Origin_End_To_End_Test extends TestCase {
 		$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
 
 		file_put_contents(
+			$clone_dir . '/post/rejected-invalid-date.md',
+			"---\nstatus: \"publish\"\ndate: \"not a date\"\ntitle: \"Rejected Invalid Date\"\n---\n\nThis push must be rejected.\n"
+		);
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', 'post/rejected-invalid-date.md' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject invalid front matter date' ) );
+		$push_result = $this->run_cmd(
+			array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ),
+			true
+		);
+		$this->assertNotSame( 0, $push_result['code'], 'Invalid date front matter should have been rejected.' );
+		$this->assertStringContainsString( 'Push rejected because Markdown front matter date is invalid.', $push_result['output'] );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
+
+		file_put_contents(
+			$clone_dir . '/post/rejected-impossible-date.md',
+			"---\nstatus: \"publish\"\ndate: \"2024-02-31\"\ntitle: \"Rejected Impossible Date\"\n---\n\nThis push must be rejected.\n"
+		);
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', 'post/rejected-impossible-date.md' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject impossible front matter date' ) );
+		$push_result = $this->run_cmd(
+			array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ),
+			true
+		);
+		$this->assertNotSame( 0, $push_result['code'], 'Impossible date front matter should have been rejected.' );
+		$this->assertStringContainsString( 'Push rejected because Markdown front matter date is invalid.', $push_result['output'] );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
+
+		file_put_contents(
+			$clone_dir . '/post/rejected-scheduled-no-date.md',
+			"---\nstatus: \"scheduled\"\ntitle: \"Rejected Scheduled No Date\"\n---\n\nThis push must be rejected.\n"
+		);
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', 'post/rejected-scheduled-no-date.md' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject scheduled post without date' ) );
+		$push_result = $this->run_cmd(
+			array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ),
+			true
+		);
+		$this->assertNotSame( 0, $push_result['code'], 'Scheduled posts without dates should have been rejected.' );
+		$this->assertStringContainsString( 'Push rejected because scheduled posts must include a future date.', $push_result['output'] );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
+
+		file_put_contents(
+			$clone_dir . '/post/rejected-scheduled-past-date.md',
+			"---\nstatus: \"scheduled\"\ndate: \"2000-01-01T00:00:00Z\"\ntitle: \"Rejected Scheduled Past Date\"\n---\n\nThis push must be rejected.\n"
+		);
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', 'post/rejected-scheduled-past-date.md' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject scheduled post with past date' ) );
+		$push_result = $this->run_cmd(
+			array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ),
+			true
+		);
+			$this->assertNotSame( 0, $push_result['code'], 'Scheduled posts with past dates should have been rejected.' );
+			$this->assertStringContainsString( 'Push rejected because scheduled posts must include a date in the future.', $push_result['output'] );
+			$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
+
+			file_put_contents(
+				$clone_dir . '/post/rejected-published-future-date.md',
+				"---\nstatus: \"publish\"\ndate: \"2099-01-01T00:00:00Z\"\ntitle: \"Rejected Published Future Date\"\n---\n\nThis push must be rejected.\n"
+			);
+			$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', 'post/rejected-published-future-date.md' ) );
+			$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject published post with future date' ) );
+			$push_result = $this->run_cmd(
+				array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ),
+				true
+			);
+			$this->assertNotSame( 0, $push_result['code'], 'Published posts with future dates should have been rejected.' );
+			$this->assertStringContainsString( 'Push rejected because published posts must not include a future date.', $push_result['output'] );
+			$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
+
+			file_put_contents(
+				$clone_dir . '/post/rejected-nul-byte.md',
+				"---\nstatus: \"publish\"\ntitle: \"Rejected NUL Byte\"\n---\n\nBefore " . "\0" . " after.\n"
+		);
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', 'post/rejected-nul-byte.md' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject NUL byte content' ) );
+		$push_result = $this->run_cmd(
+			array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ),
+			true
+		);
+		$this->assertNotSame( 0, $push_result['code'], 'NUL byte content should have been rejected.' );
+		$this->assertStringContainsString( 'Push rejected because content files must not contain NUL bytes.', $push_result['output'] );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
+
+		file_put_contents(
+			$clone_dir . '/post/rejected-array-title.md',
+			"---\nstatus: \"publish\"\ntitle:\n  - \"Array Title\"\n---\n\nThis push must be rejected.\n"
+		);
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', 'post/rejected-array-title.md' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject array front matter title' ) );
+		$push_result = $this->run_cmd(
+			array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ),
+			true
+		);
+		$this->assertNotSame( 0, $push_result['code'], 'Array title front matter should have been rejected.' );
+		$this->assertStringContainsString( 'Push rejected because Markdown front matter field "title" must be a scalar string or number.', $push_result['output'] );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
+
+		file_put_contents(
+			$clone_dir . '/post/rejected-unknown-frontmatter.md',
+			"---\nstatus: \"publish\"\nauthor: \"admin\"\ntitle: \"Rejected Unknown Front Matter\"\n---\n\nThis push must be rejected.\n"
+		);
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', 'post/rejected-unknown-frontmatter.md' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject unknown front matter' ) );
+		$push_result = $this->run_cmd(
+			array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ),
+			true
+		);
+		$this->assertNotSame( 0, $push_result['code'], 'Unknown front matter should have been rejected.' );
+		$this->assertStringContainsString( 'Push rejected because Markdown front matter field "author" is not supported.', $push_result['output'] );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
+
+		file_put_contents(
 			$clone_dir . '/post/rejected-block-markup.md',
 			"---\nstatus: \"publish\"\ntitle: \"Rejected Block Markup\"\n---\n\n<!-- wp:group {bad json} -->\nBroken block markup.\n<!-- /wp:group -->\n"
 		);
@@ -427,6 +794,26 @@ class WP_Origin_End_To_End_Test extends TestCase {
 		$this->assertNotSame( 0, $push_result['code'], 'Mismatched block delimiters should have been rejected.' );
 		$this->assertStringContainsString( 'Push rejected because the content contains mismatched Gutenberg block delimiters.', $push_result['output'] );
 		$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
+
+		file_put_contents(
+			$clone_dir . '/post/rejected-raw-block-in-markdown.md',
+			"---\nstatus: \"publish\"\ntitle: \"Rejected Raw Block In Markdown\"\n---\n\n<!-- wp:acme/custom-block-2 {\"flag\":true} /-->\n"
+		);
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', 'post/rejected-raw-block-in-markdown.md' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject raw block in Markdown' ) );
+		$push_result = $this->run_cmd(
+			array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ),
+			true
+		);
+		$this->assertNotSame( 0, $push_result['code'], 'Raw block delimiters in Markdown should have been rejected.' );
+		$this->assertStringContainsString( 'Push rejected because Markdown content must not embed raw Gutenberg block delimiters inside HTML blocks.', $push_result['output'] );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
+
+		file_put_contents(
+			$clone_dir . '/wp_template/custom-acme-block.html',
+			'<!-- wp:acme/custom-block-2 {"flag":true} /-->'
+		);
+		$this->commit_and_push( $clone_dir, 'wp_template/custom-acme-block.html', 'Accept custom block markup' );
 
 		file_put_contents(
 			$clone_dir . '/post/delete-restore-e2e.md',
@@ -478,6 +865,7 @@ class WP_Origin_End_To_End_Test extends TestCase {
 		$this->assertFileExists( $fresh . '/post/created-from-git.md' );
 		$this->assertFileExists( $fresh . '/wp_template/blog-home.html' );
 		$this->assertFileExists( $fresh . '/wp_template/custom-blog-card.html' );
+		$this->assertFileExists( $fresh . '/wp_template/custom-acme-block.html' );
 		$this->assertFileDoesNotExist( $fresh . '/page/sample-page.md' );
 		$this->assertFileDoesNotExist( $fresh . '/wp_template/renamed-blog-card.html' );
 		$this->assertFileExists( $fresh . '/post/delete-restore-e2e.md' );
@@ -488,6 +876,10 @@ class WP_Origin_End_To_End_Test extends TestCase {
 		$this->assertStringContainsString(
 			'Created template from Git',
 			file_get_contents( $fresh . '/wp_template/custom-blog-card.html' )
+		);
+		$this->assertStringContainsString(
+			'wp:acme/custom-block-2',
+			file_get_contents( $fresh . '/wp_template/custom-acme-block.html' )
 		);
 		$log = $this->run_cmd( array( 'git', '-C', $fresh, 'log', '--format=%s' ) );
 		$this->assertStringContainsString( 'Update hello world from Git', $log['output'] );
@@ -568,6 +960,70 @@ class WP_Origin_End_To_End_Test extends TestCase {
 		$post = json_decode( $body, true );
 
 		return $post['status'];
+	}
+
+	private function fetch_rest_item( $id, $endpoint ) {
+		$body = $this->curl_get( $this->base_url . '/wp-json/wp/v2/' . $endpoint . '/' . $id . '?context=edit' );
+		$item = json_decode( $body, true );
+		$this->assertIsArray( $item, "Unexpected REST response for $endpoint/$id: $body" );
+
+		return $item;
+	}
+
+	private function create_page_via_rest( array $payload ) {
+		$ch = curl_init( $this->base_url . '/wp-json/wp/v2/pages?context=edit' );
+		curl_setopt_array(
+			$ch,
+			array(
+				CURLOPT_RETURNTRANSFER => true,
+				CURLOPT_CUSTOMREQUEST  => 'POST',
+				CURLOPT_HTTPHEADER     => array( $this->auth_header, 'Content-Type: application/json' ),
+				CURLOPT_POSTFIELDS     => wp_origin_e2e_json_encode( $payload ),
+			)
+		);
+		$response = curl_exec( $ch );
+		$status   = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
+		curl_close( $ch );
+		$this->assertTrue( 200 === $status || 201 === $status, "REST page create failed: $response" );
+
+		$page = json_decode( $response, true );
+		$this->assertIsArray( $page, "Unexpected REST page create response: $response" );
+		$this->assertArrayHasKey( 'id', $page, "REST page create response had no ID: $response" );
+
+		return intval( $page['id'] );
+	}
+
+	private function update_page_via_rest( $id, array $payload ) {
+		$ch = curl_init( $this->base_url . '/wp-json/wp/v2/pages/' . $id . '?context=edit' );
+		curl_setopt_array(
+			$ch,
+			array(
+				CURLOPT_RETURNTRANSFER => true,
+				CURLOPT_CUSTOMREQUEST  => 'POST',
+				CURLOPT_HTTPHEADER     => array( $this->auth_header, 'Content-Type: application/json' ),
+				CURLOPT_POSTFIELDS     => wp_origin_e2e_json_encode( $payload ),
+			)
+		);
+		$response = curl_exec( $ch );
+		$status   = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
+		curl_close( $ch );
+		$this->assertSame( 200, $status, "REST page update failed: $response" );
+	}
+
+	private function delete_page_via_rest( $id ) {
+		$ch = curl_init( $this->base_url . '/wp-json/wp/v2/pages/' . $id . '?context=edit' );
+		curl_setopt_array(
+			$ch,
+			array(
+				CURLOPT_RETURNTRANSFER => true,
+				CURLOPT_CUSTOMREQUEST  => 'DELETE',
+				CURLOPT_HTTPHEADER     => array( $this->auth_header ),
+			)
+		);
+		$response = curl_exec( $ch );
+		$status   = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
+		curl_close( $ch );
+		$this->assertSame( 200, $status, "REST page delete failed: $response" );
 	}
 
 	private function update_post_via_rest( $id, array $payload ) {

--- a/plugins/wp-origin/Tests/EndToEndTest.php
+++ b/plugins/wp-origin/Tests/EndToEndTest.php
@@ -307,7 +307,7 @@ class WP_Origin_End_To_End_Test extends TestCase {
 		// 6) Create a new post and delete an existing page in one push.
 		file_put_contents(
 			$clone_dir . '/post/created-from-git.md',
-			"---\ntype: \"post\"\nslug: \"created-from-git\"\nstatus: \"publish\"\ntitle: \"Created From Git\"\n---\n\nCreated from Git.\n"
+			"---\nstatus: \"publish\"\ntitle: \"Created From Git\"\n---\n\nCreated from Git.\n"
 		);
 		unlink( $clone_dir . '/page/sample-page.md' );
 		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', '-A' ) );
@@ -321,8 +321,135 @@ class WP_Origin_End_To_End_Test extends TestCase {
 		);
 		$this->assertSame( 'trash', $this->fetch_status( $sample_page_id, 'pages' ) );
 
-		// 7) Stale push: an out-of-date local commit must be rejected.
+		// 7) The Git path is the content identity; front matter cannot
+		// smuggle a different ID or slug.
 		$this->run_cmd( array( 'git', '-C', $clone_dir, 'pull', '--rebase', 'origin', 'trunk' ) );
+		file_put_contents(
+			$clone_dir . '/post/rejected-id-frontmatter.md',
+			"---\nid: \"1\"\nstatus: \"publish\"\ntitle: \"Rejected ID Front Matter\"\n---\n\nThis push must be rejected.\n"
+		);
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', 'post/rejected-id-frontmatter.md' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject post id front matter' ) );
+		$push_result = $this->run_cmd(
+			array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ),
+			true
+		);
+		$this->assertNotSame( 0, $push_result['code'], 'ID front matter should have been rejected.' );
+		$this->assertStringContainsString( 'Push rejected because Markdown front matter must not include an id.', $push_result['output'] );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
+
+		file_put_contents(
+			$clone_dir . '/post/rejected-slug-frontmatter.md',
+			"---\nslug: \"rejected-slug-frontmatter\"\nstatus: \"publish\"\ntitle: \"Rejected Slug Front Matter\"\n---\n\nThis push must be rejected.\n"
+		);
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', 'post/rejected-slug-frontmatter.md' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject post slug front matter' ) );
+		$push_result = $this->run_cmd(
+			array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ),
+			true
+		);
+		$this->assertNotSame( 0, $push_result['code'], 'Slug front matter should have been rejected.' );
+		$this->assertStringContainsString( 'Push rejected because Markdown front matter must not include a slug.', $push_result['output'] );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
+
+		file_put_contents(
+			$clone_dir . '/post/rejected-type-frontmatter.md',
+			"---\ntype: \"post\"\nstatus: \"publish\"\ntitle: \"Rejected Type Front Matter\"\n---\n\nThis push must be rejected.\n"
+		);
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', 'post/rejected-type-frontmatter.md' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject post type front matter' ) );
+		$push_result = $this->run_cmd(
+			array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ),
+			true
+		);
+		$this->assertNotSame( 0, $push_result['code'], 'Type front matter should have been rejected.' );
+		$this->assertStringContainsString( 'Push rejected because Markdown front matter must not include a type.', $push_result['output'] );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
+
+		// 8) Push validation must finish before any WordPress writes.
+		file_put_contents(
+			$clone_dir . '/page/atomic-valid-page.md',
+			"---\nstatus: \"publish\"\ntitle: \"Atomic Valid Page\"\n---\n\nThis page must not be written if the push is rejected.\n"
+		);
+		file_put_contents(
+			$clone_dir . '/post/atomic-invalid-status.md',
+			"---\nstatus: \"invalid-status\"\ntitle: \"Atomic Invalid Status\"\n---\n\nThis push must be rejected.\n"
+		);
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', 'page/atomic-valid-page.md', 'post/atomic-invalid-status.md' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject atomic partial writes' ) );
+		$push_result = $this->run_cmd(
+			array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ),
+			true
+		);
+		$this->assertNotSame( 0, $push_result['code'], 'Invalid status push should have been rejected.' );
+		$this->assertStringContainsString( 'Push rejected because "invalid-status" is not a supported post status.', $push_result['output'] );
+		$this->assert_slug_absent( 'atomic-valid-page', 'pages' );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
+
+		file_put_contents(
+			$clone_dir . '/post/rejected-frontmatter.md',
+			"---\nstatus: \"publish\"\ntitle: \"Rejected Front Matter\"\n\nThis push must be rejected.\n"
+		);
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', 'post/rejected-frontmatter.md' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject malformed front matter' ) );
+		$push_result = $this->run_cmd(
+			array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ),
+			true
+		);
+		$this->assertNotSame( 0, $push_result['code'], 'Malformed front matter should have been rejected.' );
+		$this->assertStringContainsString( 'Push rejected because Markdown front matter is missing its closing --- fence.', $push_result['output'] );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
+
+		file_put_contents(
+			$clone_dir . '/post/rejected-block-markup.md',
+			"---\nstatus: \"publish\"\ntitle: \"Rejected Block Markup\"\n---\n\n<!-- wp:group {bad json} -->\nBroken block markup.\n<!-- /wp:group -->\n"
+		);
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', 'post/rejected-block-markup.md' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject malformed block markup' ) );
+		$push_result = $this->run_cmd(
+			array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ),
+			true
+		);
+		$this->assertNotSame( 0, $push_result['code'], 'Malformed block markup should have been rejected.' );
+		$this->assertStringContainsString( 'Push rejected because the content contains malformed Gutenberg block', $push_result['output'] );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
+
+		file_put_contents(
+			$clone_dir . '/post/rejected-mismatched-blocks.md',
+			"---\nstatus: \"publish\"\ntitle: \"Rejected Mismatched Blocks\"\n---\n\n<!-- wp:paragraph -->\n<p>Broken block markup.</p>\n<!-- /wp:group -->\n"
+		);
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', 'post/rejected-mismatched-blocks.md' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject mismatched block markup' ) );
+		$push_result = $this->run_cmd(
+			array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ),
+			true
+		);
+		$this->assertNotSame( 0, $push_result['code'], 'Mismatched block delimiters should have been rejected.' );
+		$this->assertStringContainsString( 'Push rejected because the content contains mismatched Gutenberg block delimiters.', $push_result['output'] );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
+
+		file_put_contents(
+			$clone_dir . '/post/delete-restore-e2e.md',
+			"---\nstatus: \"publish\"\ntitle: \"Delete Restore E2E\"\n---\n\nRestore the same WordPress post.\n"
+		);
+		$this->commit_and_push( $clone_dir, 'post/delete-restore-e2e.md', 'Create delete restore post' );
+		$restore_id = $this->fetch_id_by_slug( 'delete-restore-e2e', 'posts' );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'pull', '--rebase', 'origin', 'trunk' ) );
+		unlink( $clone_dir . '/post/delete-restore-e2e.md' );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', '-A' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Trash delete restore post' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ) );
+		$this->assertSame( 'trash', $this->fetch_status( $restore_id, 'posts' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'pull', '--rebase', 'origin', 'trunk' ) );
+		file_put_contents(
+			$clone_dir . '/post/delete-restore-e2e.md',
+			"---\nstatus: \"publish\"\ntitle: \"Delete Restore E2E\"\n---\n\nRestored through Git.\n"
+		);
+		$this->commit_and_push( $clone_dir, 'post/delete-restore-e2e.md', 'Restore delete restore post' );
+		$this->assertSame( $restore_id, $this->fetch_id_by_slug( 'delete-restore-e2e', 'posts' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'pull', '--rebase', 'origin', 'trunk' ) );
+
+		// 9) Stale push: an out-of-date local commit must be rejected.
 		$this->edit_file(
 			$clone_dir . '/post/hello-world.md',
 			'Updated from Git ~~from editor~~',
@@ -344,7 +471,7 @@ class WP_Origin_End_To_End_Test extends TestCase {
 		);
 		$this->assertNotSame( 0, $push_result['code'], 'Stale push should have been rejected.' );
 
-		// 8) Persistence proof: a brand-new clone (no shared state with
+		// 10) Persistence proof: a brand-new clone (no shared state with
 		// $clone_dir) must see every commit and file from above.
 		$fresh = $this->clone_repo( 'fresh' );
 		$this->assertFileExists( $fresh . '/post/hello-world.md' );
@@ -353,6 +480,7 @@ class WP_Origin_End_To_End_Test extends TestCase {
 		$this->assertFileExists( $fresh . '/wp_template/custom-blog-card.html' );
 		$this->assertFileDoesNotExist( $fresh . '/page/sample-page.md' );
 		$this->assertFileDoesNotExist( $fresh . '/wp_template/renamed-blog-card.html' );
+		$this->assertFileExists( $fresh . '/post/delete-restore-e2e.md' );
 		$this->assertStringContainsString(
 			'Template updated from Git',
 			file_get_contents( $fresh . '/wp_template/blog-home.html' )
@@ -366,7 +494,7 @@ class WP_Origin_End_To_End_Test extends TestCase {
 		$this->assertStringContainsString( 'Update template HTML from Git', $log['output'] );
 		$this->assertStringContainsString( 'Create and delete content from Git', $log['output'] );
 
-		// 9) The CPT-based persistence model is gone.
+		// 11) The CPT-based persistence model is gone.
 		$this->assertNotSame(
 			200,
 			$this->http_status( $this->base_url . '/wp-json/wp/v2/types/wp_origin_commit' )
@@ -417,6 +545,15 @@ class WP_Origin_End_To_End_Test extends TestCase {
 		$this->assertNotEmpty( $items, "No $endpoint match for slug $slug" );
 
 		return intval( $items[0]['id'] );
+	}
+
+	private function assert_slug_absent( $slug, $endpoint ) {
+		$url = $this->base_url . '/wp-json/wp/v2/' . $endpoint
+			. '?slug=' . rawurlencode( $slug ) . '&context=edit';
+		$body  = $this->curl_get( $url );
+		$items = json_decode( $body, true );
+		$this->assertIsArray( $items, "Unexpected REST response for $endpoint?slug=$slug: $body" );
+		$this->assertSame( array(), $items, "Unexpected $endpoint match for slug $slug" );
 	}
 
 	private function fetch_content( $id, $endpoint ) {

--- a/plugins/wp-origin/class-wp-origin-plugin.php
+++ b/plugins/wp-origin/class-wp-origin-plugin.php
@@ -269,6 +269,10 @@ SKILL;
 	}
 
 	private static function current_user_can_read_exported_content() {
+		if ( current_user_can( 'edit_others_posts' ) ) {
+			return true;
+		}
+
 		$post_ids = get_posts(
 			array(
 				'post_type'      => self::get_export_post_types(),
@@ -649,8 +653,9 @@ SKILL;
 		$files                  = array();
 		$has_guideline_skills   = false;
 		$agent_guide_skill_path = null;
+		$can_read_all_exports   = current_user_can( 'edit_others_posts' );
 		foreach ( $posts as $post ) {
-			if ( ! current_user_can( 'read_post', intval( $post->ID ) ) ) {
+			if ( ! $can_read_all_exports && ! current_user_can( 'read_post', intval( $post->ID ) ) ) {
 				throw new Exception( 'Git export rejected because you do not have permission to read all WP Origin content.' );
 			}
 
@@ -1185,17 +1190,7 @@ SKILL;
 			self::validate_single_commit_content_changes( $repository, $commit_hash );
 		}
 
-		foreach ( $commit_hashes as $index => $commit_hash ) {
-			// Conflict checks against WordPress's current modified_gmt only
-			// make sense for the first commit in the push range — every
-			// subsequent commit is being applied on top of the WP state we
-			// just produced, so per-file modified_gmt comparisons would
-			// spuriously fail.
-			$push_summary = array_merge(
-				$push_summary,
-				self::apply_single_commit_to_wordpress( $repository, $commit_hash, 0 !== $index )
-			);
-		}
+		$push_summary = self::apply_repository_diff_to_wordpress( $repository, $old_commit, $new_commit, false );
 
 		return $push_summary;
 	}
@@ -1245,18 +1240,16 @@ SKILL;
 		}
 	}
 
-	private static function apply_single_commit_to_wordpress( GitRepository $repository, $commit_hash, $skip_modified_checks ) {
-		$commit = $repository->read_object( $commit_hash )->as_commit();
-		self::validate_push_commit( $repository, $commit );
-
-		$parent_hash = empty( $commit->parents ) ? Commit::NULL_HASH : $commit->get_first_parent_hash();
-		$old_files   = Commit::is_null_hash( $parent_hash )
+	private static function apply_repository_diff_to_wordpress( GitRepository $repository, $old_commit, $new_commit, $skip_modified_checks ) {
+		$old_files = Commit::is_null_hash( $old_commit )
 			? array()
-			: self::read_repository_entries_from_commit( $repository, $parent_hash );
-		$new_files   = self::read_repository_entries_from_commit( $repository, $commit_hash );
+			: self::read_repository_entries_from_commit( $repository, $old_commit );
+		$new_files = self::read_repository_entries_from_commit( $repository, $new_commit );
 
 		$updated_post_ids = array();
 		$changes          = array();
+		$upsert_plans     = array();
+		$trash_plans      = array();
 		self::reject_deleted_raw_block_files( $old_files, $new_files );
 		self::reject_deleted_theme_base_files( $old_files, $new_files );
 		self::reject_deleted_global_styles_files( $old_files, $new_files );
@@ -1269,16 +1262,22 @@ SKILL;
 				continue;
 			}
 
-			$applied = self::upsert_post_from_markdown(
+			$planned = self::upsert_post_from_markdown(
 				$path,
 				$entry['content'],
-				array( 'skip_modified_check' => $skip_modified_checks )
+				array(
+					'dry_run'             => true,
+					'skip_modified_check' => $skip_modified_checks,
+				)
 			);
-			$post_id = $applied['post_id'];
+			$post_id = $planned['post_id'];
 			if ( $post_id ) {
 				$updated_post_ids[ $post_id ] = true;
-				$changes[]                    = $applied['change'];
 			}
+			$upsert_plans[] = array(
+				'path'    => $path,
+				'content' => $entry['content'],
+			);
 		}
 
 		foreach ( $old_files as $path => $entry ) {
@@ -1290,10 +1289,7 @@ SKILL;
 			}
 
 			$metadata = self::parse_markdown_metadata( $entry['content'] );
-			$post_id  = isset( $metadata['id'] ) ? intval( $metadata['id'] ) : 0;
-			if ( ! $post_id ) {
-				$post_id = self::find_post_id_by_path_metadata( $path, $metadata );
-			}
+			$post_id  = self::find_post_id_by_path_metadata( $path, $metadata );
 
 			if ( ! $post_id || isset( $updated_post_ids[ $post_id ] ) ) {
 				continue;
@@ -1307,10 +1303,28 @@ SKILL;
 			}
 			self::assert_can_edit_post( $post_id );
 
-			$post      = get_post( $post_id );
-			$changes[] = self::build_push_summary_item( 'trashed', $post, $path );
+			$trash_plans[] = array(
+				'post_id' => $post_id,
+				'path'    => $path,
+			);
+		}
 
-			if ( false === wp_trash_post( $post_id ) ) {
+		foreach ( $upsert_plans as $plan ) {
+			$applied = self::upsert_post_from_markdown(
+				$plan['path'],
+				$plan['content'],
+				array( 'skip_modified_check' => $skip_modified_checks )
+			);
+			if ( $applied['post_id'] ) {
+				$changes[] = $applied['change'];
+			}
+		}
+
+		foreach ( $trash_plans as $plan ) {
+			$post      = get_post( $plan['post_id'] );
+			$changes[] = self::build_push_summary_item( 'trashed', $post, $plan['path'] );
+
+			if ( false === wp_trash_post( $plan['post_id'] ) ) {
 				throw new Exception( 'Push rejected because WordPress could not trash the deleted content.' );
 			}
 		}
@@ -1410,34 +1424,27 @@ SKILL;
 			return self::upsert_guideline_from_markdown( $path, $markdown, $options );
 		}
 		if ( self::is_raw_block_post_type( $post_type ) ) {
-			return self::upsert_raw_block_post_from_html( $path, $markdown );
+			return self::upsert_raw_block_post_from_html( $path, $markdown, $options );
 		}
 		if ( 'wp_global_styles' === $post_type ) {
-			return self::upsert_global_styles_from_json( $path, $markdown );
+			return self::upsert_global_styles_from_json( $path, $markdown, $options );
 		}
 
+		self::assert_markdown_front_matter_is_closed( $markdown );
 		$consumer = new MarkdownConsumer( $markdown );
 		$result   = $consumer->consume();
+		self::assert_block_markup_is_safe( $result->get_block_markup() );
 		$metadata = array();
 		foreach ( $result->get_all_metadata() as $key => $value ) {
 			$metadata[ $key ] = is_array( $value ) ? reset( $value ) : $value;
 		}
 
-		if ( isset( $metadata['type'] ) && $metadata['type'] !== $post_type ) {
-			throw new Exception( 'Push rejected because the file post type does not match its directory.' );
-		}
-		if ( isset( $metadata['slug'] ) && $metadata['slug'] !== $slug ) {
-			throw new Exception( 'Push rejected because the file slug does not match its filename.' );
-		}
-		$post_id = isset( $metadata['id'] ) ? intval( $metadata['id'] ) : 0;
-		if ( $post_id && get_post( $post_id ) ) {
-			$existing_post = get_post( $post_id );
-		} else {
-			$post_id       = self::find_post_id_by_path_metadata( $path, $metadata );
-			$existing_post = $post_id ? get_post( $post_id ) : null;
-		}
-		$post_status = self::normalize_frontmatter_status(
-			isset( $metadata['status'] ) ? $metadata['status'] : ( $existing_post ? $existing_post->post_status : 'draft' )
+		self::reject_identity_frontmatter( $metadata );
+		$post_id        = self::find_post_id_by_path_metadata( $path, $metadata );
+		$existing_post  = $post_id ? get_post( $post_id ) : null;
+		$default_status = $existing_post && 'trash' !== $existing_post->post_status ? $existing_post->post_status : 'draft';
+		$post_status    = self::normalize_frontmatter_status(
+			isset( $metadata['status'] ) ? $metadata['status'] : $default_status
 		);
 		self::validate_post_status( $post_status, $post_type );
 		self::assert_can_set_post_status( $post_type, $post_status, $existing_post );
@@ -1459,7 +1466,7 @@ SKILL;
 
 		$postarr = array(
 			'post_type'    => $post_type,
-			'post_name'    => isset( $metadata['slug'] ) ? $metadata['slug'] : $slug,
+			'post_name'    => $slug,
 			'post_title'   => isset( $metadata['title'] ) ? $metadata['title'] : ucwords( str_replace( '-', ' ', $slug ) ),
 			'post_status'  => $post_status,
 			'post_content' => $result->get_block_markup(),
@@ -1474,7 +1481,16 @@ SKILL;
 			$postarr['post_excerpt'] = $metadata['description'];
 		}
 
+		$change_action = $existing_post && 'trash' === $existing_post->post_status ? 'restored' : ( $existing_post ? 'updated' : 'created' );
+		if ( ! empty( $options['dry_run'] ) ) {
+			return array(
+				'post_id' => $existing_post ? intval( $existing_post->ID ) : 0,
+				'change'  => null,
+			);
+		}
+
 		if ( $existing_post ) {
+			$existing_post = self::restore_trashed_post_before_update( $existing_post );
 			$postarr['ID'] = $existing_post->ID;
 			$post_id       = wp_update_post( wp_slash( $postarr ), true );
 		} else {
@@ -1490,15 +1506,16 @@ SKILL;
 		return array(
 			'post_id' => $post_id,
 			'change'  => self::build_push_summary_item(
-				$existing_post ? 'updated' : 'created',
+				$change_action,
 				$post,
 				$path
 			),
 		);
 	}
 
-	private static function upsert_raw_block_post_from_html( $path, $html ) {
+	private static function upsert_raw_block_post_from_html( $path, $html, $options = array() ) {
 		self::assert_raw_block_html_has_no_front_matter( $html );
+		self::assert_block_markup_is_safe( $html );
 
 		$identity      = self::path_to_raw_block_identity( $path );
 		$post_type     = $identity['post_type'];
@@ -1512,7 +1529,6 @@ SKILL;
 				'ID'           => $existing_post->ID,
 				'post_content' => $html,
 			);
-			$post_id = wp_update_post( wp_slash( $postarr ), true );
 		} else {
 			self::assert_can_create_post_type( $post_type );
 			self::assert_can_set_post_status( $post_type, 'publish' );
@@ -1523,6 +1539,18 @@ SKILL;
 				'post_status'  => 'publish',
 				'post_content' => $html,
 			);
+		}
+
+		if ( ! empty( $options['dry_run'] ) ) {
+			return array(
+				'post_id' => $existing_post ? intval( $existing_post->ID ) : 0,
+				'change'  => null,
+			);
+		}
+
+		if ( $existing_post ) {
+			$post_id = wp_update_post( wp_slash( $postarr ), true );
+		} else {
 			$post_id = wp_insert_post( wp_slash( $postarr ), true );
 		}
 
@@ -1544,7 +1572,7 @@ SKILL;
 		);
 	}
 
-	private static function upsert_global_styles_from_json( $path, $json ) {
+	private static function upsert_global_styles_from_json( $path, $json, $options = array() ) {
 		$config        = self::parse_global_styles_json( $path, $json );
 		$theme_slug    = self::path_to_global_styles_theme_slug( $path );
 		$post_id       = self::find_global_styles_post_id_by_theme_slug( $theme_slug, false );
@@ -1566,7 +1594,6 @@ SKILL;
 				'ID'           => $existing_post->ID,
 				'post_content' => $post_content,
 			);
-			$post_id = wp_update_post( wp_slash( $postarr ), true );
 		} else {
 			self::assert_can_create_post_type( 'wp_global_styles' );
 			self::assert_can_set_post_status( 'wp_global_styles', 'publish' );
@@ -1577,6 +1604,18 @@ SKILL;
 				'post_status'  => 'publish',
 				'post_content' => $post_content,
 			);
+		}
+
+		if ( ! empty( $options['dry_run'] ) ) {
+			return array(
+				'post_id' => $existing_post ? intval( $existing_post->ID ) : 0,
+				'change'  => null,
+			);
+		}
+
+		if ( $existing_post ) {
+			$post_id = wp_update_post( wp_slash( $postarr ), true );
+		} else {
 			$post_id = wp_insert_post( wp_slash( $postarr ), true );
 		}
 
@@ -1629,6 +1668,95 @@ SKILL;
 		}
 	}
 
+	private static function assert_markdown_front_matter_is_closed( $markdown ) {
+		if (
+			preg_match( '/\A---\r?\n/', $markdown ) &&
+			! preg_match( '/\A---\r?\n.*?\r?\n---(?:\r?\n|\z)/s', $markdown )
+		) {
+			throw new Exception( 'Push rejected because Markdown front matter is missing its closing --- fence.' );
+		}
+	}
+
+	private static function assert_block_markup_is_safe( $block_markup ) {
+		if (
+			false === strpos( $block_markup, '<!-- wp:' ) &&
+			false === strpos( $block_markup, '<!-- /wp:' )
+		) {
+			return;
+		}
+
+		self::assert_block_delimiters_are_well_formed( $block_markup );
+		self::assert_parsed_blocks_are_safe( parse_blocks( $block_markup ) );
+	}
+
+	private static function assert_block_delimiters_are_well_formed( $block_markup ) {
+		if ( ! preg_match_all( '/<!--\s*\/?wp:.*?-->/s', $block_markup, $matches ) ) {
+			throw new Exception( 'Push rejected because the content contains malformed Gutenberg block markup.' );
+		}
+
+		$stack = array();
+		foreach ( $matches[0] as $token ) {
+			if (
+				! preg_match(
+					'/\A<!--\s+(?P<closer>\/)?wp:(?P<namespace>[a-z][a-z0-9_-]*\/)?(?P<name>[a-z][a-z0-9_-]*)(?P<attrs>\s+\{.*\})?\s+(?P<void>\/)?-->\z/s',
+					$token,
+					$token_match
+				)
+			) {
+				throw new Exception( 'Push rejected because the content contains malformed Gutenberg block markup.' );
+			}
+
+			$is_closer = isset( $token_match['closer'] ) && '' !== $token_match['closer'];
+			$is_void   = isset( $token_match['void'] ) && '' !== $token_match['void'];
+			$namespace = isset( $token_match['namespace'] ) && '' !== $token_match['namespace'] ? $token_match['namespace'] : 'core/';
+			$name      = $namespace . $token_match['name'];
+
+			if ( isset( $token_match['attrs'] ) && '' !== $token_match['attrs'] ) {
+				json_decode( trim( $token_match['attrs'] ), true );
+				if ( JSON_ERROR_NONE !== json_last_error() ) {
+					throw new Exception( 'Push rejected because the content contains malformed Gutenberg block attributes.' );
+				}
+			}
+
+			if ( $is_closer ) {
+				if ( $is_void || ( isset( $token_match['attrs'] ) && '' !== $token_match['attrs'] ) ) {
+					throw new Exception( 'Push rejected because the content contains malformed Gutenberg block markup.' );
+				}
+				if ( empty( $stack ) || array_pop( $stack ) !== $name ) {
+					throw new Exception( 'Push rejected because the content contains mismatched Gutenberg block delimiters.' );
+				}
+			} elseif ( ! $is_void ) {
+				$stack[] = $name;
+			}
+		}
+
+		if ( ! empty( $stack ) ) {
+			throw new Exception( 'Push rejected because the content contains unclosed Gutenberg block delimiters.' );
+		}
+	}
+
+	private static function assert_parsed_blocks_are_safe( $blocks ) {
+		foreach ( $blocks as $block ) {
+			$block_name   = isset( $block['blockName'] ) ? $block['blockName'] : null;
+			$attrs        = array_key_exists( 'attrs', $block ) ? $block['attrs'] : array();
+			$inner_html   = isset( $block['innerHTML'] ) ? $block['innerHTML'] : '';
+			$inner_blocks = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? $block['innerBlocks'] : array();
+
+			if ( null === $block_name && self::contains_block_delimiter( $inner_html ) ) {
+				throw new Exception( 'Push rejected because the content contains malformed Gutenberg block markup.' );
+			}
+			if ( null !== $block_name && ! is_array( $attrs ) ) {
+				throw new Exception( 'Push rejected because the content contains malformed Gutenberg block attributes.' );
+			}
+
+			self::assert_parsed_blocks_are_safe( $inner_blocks );
+		}
+	}
+
+	private static function contains_block_delimiter( $html ) {
+		return false !== strpos( $html, '<!-- wp:' ) || false !== strpos( $html, '<!-- /wp:' );
+	}
+
 	private static function is_array_list( $items ) {
 		$index = 0;
 		foreach ( $items as $key => $value ) {
@@ -1654,21 +1782,21 @@ SKILL;
 			$skill_document = self::split_guideline_skill_markdown( $markdown );
 			$metadata       = $skill_document['metadata'];
 			$markdown       = $skill_document['content'];
+			self::assert_block_markup_is_safe( $markdown );
+			self::reject_identity_frontmatter( $metadata );
 			if ( isset( $metadata['name'] ) && $metadata['name'] !== $slug ) {
 				throw new Exception( 'Push rejected because the skill name front matter does not match its directory.' );
 			}
-		}
-
-		$post_id = isset( $metadata['id'] ) ? intval( $metadata['id'] ) : 0;
-		if ( $post_id && get_post( $post_id ) ) {
-			$existing_post = get_post( $post_id );
 		} else {
-			$post_id       = self::find_post_id_by_path_metadata( $path, $metadata );
-			$existing_post = $post_id ? get_post( $post_id ) : null;
+			self::assert_block_markup_is_safe( $markdown );
 		}
 
-		$post_status = self::normalize_frontmatter_status(
-			isset( $metadata['status'] ) ? $metadata['status'] : ( $existing_post ? $existing_post->post_status : 'draft' )
+		$post_id       = self::find_post_id_by_path_metadata( $path, $metadata );
+		$existing_post = $post_id ? get_post( $post_id ) : null;
+
+		$default_status = $existing_post && 'trash' !== $existing_post->post_status ? $existing_post->post_status : 'draft';
+		$post_status    = self::normalize_frontmatter_status(
+			isset( $metadata['status'] ) ? $metadata['status'] : $default_status
 		);
 		self::validate_post_status( $post_status, 'wp_guideline' );
 		self::assert_can_set_post_status( 'wp_guideline', $post_status, $existing_post );
@@ -1700,7 +1828,16 @@ SKILL;
 			$postarr['post_excerpt'] = $metadata['description'];
 		}
 
+		$change_action = $existing_post && 'trash' === $existing_post->post_status ? 'restored' : ( $existing_post ? 'updated' : 'created' );
+		if ( ! empty( $options['dry_run'] ) ) {
+			return array(
+				'post_id' => $existing_post ? intval( $existing_post->ID ) : 0,
+				'change'  => null,
+			);
+		}
+
 		if ( $existing_post ) {
+			$existing_post = self::restore_trashed_post_before_update( $existing_post );
 			$postarr['ID'] = $existing_post->ID;
 			$post_id       = wp_update_post( wp_slash( $postarr ), true );
 		} else {
@@ -1722,7 +1859,7 @@ SKILL;
 		return array(
 			'post_id' => $post_id,
 			'change'  => self::build_push_summary_item(
-				$existing_post ? 'updated' : 'created',
+				$change_action,
 				$post,
 				$path
 			),
@@ -1858,6 +1995,35 @@ SKILL;
 		return isset( $statuses[ $key ] ) ? $statuses[ $key ] : $post_status;
 	}
 
+	private static function reject_identity_frontmatter( $metadata ) {
+		if ( isset( $metadata['id'] ) ) {
+			throw new Exception( 'Push rejected because Markdown front matter must not include an id. The file path is the content identity.' );
+		}
+		if ( isset( $metadata['slug'] ) ) {
+			throw new Exception( 'Push rejected because Markdown front matter must not include a slug. Rename the file path only when creating distinct content.' );
+		}
+		if ( isset( $metadata['type'] ) ) {
+			throw new Exception( 'Push rejected because Markdown front matter must not include a type. The directory determines the post type.' );
+		}
+	}
+
+	private static function restore_trashed_post_before_update( WP_Post $post ) {
+		if ( 'trash' !== $post->post_status ) {
+			return $post;
+		}
+
+		if ( false === wp_untrash_post( $post->ID ) ) {
+			throw new Exception( 'Push rejected because WordPress could not restore the trashed content for this path.' );
+		}
+
+		$restored = get_post( $post->ID );
+		if ( ! $restored ) {
+			throw new Exception( 'Push rejected because WordPress could not reload the restored content.' );
+		}
+
+		return $restored;
+	}
+
 	private static function find_post_id_by_path_metadata( $path, $metadata, $include_trash = true ) {
 		$post_type = self::path_to_post_type( $path );
 		if ( self::is_raw_block_post_type( $post_type ) ) {
@@ -1870,7 +2036,9 @@ SKILL;
 			);
 		}
 
-		$slug     = isset( $metadata['slug'] ) ? $metadata['slug'] : self::path_to_slug( $path );
+		unset( $metadata );
+
+		$slug     = self::path_to_slug( $path );
 		$statuses = $include_trash
 			? array_merge( self::$supported_post_statuses, array( 'trash' ) )
 			: self::$supported_post_statuses;
@@ -1885,7 +2053,22 @@ SKILL;
 		);
 
 		if ( empty( $posts ) ) {
-			return 0;
+			if ( ! $include_trash ) {
+				return 0;
+			}
+
+			$posts = get_posts(
+				array(
+					'post_type'      => $post_type,
+					'name'           => $slug . '__trashed',
+					'post_status'    => array( 'trash' ),
+					'posts_per_page' => 1,
+					'fields'         => 'ids',
+				)
+			);
+			if ( empty( $posts ) ) {
+				return 0;
+			}
 		}
 
 		return intval( $posts[0] );
@@ -2113,6 +2296,7 @@ SKILL;
 		$metadata = array();
 		$content  = $markdown;
 
+		self::assert_markdown_front_matter_is_closed( $markdown );
 		if ( preg_match( '/\A---\r?\n.*?\r?\n---(?:\r?\n|\z)/s', $markdown, $matches ) ) {
 			$metadata = self::parse_markdown_metadata( $markdown );
 			$content  = substr( $markdown, strlen( $matches[0] ) );

--- a/plugins/wp-origin/class-wp-origin-plugin.php
+++ b/plugins/wp-origin/class-wp-origin-plugin.php
@@ -136,7 +136,7 @@ This repository is a Git checkout of a WordPress site exposed by WP Origin. Word
 ## Repository Layout
 
 - `post/{slug}.md` contains WordPress posts.
-- `page/{slug}.md` contains WordPress pages.
+- `page/{slug}.md` and `page/{parent}/{slug}.md` contain WordPress pages.
 - `wp_template/{slug}.html`, `wp_template_part/{slug}.html`, and `wp_navigation/{slug}.html` contain raw Gutenberg block markup for structural site entities. Theme-qualified WordPress slugs may appear as nested paths such as `wp_template_part/{theme}/header.html`.
 - `wp_theme/{theme}/theme.json` contains read-only theme-provided design settings for agent context.
 - `wp_global_styles/{theme}.json` contains the editable Global Styles overlay for the active theme. Edit this file for site-wide styles and settings instead of editing `wp_theme/{theme}/theme.json`.
@@ -313,11 +313,23 @@ SKILL;
 				return $response->to_rest_response();
 			}
 
-			$repository = self::open_repository();
-			self::sync_repository_from_wordpress( $repository );
-
 			$git_path     = self::build_git_path( $request );
 			$request_body = file_get_contents( 'php://input' );
+			$repository   = self::open_repository();
+			try {
+				self::sync_repository_from_wordpress( $repository );
+			} catch ( Throwable $exception ) {
+				$service = self::git_service_from_request( $git_path, $request );
+				if ( $service ) {
+					return self::build_protocol_error_response(
+						$service,
+						self::get_throwable_message( $exception )
+					);
+				}
+
+				throw $exception;
+			}
+
 			$current_head = $repository->get_branch_tip( 'refs/heads/' . self::DEFAULT_BRANCH );
 
 			$push_header = null;
@@ -327,6 +339,12 @@ SKILL;
 					return self::build_protocol_error_response(
 						'git-receive-pack',
 						'Invalid push request.'
+					);
+				}
+				if ( isset( $push_header['error'] ) ) {
+					return self::build_protocol_error_response(
+						'git-receive-pack',
+						$push_header['error']
 					);
 				}
 
@@ -444,6 +462,15 @@ SKILL;
 		}
 
 		return $path;
+	}
+
+	private static function git_service_from_request( $git_path, WP_REST_Request $request ) {
+		unset( $request );
+		if ( '/git-upload-pack' === $git_path || '/git-receive-pack' === $git_path ) {
+			return ltrim( $git_path, '/' );
+		}
+
+		return '';
 	}
 
 	private static function is_push_request( $git_path ) {
@@ -659,7 +686,11 @@ SKILL;
 				throw new Exception( 'Git export rejected because you do not have permission to read all WP Origin content.' );
 			}
 
-			$path    = self::build_markdown_path( $post );
+			$path = self::build_markdown_path( $post );
+			if ( isset( $files[ $path ] ) ) {
+				throw new Exception( 'Git export rejected because multiple WordPress entities map to the same WP Origin path: ' . esc_html( $path ) );
+			}
+
 			$content = self::export_post_to_markdown( $post );
 
 			$files[ $path ] = array(
@@ -932,6 +963,9 @@ SKILL;
 					self::get_post_theme_slug( $post_or_type )
 				);
 			}
+			if ( 'page' === $post_or_type->post_type ) {
+				return self::build_page_markdown_path( $post_or_type );
+			}
 
 			return ltrim( $post_or_type->post_type . '/' . $post_or_type->post_name . '.md', '/' );
 		}
@@ -944,6 +978,32 @@ SKILL;
 		}
 
 		return ltrim( $post_or_type . '/' . $slug . '.md', '/' );
+	}
+
+	private static function build_page_markdown_path( WP_Post $post ) {
+		$segments  = array( $post->post_name );
+		$seen      = array( intval( $post->ID ) => true );
+		$parent_id = intval( $post->post_parent );
+
+		while ( $parent_id > 0 ) {
+			if ( ! empty( $seen[ $parent_id ] ) ) {
+				throw new Exception( 'Git export rejected because a WordPress page hierarchy contains a cycle.' );
+			}
+
+			$parent = get_post( $parent_id );
+			if ( ! $parent || 'page' !== $parent->post_type ) {
+				throw new Exception( 'Git export rejected because a WordPress page has an invalid parent.' );
+			}
+			if ( ! in_array( $parent->post_status, self::$supported_post_statuses, true ) ) {
+				throw new Exception( 'Git export rejected because a WordPress page has a non-exported parent page. Restore, publish, or reparent the child page before cloning.' );
+			}
+
+			array_unshift( $segments, $parent->post_name );
+			$seen[ $parent_id ] = true;
+			$parent_id          = intval( $parent->post_parent );
+		}
+
+		return 'page/' . implode( '/', $segments ) . '.md';
 	}
 
 	private static function build_raw_block_path( $post_type, $slug, $theme_slug = '' ) {
@@ -1217,9 +1277,12 @@ SKILL;
 			: self::read_repository_entries_from_commit( $repository, $parent_hash );
 		$new_files   = self::read_repository_entries_from_commit( $repository, $commit_hash );
 
+		self::reject_symlink_file_changes( $old_files, $new_files );
+		self::reject_executable_file_changes( $old_files, $new_files );
 		self::reject_deleted_raw_block_files( $old_files, $new_files );
 		self::reject_deleted_theme_base_files( $old_files, $new_files );
 		self::reject_deleted_global_styles_files( $old_files, $new_files );
+		self::reject_deleted_page_parent_files_with_remaining_children( $old_files, $new_files );
 
 		foreach ( $new_files as $path => $entry ) {
 			if ( isset( $old_files[ $path ] ) && self::repository_entries_match( $old_files[ $path ], $entry ) ) {
@@ -1233,6 +1296,7 @@ SKILL;
 			}
 			if ( self::is_raw_block_path( $path ) ) {
 				self::assert_raw_block_html_has_no_front_matter( $entry['content'] );
+				self::assert_raw_block_html_has_block_markup( $entry['content'] );
 			}
 			if ( self::is_global_styles_path( $path ) ) {
 				self::assert_global_styles_json_is_valid( $path, $entry['content'] );
@@ -1250,9 +1314,12 @@ SKILL;
 		$changes          = array();
 		$upsert_plans     = array();
 		$trash_plans      = array();
+		self::reject_symlink_file_changes( $old_files, $new_files );
+		self::reject_executable_file_changes( $old_files, $new_files );
 		self::reject_deleted_raw_block_files( $old_files, $new_files );
 		self::reject_deleted_theme_base_files( $old_files, $new_files );
 		self::reject_deleted_global_styles_files( $old_files, $new_files );
+		self::reject_deleted_page_parent_files_with_remaining_children( $old_files, $new_files );
 
 		foreach ( $new_files as $path => $entry ) {
 			if ( isset( $old_files[ $path ] ) && self::repository_entries_match( $old_files[ $path ], $entry ) ) {
@@ -1417,7 +1484,78 @@ SKILL;
 		}
 	}
 
+	private static function reject_deleted_page_parent_files_with_remaining_children( $old_files, $new_files ) {
+		foreach ( $old_files as $path => $entry ) {
+			if ( isset( $new_files[ $path ] ) ) {
+				continue;
+			}
+			if ( TreeEntry::FILE_MODE_SYMBOLIC_LINK === $entry['mode'] || ! self::is_page_markdown_path( $path ) ) {
+				continue;
+			}
+
+			$descendant_prefix = self::page_descendant_prefix_from_path( $path );
+			if ( '' === $descendant_prefix ) {
+				continue;
+			}
+
+			foreach ( $new_files as $new_path => $new_entry ) {
+				unset( $new_entry );
+				if ( 0 === strpos( $new_path, $descendant_prefix ) ) {
+					throw new Exception( 'Push rejected because deleting a parent page while keeping nested child page files would move child content. Delete the nested child page files too, or keep the parent page.' );
+				}
+			}
+		}
+	}
+
+	private static function is_page_markdown_path( $path ) {
+		$segments = explode( '/', ltrim( $path, '/' ) );
+		return isset( $segments[0] )
+			&& 'page' === $segments[0]
+			&& 'md' === pathinfo( basename( $path ), PATHINFO_EXTENSION );
+	}
+
+	private static function page_descendant_prefix_from_path( $path ) {
+		$relative_path = substr( ltrim( $path, '/' ), strlen( 'page/' ) );
+		if ( '.md' !== substr( $relative_path, - strlen( '.md' ) ) ) {
+			return '';
+		}
+
+		return 'page/' . substr( $relative_path, 0, - strlen( '.md' ) ) . '/';
+	}
+
+	private static function reject_symlink_file_changes( $old_files, $new_files ) {
+		foreach ( $new_files as $path => $entry ) {
+			if ( TreeEntry::FILE_MODE_SYMBOLIC_LINK !== $entry['mode'] ) {
+				continue;
+			}
+			if ( ! isset( $old_files[ $path ] ) || ! self::repository_entries_match( $old_files[ $path ], $entry ) ) {
+				throw new Exception( 'Push rejected because symlink files are generated by WP Origin and cannot be created or modified.' );
+			}
+		}
+
+		foreach ( $old_files as $path => $entry ) {
+			if ( TreeEntry::FILE_MODE_SYMBOLIC_LINK !== $entry['mode'] ) {
+				continue;
+			}
+			if ( ! isset( $new_files[ $path ] ) || ! self::repository_entries_match( $entry, $new_files[ $path ] ) ) {
+				throw new Exception( 'Push rejected because symlink files are generated by WP Origin and cannot be deleted or modified.' );
+			}
+		}
+	}
+
+	private static function reject_executable_file_changes( $old_files, $new_files ) {
+		foreach ( $new_files as $path => $entry ) {
+			if ( TreeEntry::FILE_MODE_REGULAR_EXECUTABLE !== $entry['mode'] ) {
+				continue;
+			}
+			if ( ! isset( $old_files[ $path ] ) || ! self::repository_entries_match( $old_files[ $path ], $entry ) ) {
+				throw new Exception( 'Push rejected because executable file modes are not supported by WP Origin content exports.' );
+			}
+		}
+	}
+
 	private static function upsert_post_from_markdown( $path, $markdown, $options = array() ) {
+		self::assert_content_has_no_nul_bytes( $markdown );
 		$post_type = self::path_to_post_type( $path );
 		$slug      = self::path_to_slug( $path );
 		if ( 'wp_guideline' === $post_type ) {
@@ -1440,6 +1578,10 @@ SKILL;
 		}
 
 		self::reject_identity_frontmatter( $metadata );
+		$metadata       = self::normalize_supported_frontmatter(
+			$metadata,
+			array( 'title', 'date', 'status', 'description' )
+		);
 		$post_id        = self::find_post_id_by_path_metadata( $path, $metadata );
 		$existing_post  = $post_id ? get_post( $post_id ) : null;
 		$default_status = $existing_post && 'trash' !== $existing_post->post_status ? $existing_post->post_status : 'draft';
@@ -1448,6 +1590,7 @@ SKILL;
 		);
 		self::validate_post_status( $post_status, $post_type );
 		self::assert_can_set_post_status( $post_type, $post_status, $existing_post );
+		$post_parent = 'page' === $post_type ? self::path_to_page_parent_id( $path, false ) : 0;
 
 		if (
 			$existing_post &&
@@ -1471,8 +1614,12 @@ SKILL;
 			'post_status'  => $post_status,
 			'post_content' => $result->get_block_markup(),
 		);
+		if ( 'page' === $post_type ) {
+			$postarr['post_parent'] = $post_parent;
+		}
 
 		$post_date_gmt = self::frontmatter_date_to_mysql_gmt( $metadata );
+		self::assert_frontmatter_date_matches_status( $post_status, $post_date_gmt );
 		if ( '' !== $post_date_gmt ) {
 			$postarr['post_date_gmt'] = $post_date_gmt;
 			$postarr['post_date']     = get_date_from_gmt( $post_date_gmt );
@@ -1514,7 +1661,9 @@ SKILL;
 	}
 
 	private static function upsert_raw_block_post_from_html( $path, $html, $options = array() ) {
+		self::assert_content_has_no_nul_bytes( $html );
 		self::assert_raw_block_html_has_no_front_matter( $html );
+		self::assert_raw_block_html_has_block_markup( $html );
 		self::assert_block_markup_is_safe( $html );
 
 		$identity      = self::path_to_raw_block_identity( $path );
@@ -1573,6 +1722,7 @@ SKILL;
 	}
 
 	private static function upsert_global_styles_from_json( $path, $json, $options = array() ) {
+		self::assert_content_has_no_nul_bytes( $json );
 		$config        = self::parse_global_styles_json( $path, $json );
 		$theme_slug    = self::path_to_global_styles_theme_slug( $path );
 		$post_id       = self::find_global_styles_post_id_by_theme_slug( $theme_slug, false );
@@ -1668,6 +1818,18 @@ SKILL;
 		}
 	}
 
+	private static function assert_content_has_no_nul_bytes( $content ) {
+		if ( false !== strpos( $content, "\0" ) ) {
+			throw new Exception( 'Push rejected because content files must not contain NUL bytes.' );
+		}
+	}
+
+	private static function assert_raw_block_html_has_block_markup( $html ) {
+		if ( false === strpos( $html, '<!-- wp:' ) ) {
+			throw new Exception( 'Push rejected because template HTML files must contain serialized Gutenberg block markup.' );
+		}
+	}
+
 	private static function assert_markdown_front_matter_is_closed( $markdown ) {
 		if (
 			preg_match( '/\A---\r?\n/', $markdown ) &&
@@ -1745,6 +1907,9 @@ SKILL;
 			if ( null === $block_name && self::contains_block_delimiter( $inner_html ) ) {
 				throw new Exception( 'Push rejected because the content contains malformed Gutenberg block markup.' );
 			}
+			if ( 'core/html' === $block_name && ( ! empty( $inner_blocks ) || self::contains_block_delimiter( $inner_html ) ) ) {
+				throw new Exception( 'Push rejected because Markdown content must not embed raw Gutenberg block delimiters inside HTML blocks.' );
+			}
 			if ( null !== $block_name && ! is_array( $attrs ) ) {
 				throw new Exception( 'Push rejected because the content contains malformed Gutenberg block attributes.' );
 			}
@@ -1784,6 +1949,10 @@ SKILL;
 			$markdown       = $skill_document['content'];
 			self::assert_block_markup_is_safe( $markdown );
 			self::reject_identity_frontmatter( $metadata );
+			$metadata = self::normalize_supported_frontmatter(
+				$metadata,
+				array( 'name', 'description' )
+			);
 			if ( isset( $metadata['name'] ) && $metadata['name'] !== $slug ) {
 				throw new Exception( 'Push rejected because the skill name front matter does not match its directory.' );
 			}
@@ -1939,12 +2108,20 @@ SKILL;
 
 	private static function frontmatter_date_to_mysql_gmt( $metadata ) {
 		if ( isset( $metadata['date'] ) && '' !== trim( (string) $metadata['date'] ) ) {
-			return self::parse_frontmatter_date( $metadata['date'] );
+			$parsed = self::parse_frontmatter_date( $metadata['date'] );
+			if ( '' === $parsed ) {
+				throw new Exception( 'Push rejected because Markdown front matter date is invalid.' );
+			}
+
+			return $parsed;
 		}
 		if ( isset( $metadata['date_gmt'] ) && '' !== trim( (string) $metadata['date_gmt'] ) ) {
-			$timestamp = self::timestamp_from_gmt_string( $metadata['date_gmt'] );
+			$parsed = self::parse_frontmatter_date( $metadata['date_gmt'] );
+			if ( '' === $parsed ) {
+				throw new Exception( 'Push rejected because Markdown front matter date_gmt is invalid.' );
+			}
 
-			return false === $timestamp ? '' : gmdate( 'Y-m-d H:i:s', $timestamp );
+			return $parsed;
 		}
 
 		return '';
@@ -1957,14 +2134,57 @@ SKILL;
 		}
 
 		if ( preg_match( '/^\d{4}-\d{2}-\d{2}$/', $date ) ) {
-			$timestamp = strtotime( $date . ' 00:00:00 UTC' );
-		} elseif ( preg_match( '/^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}$/', $date ) ) {
-			$timestamp = strtotime( $date . ' UTC' );
-		} else {
-			$timestamp = strtotime( $date );
+			return self::parse_frontmatter_date_format( $date . ' 00:00:00', 'Y-m-d H:i:s', $date . ' 00:00:00' );
 		}
 
-		return false === $timestamp ? '' : gmdate( 'Y-m-d H:i:s', $timestamp );
+		if ( preg_match( '/^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}Z$/', $date ) ) {
+			$normalized = str_replace( 'T', ' ', substr( $date, 0, -1 ) );
+
+			return self::parse_frontmatter_date_format( $normalized, 'Y-m-d H:i:s', $normalized );
+		}
+
+		if ( preg_match( '/^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}$/', $date ) ) {
+			$normalized = str_replace( 'T', ' ', $date );
+
+			return self::parse_frontmatter_date_format( $normalized, 'Y-m-d H:i:s', $normalized );
+		}
+
+		return '';
+	}
+
+	private static function parse_frontmatter_date_format( $date, $format, $expected ) {
+		$timezone = new DateTimeZone( 'UTC' );
+		$datetime = DateTime::createFromFormat( '!' . $format, $date, $timezone );
+		$errors   = DateTime::getLastErrors();
+		if (
+			false === $datetime ||
+			(
+				is_array( $errors ) &&
+				( 0 !== $errors['warning_count'] || 0 !== $errors['error_count'] )
+			) ||
+			$datetime->format( $format ) !== $expected
+		) {
+			return '';
+		}
+
+		return $datetime->format( 'Y-m-d H:i:s' );
+	}
+
+	private static function assert_frontmatter_date_matches_status( $post_status, $post_date_gmt ) {
+		if ( '' === $post_date_gmt ) {
+			if ( 'future' === $post_status ) {
+				throw new Exception( 'Push rejected because scheduled posts must include a future date.' );
+			}
+			return;
+		}
+
+		$timestamp = self::timestamp_from_gmt_string( $post_date_gmt );
+		if ( 'future' === $post_status && ( false === $timestamp || $timestamp <= time() ) ) {
+			throw new Exception( 'Push rejected because scheduled posts must include a date in the future.' );
+		}
+		if ( 'publish' === $post_status && false !== $timestamp && $timestamp > time() ) {
+			throw new Exception( 'Push rejected because published posts must not include a future date. Use scheduled status for future-dated content.' );
+		}
 	}
 
 	private static function frontmatter_status_from_post_status( $post_status ) {
@@ -2007,6 +2227,38 @@ SKILL;
 		}
 	}
 
+	private static function normalize_supported_frontmatter( $metadata, $allowed_keys ) {
+		$allowed = array();
+		foreach ( $allowed_keys as $key ) {
+			$allowed[ $key ] = true;
+		}
+
+		$normalized = array();
+		foreach ( $metadata as $key => $value ) {
+			$key = (string) $key;
+			if ( ! isset( $allowed[ $key ] ) ) {
+				throw new Exception(
+					sprintf(
+						'Push rejected because Markdown front matter field "%s" is not supported.',
+						esc_html( $key )
+					)
+				);
+			}
+			if ( ! is_scalar( $value ) || is_bool( $value ) ) {
+				throw new Exception(
+					sprintf(
+						'Push rejected because Markdown front matter field "%s" must be a scalar string or number.',
+						esc_html( $key )
+					)
+				);
+			}
+
+			$normalized[ $key ] = (string) $value;
+		}
+
+		return $normalized;
+	}
+
 	private static function restore_trashed_post_before_update( WP_Post $post ) {
 		if ( 'trash' !== $post->post_status ) {
 			return $post;
@@ -2035,6 +2287,9 @@ SKILL;
 				$include_trash
 			);
 		}
+		if ( 'page' === $post_type ) {
+			return self::find_page_id_by_path( $path, $include_trash );
+		}
 
 		unset( $metadata );
 
@@ -2054,6 +2309,7 @@ SKILL;
 
 		if ( empty( $posts ) ) {
 			if ( ! $include_trash ) {
+				self::reject_unsupported_status_slug_collision( $post_type, $slug, self::$supported_post_statuses );
 				return 0;
 			}
 
@@ -2067,11 +2323,126 @@ SKILL;
 				)
 			);
 			if ( empty( $posts ) ) {
+				self::reject_unsupported_status_slug_collision(
+					$post_type,
+					$slug,
+					array_merge( self::$supported_post_statuses, array( 'trash' ) )
+				);
 				return 0;
 			}
 		}
 
 		return intval( $posts[0] );
+	}
+
+	private static function find_page_id_by_path( $path, $include_trash = true ) {
+		$slugs     = self::path_to_page_slugs( $path );
+		$slug      = array_pop( $slugs );
+		$parent_id = self::resolve_page_parent_id( $slugs, $include_trash );
+		$statuses  = $include_trash
+			? array_merge( self::$supported_post_statuses, array( 'trash' ) )
+			: self::$supported_post_statuses;
+		$posts     = get_posts(
+			array(
+				'post_type'      => 'page',
+				'name'           => $slug,
+				'post_parent'    => $parent_id,
+				'post_status'    => $statuses,
+				'posts_per_page' => 1,
+				'fields'         => 'ids',
+			)
+		);
+
+		if ( empty( $posts ) ) {
+			if ( ! $include_trash ) {
+				self::reject_unsupported_status_slug_collision( 'page', $slug, self::$supported_post_statuses, $parent_id );
+				return 0;
+			}
+
+			$posts = get_posts(
+				array(
+					'post_type'      => 'page',
+					'name'           => $slug . '__trashed',
+					'post_parent'    => $parent_id,
+					'post_status'    => array( 'trash' ),
+					'posts_per_page' => 1,
+					'fields'         => 'ids',
+				)
+			);
+			if ( empty( $posts ) ) {
+				self::reject_unsupported_status_slug_collision(
+					'page',
+					$slug,
+					array_merge( self::$supported_post_statuses, array( 'trash' ) ),
+					$parent_id
+				);
+				return 0;
+			}
+		}
+
+		return intval( $posts[0] );
+	}
+
+	private static function resolve_page_parent_id( $parent_slugs, $include_trash = true ) {
+		$parent_id = 0;
+		$statuses  = $include_trash
+			? array_merge( self::$supported_post_statuses, array( 'trash' ) )
+			: self::$supported_post_statuses;
+
+		foreach ( $parent_slugs as $slug ) {
+			$parents = get_posts(
+				array(
+					'post_type'      => 'page',
+					'name'           => $slug,
+					'post_parent'    => $parent_id,
+					'post_status'    => $statuses,
+					'posts_per_page' => 1,
+					'fields'         => 'ids',
+				)
+			);
+			if ( empty( $parents ) ) {
+				throw new Exception( 'Push rejected because nested page paths must reference existing WordPress parent pages.' );
+			}
+
+			$parent_id = intval( $parents[0] );
+		}
+
+		return $parent_id;
+	}
+
+	private static function path_to_page_parent_id( $path, $include_trash = true ) {
+		$slugs = self::path_to_page_slugs( $path );
+		array_pop( $slugs );
+
+		return self::resolve_page_parent_id( $slugs, $include_trash );
+	}
+
+	private static function reject_unsupported_status_slug_collision( $post_type, $slug, $allowed_statuses, $post_parent = null ) {
+		$args = array(
+			'post_type'      => $post_type,
+			'name'           => $slug,
+			'post_status'    => self::get_all_post_status_names(),
+			'posts_per_page' => 1,
+		);
+		if ( null !== $post_parent ) {
+			$args['post_parent'] = $post_parent;
+		}
+
+		$posts = get_posts( $args );
+		if ( empty( $posts ) || in_array( $posts[0]->post_status, $allowed_statuses, true ) ) {
+			return;
+		}
+
+		throw new Exception( 'Push rejected because a non-exported WordPress post already uses this file path slug.' );
+	}
+
+	private static function get_all_post_status_names() {
+		$statuses = get_post_stati( array(), 'names' );
+		if ( is_array( $statuses ) && ! empty( $statuses ) ) {
+			return array_values( $statuses );
+		}
+
+		return array_merge( self::$supported_post_statuses, array( 'trash', 'auto-draft', 'inherit' ) );
 	}
 
 	private static function find_raw_block_post_id_by_path( $path, $include_trash = true ) {
@@ -2136,6 +2507,7 @@ SKILL;
 	private static function path_to_slug( $path ) {
 		if ( self::is_guideline_skill_path( $path ) ) {
 			$segments = explode( '/', ltrim( $path, '/' ) );
+			self::assert_markdown_slug_is_canonical( $segments[2] );
 			return $segments[2];
 		}
 		if ( self::is_raw_block_path( $path ) ) {
@@ -2150,12 +2522,51 @@ SKILL;
 			return self::path_to_global_styles_theme_slug( $path );
 		}
 
+		$segments = explode( '/', ltrim( $path, '/' ) );
+		if ( 'post' === $segments[0] && 2 !== count( $segments ) ) {
+			throw new Exception( 'Push rejected because post Markdown files must use post/<slug>.md paths.' );
+		}
+		if ( 'page' === $segments[0] ) {
+			$slugs = self::path_to_page_slugs( $path );
+
+			return end( $slugs );
+		}
+
 		$basename = basename( $path );
 		if ( 'md' !== pathinfo( $basename, PATHINFO_EXTENSION ) ) {
 			throw new Exception( 'Push rejected because only Markdown files are supported.' );
 		}
 
-		return pathinfo( $basename, PATHINFO_FILENAME );
+		$slug = pathinfo( $basename, PATHINFO_FILENAME );
+		self::assert_markdown_slug_is_canonical( $slug );
+
+		return $slug;
+	}
+
+	private static function path_to_page_slugs( $path ) {
+		$segments = explode( '/', ltrim( $path, '/' ) );
+		if ( count( $segments ) < 2 || 'page' !== $segments[0] ) {
+			throw new Exception( 'Push rejected because page Markdown files must use page/<slug>.md or page/<parent>/<slug>.md paths.' );
+		}
+
+		$basename = array_pop( $segments );
+		if ( 'md' !== pathinfo( $basename, PATHINFO_EXTENSION ) ) {
+			throw new Exception( 'Push rejected because only Markdown files are supported.' );
+		}
+
+		$slugs   = array_slice( $segments, 1 );
+		$slugs[] = pathinfo( $basename, PATHINFO_FILENAME );
+		foreach ( $slugs as $slug ) {
+			self::assert_markdown_slug_is_canonical( $slug );
+		}
+
+		return $slugs;
+	}
+
+	private static function assert_markdown_slug_is_canonical( $slug ) {
+		if ( '' === $slug || sanitize_title( $slug ) !== $slug ) {
+			throw new Exception( 'Push rejected because Markdown file slugs must already match WordPress slug formatting.' );
+		}
 	}
 
 	private static function path_to_raw_block_identity( $path ) {
@@ -2173,9 +2584,17 @@ SKILL;
 			$parts = explode( '/', $slug_path );
 			if ( count( $parts ) > 1 ) {
 				$theme_slug = array_shift( $parts );
-				$slug_path  = implode( '/', $parts );
+				self::assert_repository_slug_path_is_canonical(
+					$theme_slug,
+					'Push rejected because template theme path segments must already match WordPress slug formatting.'
+				);
+				$slug_path = implode( '/', $parts );
 			}
 		}
+		self::assert_repository_slug_path_is_canonical(
+			$slug_path,
+			'Push rejected because template file slugs must already match WordPress slug formatting.'
+		);
 
 		return array(
 			'post_type' => $post_type,
@@ -2197,11 +2616,21 @@ SKILL;
 		}
 
 		$theme_slug = pathinfo( $basename, PATHINFO_FILENAME );
-		if ( '' === $theme_slug || self::sanitize_repository_path_segment( $theme_slug ) !== $theme_slug ) {
-			throw new Exception( 'Push rejected because the Global Styles theme filename is not supported.' );
-		}
+		self::assert_repository_slug_path_is_canonical(
+			$theme_slug,
+			'Push rejected because the Global Styles theme filename must already match WordPress slug formatting.'
+		);
 
 		return $theme_slug;
+	}
+
+	private static function assert_repository_slug_path_is_canonical( $slug_path, $message ) {
+		$segments = explode( '/', $slug_path );
+		foreach ( $segments as $segment ) {
+			if ( '' === $segment || sanitize_title( $segment ) !== $segment ) {
+				throw new Exception( $message );
+			}
+		}
 	}
 
 	private static function assign_raw_block_theme_slug( $post_id, $theme_slug ) {
@@ -2398,14 +2827,75 @@ SKILL;
 	}
 
 	private static function parse_push_header( $request_bytes ) {
-		if ( ! preg_match( '/([0-9a-f]{40}) ([0-9a-f]{40}) refs\\/heads\\/' . self::DEFAULT_BRANCH . '/', $request_bytes, $matches ) ) {
+		$commands = self::parse_push_commands( $request_bytes );
+		if ( empty( $commands ) ) {
 			return false;
+		}
+		if ( 1 !== count( $commands ) ) {
+			return array(
+				'error' => 'Push rejected because WP Origin only accepts one ref update at a time.',
+			);
+		}
+
+		$command = $commands[0];
+		if ( 'refs/heads/' . self::DEFAULT_BRANCH !== $command['ref'] ) {
+			return array(
+				'error' => 'Push rejected because WP Origin only accepts pushes to trunk.',
+			);
+		}
+		if ( Commit::is_null_hash( $command['new_oid'] ) ) {
+			return array(
+				'error' => 'Push rejected because deleting trunk is not supported.',
+			);
 		}
 
 		return array(
-			'old_oid' => $matches[1],
-			'new_oid' => $matches[2],
+			'old_oid' => $command['old_oid'],
+			'new_oid' => $command['new_oid'],
 		);
+	}
+
+	private static function parse_push_commands( $request_bytes ) {
+		$commands = array();
+		$offset   = 0;
+		$length   = strlen( $request_bytes );
+
+		while ( $offset + 4 <= $length ) {
+			$line_length_hex = substr( $request_bytes, $offset, 4 );
+			if ( ! ctype_xdigit( $line_length_hex ) ) {
+				break;
+			}
+
+			$line_length = hexdec( $line_length_hex );
+			$offset     += 4;
+			if ( 0 === $line_length ) {
+				break;
+			}
+			if ( $line_length < 4 || $offset + $line_length - 4 > $length ) {
+				break;
+			}
+
+			$line    = substr( $request_bytes, $offset, $line_length - 4 );
+			$offset += $line_length - 4;
+			$line    = explode( "\0", $line, 2 );
+			$line    = rtrim( $line[0], "\r\n" );
+
+			if (
+				preg_match(
+					'/\A(?P<old_oid>[0-9a-f]{40}) (?P<new_oid>[0-9a-f]{40}) (?P<ref>\S+)\z/',
+					$line,
+					$matches
+				)
+			) {
+				$commands[] = array(
+					'old_oid' => $matches['old_oid'],
+					'new_oid' => $matches['new_oid'],
+					'ref'     => $matches['ref'],
+				);
+			}
+		}
+
+		return $commands;
 	}
 
 	private static function assert_can_edit_post( $post_id ) {

--- a/plugins/wp-origin/docs/prd.md
+++ b/plugins/wp-origin/docs/prd.md
@@ -1,541 +1,352 @@
 # PRD: WP Origin
 
-## 1. Product overview
+## 1. Product Overview
 
-### 1.1 Document title and version
+### 1.1 Document Title And Version
 
 - PRD: WP Origin
-- Version: 0.1
+- Version: 0.1 implementation refresh
+- Status: Pre-release
 
-### 1.2 Product summary
+### 1.2 Product Summary
 
-WP Origin makes WordPress content available as a Git remote where posts and pages are represented as Markdown files, and structural block entities can be represented as raw Gutenberg HTML files. A user or coding agent can run normal Git commands such as `clone`, `pull`, and `push`; WordPress remains the source of truth, and pushed files update WordPress content directly.
+WP Origin makes supported WordPress content available as a Git remote. Users and
+coding agents can run normal Git commands such as `clone`, `pull`, and `push`
+against `/wp-json/git/v1/md.git`, edit content locally, and push those changes
+back into WordPress.
 
-The MVP is a standalone WordPress plugin. It focuses on a happy path that proves the workflow works for posts and pages, while keeping the design open for media, block theme entities, custom post types, templates, navigation, and WordPress.com integration later.
+WordPress remains the source of truth. The plugin stores the Git object data it
+needs in WordPress database tables, exports the current WordPress state into a
+repository tree, and imports pushed changes through WordPress post APIs.
 
-The guiding rule is that users must not lose data. If a conversion cannot preserve a block safely, the plugin should preserve it as a fenced `gutenberg` code block or inline HTML, or reject the change with a clear error instead of silently dropping content.
+The main product rule is content safety. WP Origin should reject unsafe pushes
+before any WordPress content is changed. It should prefer a clear Git error over
+partial writes, lossy conversion, ambiguous identity, or silent normalization.
 
 ## 2. Goals
 
-### 2.1 Business goals
-
-- Prove that any WordPress site can behave like a Git remote for Markdown content.
-- Make WordPress content easier for agents and developer tools to read, edit, review, and version.
-- Create a credible standalone plugin path that can later inform WordPress.com or Jetpack integration.
-- Reuse php-toolkit Git, Markdown, and Data Liberation primitives where possible.
-
-### 2.2 User goals
-
-- Clone or pull site content as Markdown files.
-- Edit content locally in an editor, vault, or coding-agent workspace.
-- Push Markdown changes back to WordPress without visiting WP-Admin.
-- Keep using WP-Admin as normal while also allowing Git-based editing.
-- Rely on Git history locally for review, rollback, and conflict handling.
-- Add WordPress as any Git remote name, such as `origin`, `wp`, or `production`, without requiring the site to manage other external remotes.
-- Use the checked-out content in Obsidian-compatible Markdown workflows where possible.
-
-### 2.3 Non-goals
-
-- Do not version PHP code, themes, plugins, uploads, or the full database in the MVP.
-- Do not manage GitHub/GitLab/Bitbucket synchronization in the MVP. Users can still add those as separate remotes in their local clone.
-- Do not preserve a complete immutable Git object graph on the WordPress server in the MVP.
-- Do not support every WordPress post type, setting, template, navigation item, or media workflow in the first release.
-- Do not treat full block theme editing as MVP scope, but keep `wp_template`, `wp_template_part`, and `wp_navigation` visible as early follow-up candidates because they are post types under the hood.
-- Do not introduce external Composer dependencies or required PHP extensions beyond this repo's constraints.
-
-## 3. Users and permissions
-
-### 3.1 Key user types
-
-- **Site owner**: Wants simple local editing, backups, and agent-assisted content updates.
-- **Content editor**: Writes or reviews posts and pages in Markdown-friendly tools.
-- **Coding agent**: Reads, edits, commits, and pushes content changes on behalf of a user.
-- **Developer**: Installs, configures, debugs, and extends the plugin.
-
-### 3.2 Role-based access
-
-- **Unauthenticated users**: Cannot clone, pull, or push private site content.
-- **Users with read access**: Can clone or pull content they are allowed to read.
-- **Users with edit permissions**: Can push changes to posts or pages they are allowed to edit.
-- **Administrators**: Can configure enabled post types, endpoint behavior, and future advanced options.
-
-## 4. Functional requirements
-
-- **Git endpoint** (Priority: High)
-  - Expose a Git-compatible HTTP endpoint for Markdown content at `/wp-json/git/v1/md.git`.
-  - Support `git clone`, `git pull`, and `git push` for the MVP happy path.
-  - Keep the endpoint scoped to content, not code or database exports.
-
-- **Content export to Markdown** (Priority: High)
-  - Export posts and pages as Markdown files.
-  - Store files in predictable paths that mirror WordPress post type names, such as `post/{slug}.md` and `page/{slug}.md`.
-  - Include lean, established front matter such as title, date, status, and an explicit excerpt description.
-  - Preserve unsupported block markup as fenced `gutenberg` code blocks, or inline HTML when Markdown cannot represent it safely.
-  - Keep Markdown human-editable and compatible with common editors such as Obsidian wherever that does not weaken round-trip fidelity.
-
-- **Guidelines and agent portability** (Priority: Medium)
-  - When Gutenberg's Guidelines experiment is available, export `wp_guideline` posts under `wp_guideline/{type}/`.
-  - When Guidelines is not available, still export WP Origin's built-in agent guide and template-editing skill as generated read-only checkout files so agents receive the same operational guidance.
-  - Store guideline skills as agent-portable skill directories, such as `wp_guideline/skills/{slug}/SKILL.md`.
-  - Expose guideline skills through `.agents/skills` and `.claude/skills` directory symlinks so agents can discover the same canonical skill content.
-  - Install default WP Origin coding-agent skills when Guidelines is available, including a general checkout guide and a focused block theme template-editing skill.
-  - Expose `AGENTS.md` and `CLAUDE.md` as symlinks to the general WP Origin checkout guide.
-  - Store guideline skill bodies as content only in WordPress, and generate agent-required YAML front matter from WordPress title, slug, and excerpt on export.
-  - Keep the canonical `wp_guideline/` tree aligned with `wp_guideline_type` taxonomy terms, including `artifact`, `skill`, `plan`, and future instruction-like types.
-
-- **Markdown import to WordPress** (Priority: High)
-  - Convert pushed Markdown back into WordPress post content.
-  - Update existing posts by stable metadata when possible, then by path or slug as a fallback.
-  - Create new posts or pages when new Markdown files are pushed.
-  - Move deleted files to trash by default instead of permanently deleting content.
-
-- **Round-trip fidelity** (Priority: High)
-  - Treat `wp -> md -> wp` and `md -> wp -> md` as byte-preservation contracts for supported content.
-  - Detect byte changes using fixture-based tests that compare exact strings and content hashes, not rendered output.
-  - If exact preservation is not possible for a block, preserve it as an opaque `gutenberg` fence or reject the conversion instead of normalizing it.
-  - Avoid automatic newline, whitespace, attribute-order, or escaping changes unless the test fixture explicitly accepts them.
-
-- **Media handling** (Priority: Medium)
-  - Export referenced media files into an `attachment/` directory to mirror the WordPress `attachment` post type.
-  - Rewrite image references in Markdown to relative paths where possible.
-  - Import new or changed media files as WordPress attachments when safe.
-  - Track media hashes so unchanged binaries do not get reuploaded.
-  - Keep large media transfers streaming-first and reject pushes that exceed safe runtime limits.
-
-- **Block theme entities** (Priority: Medium)
-  - Support `wp_template`, `wp_template_part`, and `wp_navigation` once posts/pages round-trip safely.
-  - Represent these as explicit directories rather than mixing them into generic custom post type output.
-  - Export theme-provided base templates and template parts as `.html` files containing raw Gutenberg block markup, not Markdown, even before they have database customizations.
-  - Layer database customizations for `wp_template`, `wp_template_part`, and `wp_navigation` on top of the theme-provided base files at the same logical paths.
-  - Create a distinct theme-base commit before the WordPress customization/content commit so agents can distinguish hardcoded theme defaults from site-specific changes.
-  - Export theme-provided `theme.json` files under `wp_theme/{theme}/theme.json` for agent context.
-  - Export editable Global Styles overlays under `wp_global_styles/{theme}.json` so site-wide theme.json-style changes round-trip through the WordPress `wp_global_styles` post type instead of mutating theme source files.
-  - Do not include front matter in these `.html` files.
-  - Use the directory and path as identity: `wp_template/single.html` maps to post type `wp_template` and slug `single`.
-  - For theme-scoped templates and template parts, map `wp_template/{theme}/index.html` and `wp_template_part/{theme}/footer.html` to WordPress template IDs such as `{theme}//index` and `{theme}//footer`.
-  - Store pushed theme-scoped customizations using the WordPress identity model: the post slug remains the template slug, such as `footer`, while the `wp_theme` taxonomy term stores the theme, such as `twentytwentyfive`. Do not flatten these into slugs such as `twentytwentyfive-footer`.
-  - Allow pushed create and update operations for template HTML files; editing a theme-provided template creates a WordPress customization.
-  - Reject pushed deletes and renames for these files because the path is the identity and deletion can break site rendering.
-  - Reject pushed edits to `wp_theme/{theme}/theme.json` because WP Origin does not mutate theme source files.
-  - Allow pushed create and update operations for `wp_global_styles/{theme}.json`, adding WordPress's internal Global Styles safety flag on import and omitting it from the checkout.
-  - Reject pushed deletes and renames for Global Styles JSON overlays until reset semantics are explicit.
-  - Provide agent guidance for template edits that prefers editable core block markup, preserves custom blocks, avoids new `core/html` blocks for normal layout, uses WordPress-native full-width alignment patterns, and directs site-wide style changes to `wp_global_styles/{theme}.json`.
-  - Export model-facing guidance through `AGENTS.md`, `CLAUDE.md`, and a `wp-origin-template-editor` skill so agents understand that theme base files are context, `wp_theme` files are read-only, and nested theme paths such as `wp_template_part/twentytwentyfive/footer.html` must not be flattened.
-
-- **Conflict and safety checks** (Priority: High)
-  - Reject pushes that would overwrite newer WordPress edits unless the client has pulled the latest content.
-  - Create WordPress revisions for pushed updates.
-  - Fail closed when conversion would drop content or metadata.
-  - Return actionable Git/HTTP errors that explain what the user should do next.
-
-- **Configuration** (Priority: Medium)
-  - Allow administrators to enable the MVP for posts and pages.
-  - Keep custom post types disabled by default until explicitly supported.
-  - Provide a minimal admin-visible status or settings surface only when needed for setup.
-
-- **Extensibility** (Priority: Medium)
-  - Keep the content mapping small and explicit so media, custom post types, templates, and navigation can be added later.
-  - Keep server-side Git storage optional; the WordPress database is the MVP source of truth.
-
-## 5. Core experience
-
-1. An administrator activates WP Origin and enables Git access for content.
-2. A user authenticates with Git over HTTP Basic Auth using a WordPress application password.
-3. The user runs `git clone https://example.com/wp-json/git/v1/md.git` or adds the site as a remote with `git remote add wp https://example.com/wp-json/git/v1/md.git`.
-4. The cloned repository contains Markdown files for posts and pages, plus `.html` files for supported structural block entities when present.
-5. The user or agent edits files locally and commits normally.
-6. The user runs `git push wp trunk` or the equivalent command for the remote name they chose.
-7. WP Origin validates permissions, detects stale content, imports changed files back to WordPress content, and updates or creates posts.
-8. If a push cannot be applied safely, WP Origin rejects it with a clear error and leaves existing WordPress content unchanged.
-
-## 6. Technical considerations
-
-### 6.1 Integration points
-
-- WordPress REST API routes for Git Smart HTTP requests, using `/wp-json/git/v1/md.git` as the canonical route.
-- A routing layer that maps `/wp-json/git/v1/md.git/*` to Git protocol paths such as `/info/refs?service=git-upload-pack`, `/git-upload-pack`, `/info/refs?service=git-receive-pack`, and `/git-receive-pack`.
-- HTTP Basic Auth backed by WordPress application passwords.
-- WordPress post APIs for reading, creating, updating, trashing, and revisioning content.
-- php-toolkit Git component for Git protocol handling.
-- php-toolkit Markdown and Data Liberation components for Markdown/block conversions.
-
-### 6.2 Content format
-
-- Editorial posts and pages use Markdown bodies with YAML-style front matter.
-- Structural block entities use raw Gutenberg HTML with no front matter.
-- File paths are grouped by WordPress post type name, starting with `post/` and `page/`, with media under `attachment/` once media support lands.
-- Template-like structural paths use `.html`, for example `wp_template/single.html`, `wp_template_part/header.html`, and `wp_navigation/main.html`.
-- Theme-provided templates use theme-qualified nested paths such as `wp_template/{theme}/index.html` and `wp_template_part/{theme}/header.html`; pushed edits to those files create or update the matching WordPress customization.
-- Theme-qualified template paths are a file-system view of WordPress template IDs. For example, `wp_template_part/twentytwentyfive/footer.html` maps to `twentytwentyfive//footer` in the template-part REST API, backed by a `wp_template_part` post with `post_name=footer` and a `wp_theme=twentytwentyfive` term when customized.
-- Theme-provided JSON is exported as read-only context under `wp_theme/{theme}/theme.json`.
-- Editable Global Styles overlays are exported under `wp_global_styles/{theme}.json`. They map to `wp_global_styles` posts tagged with the matching `wp_theme` term; WP Origin strips the internal `isGlobalStylesUserThemeJSON` flag from Git and restores it on import.
-- The checkout includes agent-readable guidance: root `AGENTS.md` and `CLAUDE.md` point to the WP Origin guide, `.agents/skills` and `.claude/skills` expose the exported skills, and the template editor skill documents the theme-base overlay model and path identity rules.
-- Front matter should be stable enough for post/page round-trips but small enough for agents to understand.
-- Unknown or lossy blocks should round-trip using fenced `gutenberg` code blocks where possible, with raw HTML as a fallback.
-- The importer should also accept the existing `block` fence language as a compatibility alias.
-- Markdown should remain useful in Obsidian: front matter is allowed, links and images should prefer normal Markdown syntax, media references should prefer relative paths, and hidden metadata should be kept minimal.
-- If an Obsidian-friendly representation conflicts with binary-safe round-tripping, round-trip safety wins.
-- For structural `.html` files, WordPress keeps title, status, date, author, IDs, and other administrative metadata. WP Origin resolves IDs dynamically from path-derived post type and slug.
-
-### 6.3 Data storage and privacy
-
-- WordPress remains the canonical storage layer.
-- The MVP does not require a persistent `.git` directory on the server.
-- Local clones keep their own Git history.
-- Credentials must never be written into generated Markdown files or Git history.
-- Application passwords should be used only through HTTP auth and never serialized into the generated repository.
-- Private, draft, or restricted content must follow existing WordPress permissions.
-
-### 6.4 Scalability and performance
-
-- Use streaming where available for Git pack data and content conversion.
-- Start with posts and pages to keep repository size manageable.
-- Avoid loading all media or full site data into memory in the MVP.
-- Stream media files when exporting/importing and hash them incrementally.
-- Add limits and clear errors for large pushes that exceed PHP execution or memory limits.
-
-### 6.5 Potential challenges
-
-- WordPress is mutable while Git expects immutable object history.
-- Markdown conversion can be lossy for custom blocks and complex layouts.
-- The current Markdown conversion already notes some block attributes can be lost, so the MVP must test and reject cases that would silently flatten important content.
-- Git clients expect precise HTTP behavior.
-- Slug changes, deleted posts, trashed posts, and duplicate titles need stable mapping rules.
-- Media introduces binary data, large payloads, URL rewriting, deduplication, and attachment metadata concerns.
-- Block theme entities are post types, but their content is closer to site structure than editorial content and may need separate conflict rules.
-- Multiple agents and WP-Admin users can edit the same content concurrently.
-
-## 7. Prior art and repo fit
-
-- **`plugins/git-repo/git-repo.php`** already proves WordPress can sit behind a `GitEndpoint` and respond to Git upload/receive requests. It currently materializes a test Git repository and syncs WordPress content in an ad hoc way. WP Origin should reuse the idea but make the content mapping explicit and Markdown-first.
-- **`plugins/static-files-editor/DataSource.php`** models the opposite workflow: a WordPress plugin pulls from and pushes to an external Git remote. WP Origin should invert that relationship. The site itself is the remote, and the WordPress database remains the source of truth.
-- **`components/Git`** already supports pure-PHP Git repositories, commits, refs, protocol v2 discovery, fetch, receive-pack, `GitFilesystem`, and remote operations. The MVP should use these pieces rather than shelling out to the `git` binary.
-- **`components/Markdown`** already supports bidirectional Markdown and block markup conversion with front matter. It serializes blocks that cannot be represented as Markdown into fenced `block` code blocks; WP Origin should evolve that toward a more descriptive `gutenberg` fence while accepting `block` for compatibility.
-- **`components/DataLiberation`** supplies streaming-oriented content import/export primitives. That matters for future media and larger sites, even if the first MVP keeps the data scope small.
-- **`wp-plugin-template`** uses a simple docs-first planning flow with `docs/prd.md` and a minimal plugin entry file later. For now, WP Origin should stay documentation-only until the shape is agreed.
-
-## 8. Success metrics
-
-- A user can clone a test site and see posts and pages as Markdown.
-- A user can edit an existing post locally and push it back without data loss.
-- A user can create a new Markdown file and push it as a new post or page.
-- A stale push is rejected instead of overwriting newer WordPress edits.
-- Round-trip tests prove byte-for-byte stability for supported `wp -> md -> wp` and `md -> wp -> md` fixtures.
-- Unsupported blocks are preserved as fenced `gutenberg` payloads or HTML.
-- A Git smoke-test script can clone, edit, commit, push, pull, and verify the resulting WordPress content.
-- The MVP works in a normal standalone plugin environment without new external dependencies.
-
-## 9. Milestones
-
-- **Milestone 1: Round-trip contract tests**
-  - Add fixtures for simple Markdown, core blocks, nested blocks, unsupported blocks, front matter, whitespace, and representative media references.
-  - Assert exact byte preservation for `wp -> md -> wp` and `md -> wp -> md` where content is declared supported.
-  - Assert unsupported block preservation through `gutenberg` fences.
-  - Make these tests the prerequisite for endpoint work.
-
-- **Milestone 2: Git action test script**
-  - Add a script target, for example `bin/test-wp-origin-git-actions.sh`, that can run clone, pull, edit, commit, push, and verification against a local test site.
-  - Make the script fail loudly on changed bytes, missing files, unexpected WordPress content, auth failures, or stale push behavior.
-  - Keep the script usable by agents as an end-to-end acceptance harness.
-
-- **Milestone 3: Endpoint and authentication spike**
-  - Plugin boots.
-  - REST route exposes `/wp-json/git/v1/md.git`.
-  - Git endpoint accepts discovery/fetch requests in a local test environment.
-  - HTTP Basic Auth with application passwords works.
-
-- **Milestone 4: Pull posts and pages as Markdown**
-  - Posts and pages export into predictable `post/` and `page/` Markdown paths.
-  - Metadata front matter is included.
-  - `git clone` and `git pull` work for the happy path.
-
-- **Milestone 5: Push Markdown into WordPress**
-  - Existing posts can be updated.
-  - New posts/pages can be created.
-  - Deleted files move content to trash.
-  - WordPress revisions are created.
-
-- **Milestone 6: Safety and conflicts**
-  - Stale pushes are rejected.
-  - Lossy conversions fail closed.
-  - Errors are understandable from the Git client.
-
-- **Milestone 7: Media and block-theme exploration**
-  - Export referenced media into relative Markdown paths.
-  - Import safe new/changed media as attachments.
-  - Export theme-provided `wp_template` and `wp_template_part` files as raw `.html` Gutenberg block files before database customizations exist.
-  - Export `wp_navigation` and database customizations for `wp_template` and `wp_template_part` as raw `.html` Gutenberg block files.
-  - Export active theme `theme.json` as read-only agent context.
-  - Export active theme Global Styles overlay as editable JSON under `wp_global_styles/{theme}.json`.
-  - Allow create/update pushes for template `.html` files, including pushes that convert a theme-provided file into a WordPress customization using the correct `{theme}//{slug}` identity.
-  - Allow create/update pushes for Global Styles `.json` overlays.
-  - Reject delete/rename pushes for those `.html` files.
-  - Reject delete/rename pushes for Global Styles `.json` overlays.
-
-- **Milestone 8: MVP hardening**
-  - Document setup and supported workflows.
-  - Prepare a plugin zip or deployment path.
-
-## 10. Implementation plan
-
-### 10.1 Start with a narrow, testable MVP
-
-- Treat WordPress as the source of truth.
-- Expose only Markdown content, not PHP code, themes, uploads, or database dumps.
-- Support posts and pages first.
-- Preserve data over convenience: reject unsafe pushes rather than applying partial or lossy changes.
-- Frontload tests for the Markdown and block conversion components before building the Git endpoint.
-- Make every implementation step start with a failing fixture or smoke-test expectation so agents can keep moving independently.
-
-### 10.2 Stabilize Markdown round-tripping first
-
-- Add component-level fixtures for both directions:
-  - `wp -> md -> wp`
-  - `md -> wp -> md`
-- Compare exact bytes for supported content, including whitespace, newlines, attribute ordering, escaped characters, and fenced code block contents.
-- Add fixtures for regular Markdown, WordPress core blocks, nested blocks, raw HTML, unsupported blocks, `gutenberg` fences, legacy `block` fences, front matter, and representative Obsidian-style Markdown.
-- Add media reference fixtures before implementing full binary media transfer so URL rewriting can be stabilized early.
-- Keep unsupported or risky blocks opaque inside fenced `gutenberg` code blocks until a tested lossless Markdown representation exists.
-- Treat a changed fixture as a product decision, not incidental churn.
-
-### 10.3 Build the plugin foundation
-
-- Keep this as a docs-only proposal until the endpoint shape and content format are agreed.
-- When implementation begins, add the smallest possible plugin entry point under `plugins/wp-origin/`.
-- Use `/wp-json/git/v1/md.git` as the public Git URL.
-- Authenticate Git HTTP clients with HTTP Basic Auth backed by WordPress application passwords.
-- Add a capability check layer that separates read and write permissions.
-
-### 10.4 Introduce a Git action smoke-test script
-
-- Add a script target, for example `bin/test-wp-origin-git-actions.sh`, that can run against a local WordPress sandbox.
-- The script should create or reset fixture content in WordPress.
-- The script should clone from `/wp-json/git/v1/md.git` using an application password.
-- The script should verify expected files and exact Markdown bytes after clone.
-- The script should edit Markdown, commit, push, and verify exact WordPress post content.
-- The script should edit the WordPress post directly, pull, and verify the local file changed as expected.
-- The script should attempt a stale push and assert that it is rejected.
-- The script should include media fixtures once media support exists.
-
-### 10.5 Implement pull
-
-- Query posts and pages through WordPress APIs.
-- Convert each entity into a Markdown file:
-  - `post/{slug}.md`
-  - `page/{slug}.md`
-- Add front matter with the smallest useful metadata:
-  - `title`
-  - `date`
-  - `status`
-  - `description` when an explicit excerpt exists
-- Export human-facing status values while accepting both human-facing and WordPress-native values on push:
-  - `published` or `publish`
-  - `scheduled` or `future`
-  - `draft`
-  - `pending`
-  - `private`
-- Keep machine identity and conflict metadata out of Markdown front matter.
-- Use existing php-toolkit Markdown/Data Liberation conversion code where possible.
-- Use the Git component to serve a generated repository snapshot.
-- Verify with `git clone` and `git pull` against a local WordPress site.
-
-### 10.6 Implement push
-
-- Accept `git receive-pack` requests from a local clone.
-- Read the pushed tree and map changed files back to WordPress entities.
-- Match existing content by path and slug, while preserving backward compatibility with older front matter IDs when present.
-- Update existing posts with `wp_update_post()`.
-- Create new posts with `wp_insert_post()`.
-- Move deleted files to trash with `wp_trash_post()` instead of permanent deletion.
-- Create WordPress revisions through normal post update behavior.
-- Apply changes transactionally where practical; if any file fails validation, reject before mutating content.
-
-### 10.7 Add data-loss protections
-
-- Track identity and freshness in WP Origin's stored commit manifest instead of noisy Markdown front matter.
-- Reject pushes where the remote changed and the local clone needs to pull first.
-- Preserve unsupported blocks as fenced `gutenberg` payloads or inline HTML.
-- Reject files that would drop required metadata for an existing post.
-- Reject path traversal, unsupported directories, binary files, and unexpected extensions.
-- Reject round-trip changes that are not covered by an explicit fixture update.
-- Keep private/draft content behind WordPress permission checks.
-
-### 10.8 Add media support
-
-- Start with media referenced by posts/pages, not the whole media library.
-- Export attachments into a stable `attachment/` directory.
-- Rewrite image URLs to relative paths in Markdown.
-- Store enough metadata to map a file back to its attachment ID and source URL.
-- Hash binary files to detect unchanged media and avoid reuploads.
-- Add binary-safe tests that compare exported and imported media hashes.
-
-### 10.9 Add block theme entities
-
-- Add fixtures for `wp_template`, `wp_template_part`, and `wp_navigation`.
-- Keep them in explicit directories that mirror post type names: `wp_template/`, `wp_template_part/`, and `wp_navigation/`.
-- Store each entity as a `.html` file containing only `post_content` block markup.
-- Do not write front matter into structural `.html` files.
-- Resolve identity from path: directory is post type, the path below it without `.html` is slug, and database ID is looked up at import time.
-- Preserve block markup exactly; do not convert these files to Markdown.
-- Allow pushed creates and updates.
-- Reject pushed deletes and renames.
-- Decide later whether block theme entities belong in the same `md.git` remote or a separate remote/branch.
-
-### 10.10 Keep TDD useful for independent agents
-
-- Each task should include a failing test name, target fixture, and expected behavior before implementation begins.
-- Prefer small fixtures that isolate one rule: front matter, slug mapping, unsupported block preservation, media hash preservation, stale push rejection, and so on.
-- Add golden-file tests for content formats and smoke tests for Git workflows.
-- When a model changes behavior, it should update the fixture and add a short reason in the test name or fixture comment.
-- Keep a "known unsupported" fixture set so agents can add tests for future work without making the current MVP fail.
-
-### 10.11 Prepare the first demo
-
-- Document local setup and example commands:
-  - `git clone https://example.com/wp-json/git/v1/md.git`
-  - `git remote add wp https://example.com/wp-json/git/v1/md.git`
-  - edit `post/hello-world.md`
-  - `git commit -am "Update hello world"`
-  - `git push wp trunk`
-- Show WP-Admin edits flowing back through `git pull`.
-- Show a rejected stale push and the recovery path.
-- Show media references if the media milestone lands before the demo.
-- Keep broader custom post types and WordPress.com transport as explicit follow-up work.
-
-## 11. User stories
-
-### 11.1 Clone content as Markdown
-
-- **ID**: US-001
-- **Description**: As a content editor, I want to clone WordPress posts and pages as Markdown so that I can work with them locally.
-- **Acceptance criteria**:
-  - The user can authenticate with a Git client using HTTP Basic Auth and a WordPress application password.
-  - The clone contains Markdown files for supported posts and pages.
-  - Files are organized in predictable content-type directories.
-  - Files include metadata needed for safe round-trips.
-  - The site can be added using any local remote name, such as `wp` or `origin`.
-
-### 11.2 Pull the latest WordPress edits
-
-- **ID**: US-002
-- **Description**: As a coding agent, I want to pull the latest WordPress content so that I work from the current source of truth.
-- **Acceptance criteria**:
-  - Pull reflects changes made in WP-Admin since the last clone or pull.
-  - The local working tree updates using standard Git behavior.
-  - Deleted or trashed content is represented consistently.
-
-### 11.3 Push an edit to an existing post
-
-- **ID**: US-003
-- **Description**: As a user, I want to edit a Markdown file and push it so that the matching WordPress post is updated.
-- **Acceptance criteria**:
-  - The pushed file maps to the correct existing post.
-  - The post title, status, date, description, and content update according to supported metadata.
-  - A WordPress revision is created.
-  - The push does not modify unrelated content.
-
-### 11.4 Create content from a new Markdown file
-
-- **ID**: US-004
-- **Description**: As a user, I want to add a Markdown file and push it so that WordPress creates a new post or page.
-- **Acceptance criteria**:
-  - A new file under `post/` creates a post.
-  - A new file under `page/` creates a page.
-  - Missing metadata receives safe WordPress defaults.
-  - The response gives the Git client a successful push result when creation succeeds.
-
-### 11.5 Delete content safely
-
-- **ID**: US-005
-- **Description**: As a user, I want deleting a Markdown file to remove it from the Git view without accidentally destroying WordPress content permanently.
-- **Acceptance criteria**:
-  - A deleted Markdown file moves the matching WordPress post to trash by default.
-  - Permanently deleted content is not required for the MVP.
-  - The push is rejected if the matching content cannot be identified safely.
-
-### 11.6 Preserve complex blocks
-
-- **ID**: US-006
-- **Description**: As a site owner, I want complex WordPress blocks to survive Markdown round-trips so that using Git does not break my site.
-- **Acceptance criteria**:
-  - Supported blocks convert to Markdown.
-  - Unsupported blocks are preserved as fenced `gutenberg` payloads, HTML, or block markup.
-  - Legacy fenced `block` payloads are accepted on import.
-  - A push is rejected if conversion would silently drop content.
-
-### 11.7 Prevent unauthorized access
-
-- **ID**: US-007
-- **Description**: As a site owner, I want only authorized users to read or edit content through Git so that private content stays protected.
-- **Acceptance criteria**:
-  - Unauthenticated requests are rejected.
-  - Users cannot read content they could not read in WordPress.
-  - Users cannot push changes they could not make in WordPress.
-  - Authentication failures do not leak private content.
-
-### 11.8 Reject stale pushes
-
-- **ID**: US-008
-- **Description**: As a content editor, I want stale pushes to be rejected so that local edits do not overwrite newer WP-Admin changes.
-- **Acceptance criteria**:
-  - The plugin detects when WordPress content changed after the user's last fetched version.
-  - The push is rejected before applying partial updates.
-  - The error tells the user to pull and resolve the conflict locally.
-
-### 11.9 Preserve round-trip bytes
-
-- **ID**: US-009
-- **Description**: As a developer, I want exact round-trip tests so that agents can evolve the plugin without accidentally changing content serialization.
-- **Acceptance criteria**:
-  - Supported `wp -> md -> wp` fixtures produce identical bytes.
-  - Supported `md -> wp -> md` fixtures produce identical bytes.
-  - Unsupported content is preserved as an opaque `gutenberg` fence or rejected.
-  - Fixture changes require an explicit expected-output update.
-
-### 11.10 Work with Obsidian-friendly Markdown
-
-- **ID**: US-010
-- **Description**: As a user, I want cloned content to work naturally in Obsidian where possible so that my WordPress site can fit into Markdown-first writing workflows.
-- **Acceptance criteria**:
-  - Standard Markdown headings, links, images, lists, quotes, and code blocks remain readable in Obsidian.
-  - Front matter remains valid and understandable.
-  - Media references use relative paths where possible.
-  - WordPress-specific payloads render as ordinary code blocks instead of hidden or editor-breaking syntax.
-
-### 11.11 Sync referenced media
-
-- **ID**: US-011
-- **Description**: As a content editor, I want images referenced by posts and pages to move with the Markdown files so that local edits do not break media.
-- **Acceptance criteria**:
-  - Referenced media exports to a stable `attachment/` directory.
-  - Markdown image references point to relative media paths.
-  - Pushed new or changed media can become WordPress attachments when safe.
-  - Binary file hashes match after round-trip.
-
-### 11.12 Work with block theme content
-
-- **ID**: US-012
-- **Description**: As a site builder, I want block theme entities to be Git-addressable once content round-tripping is stable.
-- **Acceptance criteria**:
-  - `wp_template`, `wp_template_part`, and `wp_navigation` are documented as follow-up post-type targets.
-  - Files export under explicit post-type directories with `.html` extensions.
-  - Files contain raw Gutenberg block markup with no front matter.
-  - The path determines post type and slug.
-  - Pushed creates and updates are allowed.
-  - Pushed deletes and renames are rejected.
-  - Block markup is preserved exactly unless a tested representation change is explicitly accepted.
-
-## 12. Later-phase idea: Git hashes and WordPress revisions
-
-WordPress post revisions are similar to Git objects because they preserve historical snapshots of a post. They are not a complete Git object model: they do not represent a repository-wide tree, they can be pruned, they do not include every attachment or cross-post relationship, and WordPress does not naturally store parent commit metadata.
-
-A later phase could map synthetic Git commit hashes to WordPress revision sets:
-
-- Build a virtual tree from the current exported Markdown files.
-- Hash each exported file from exact bytes.
-- Map each file hash to a post revision ID, attachment ID/hash, or current post state.
-- Build a synthetic commit hash from the tree hash, parent synthetic commit hash, author, timestamp, and message.
-- Store the mapping in plugin metadata or a small custom table: synthetic commit hash -> file paths -> WordPress revision IDs/media hashes.
-- Use that mapping to make fetch/pull more Git-like without requiring the WordPress site to store a full `.git` object graph.
-
-This should stay out of the MVP unless the mutable virtual repository blocks normal clone/pull/push workflows.
+### 2.1 Product Goals
+
+- Let a WordPress site behave like a Git remote for supported content.
+- Make posts and pages readable and editable as Markdown.
+- Make block theme entities readable and editable as raw Gutenberg block files
+  where WordPress supports safe customization.
+- Give coding agents a checkout that includes operational guidance, skills, and
+  enough theme context to make safe edits.
+- Keep WP-Admin and Git editing compatible by rejecting stale pushes.
+- Keep repository identity stable through file paths, not hidden front matter
+  IDs.
+- Fail closed when a pushed tree cannot be applied safely.
+
+### 2.2 User Goals
+
+- Clone or pull site content into a local editor, vault, or agent workspace.
+- Review content changes with normal Git diffs before applying them to
+  WordPress.
+- Push scoped content changes without visiting WP-Admin.
+- Pull recent WP-Admin edits before local work.
+- Use Git conflict handling when local and WordPress edits overlap.
+- Keep WordPress permissions, publishing behavior, revisions, and rendering as
+  the source of truth.
+
+### 2.3 Non-Goals For 0.1
+
+- Do not version PHP code, plugins, theme source, uploads, or arbitrary database
+  tables.
+- Do not sync WordPress to GitHub, GitLab, Bitbucket, or another external Git
+  host. Users may add those as separate local remotes.
+- Do not mirror the full media library. Media import/export remains future work.
+- Do not support arbitrary custom post types until each content mapping is
+  explicit and tested.
+- Do not rely on front matter IDs, slugs, or post types for identity.
+- Do not provide reset/delete semantics for template and Global Styles files
+  until the product behavior is explicit.
+- Do not require Composer packages or PHP extensions beyond this repository's
+  constraints.
+
+## 3. Users And Permissions
+
+### 3.1 User Types
+
+- **Site owner**: Installs WP Origin and wants safer backups, review, and
+  agent-assisted edits.
+- **Content editor**: Writes or reviews posts and pages in local tools.
+- **Site builder**: Edits templates, template parts, navigation posts, and Global
+  Styles where supported.
+- **Coding agent**: Pulls the current checkout, edits files, commits, and pushes
+  on behalf of an authenticated user.
+- **Developer**: Extends, debugs, and tests the plugin.
+
+### 3.2 Access Model
+
+- Unauthenticated requests cannot clone, pull, or push.
+- Git over HTTPS is expected to use HTTP Basic Auth with WordPress application
+  passwords, or another REST authentication layer that authenticates the request
+  as a WordPress user.
+- Clone and pull expose a whole repository snapshot, so the user must be allowed
+  to read the exported repository. Users with broad editorial access can read the
+  full export; otherwise every exported object must be readable to that user.
+- Push checks permissions for each changed object.
+- Creating content requires the relevant create capability for the post type.
+- Updating or trashing content requires permission to edit or delete that object.
+- Publishing, scheduling, or making content private requires the corresponding
+  WordPress capabilities.
+
+## 4. Git Endpoint And Protocol Scope
+
+- The canonical remote URL is `/wp-json/git/v1/md.git`.
+- The repository branch is `trunk`.
+- Pushes may update only one ref at a time.
+- Pushes to branches other than `trunk` are rejected.
+- Deleting `trunk` is rejected.
+- Stale pushes are rejected when WordPress content changed after the client last
+  fetched the remote state.
+- If a push is rejected, WordPress content must remain unchanged.
+
+## 5. Repository Layout
+
+Current exported paths:
+
+- `post/{slug}.md` for posts.
+- `page/{slug}.md` for top-level pages.
+- `page/{parent}/{child}.md` for hierarchical pages.
+- `wp_template/{slug}.html` and `wp_template/{theme}/{slug}.html` for templates.
+- `wp_template_part/{theme}/{slug}.html` for template parts.
+- `wp_navigation/{slug}.html` for navigation posts.
+- `wp_theme/{theme}/theme.json` for read-only theme JSON context.
+- `wp_global_styles/{theme}.json` for editable Global Styles overlays.
+- `wp_guideline/skills/{slug}/SKILL.md` for Gutenberg Guidelines skills and WP
+  Origin's built-in agent skills.
+- `AGENTS.md`, `CLAUDE.md`, `.agents/skills`, and `.claude/skills` as generated
+  or symlinked agent guidance when available.
+
+Paths are part of the content identity. WP Origin should reject unsupported
+directories, unexpected extensions, path traversal, non-canonical slugs, and
+ambiguous mappings.
+
+WP Origin's built-in agent skills are generated when no matching Guideline
+exists. If Gutenberg Guidelines are unavailable, those generated skills are
+read-only checkout context. If Guidelines are available, editing the canonical
+`wp_guideline/skills/{slug}/SKILL.md` file can create or update the matching
+Guideline, while generated aliases such as `AGENTS.md` and `.agents/skills`
+remain read-only.
+
+## 6. Posts And Pages
+
+### 6.1 Markdown Format
+
+Posts and pages are Markdown files with a small YAML-style front matter block.
+Supported front matter fields are:
+
+- `title`
+- `date`
+- `status`
+- `description`
+
+Unsupported front matter is rejected. This includes `id`, `slug`, `type`,
+unknown keys, arrays, booleans, and null values. Machine identity stays out of
+Markdown so that users and agents do not accidentally edit hidden routing data.
+
+`date_gmt` and `modified_gmt` are not exported. WordPress remains responsible
+for canonical timestamps and revisions.
+
+### 6.2 Status Values
+
+Exports use human-facing values where useful:
+
+- `published` for WordPress `publish`
+- `scheduled` for WordPress `future`
+- `draft`
+- `pending`
+- `private`
+
+Imports accept both human-facing and WordPress-native values for published and
+scheduled content: `published` or `publish`, and `scheduled` or `future`.
+
+Scheduled/future content must have a future date. Published content with a
+future date is rejected.
+
+### 6.3 Identity And Page Hierarchy
+
+Post identity comes from `post/{slug}.md`.
+
+Page identity comes from the page path:
+
+- `page/about.md` maps to the top-level `about` page.
+- `page/company/about.md` maps to the child page `about` under parent `company`.
+
+The same child slug may exist under different page parents because the full path
+distinguishes them. Creating or updating a nested page requires the exported
+parent page to exist. Export fails closed if a published/exported page has a
+trashed, non-exported, invalid, or cyclic parent.
+
+Deleting a post or page file moves the matching WordPress object to trash.
+Re-adding the same path restores the trashed object instead of creating a
+duplicate.
+
+Deleting a parent page while descendant page files remain is rejected.
+
+## 7. Structural Block Entities
+
+Structural block entities are stored as raw Gutenberg block markup, not
+Markdown, and do not use front matter.
+
+Supported files:
+
+- `wp_template/*.html`
+- `wp_template/{theme}/*.html`
+- `wp_template_part/{theme}/*.html`
+- `wp_navigation/*.html`
+
+Push behavior:
+
+- Creates and updates are allowed where WordPress supports the corresponding
+  customization.
+- Editing a theme-provided template or template part creates or updates the
+  WordPress customization for that theme and slug.
+- Deletes and renames are rejected for template, template part, navigation, and
+  Global Styles files until reset semantics are explicit.
+- `wp_theme/{theme}/theme.json` is read-only context and cannot be edited.
+- `wp_global_styles/{theme}.json` is editable JSON. WP Origin strips WordPress's
+  internal Global Styles safety flag on export and restores it on import.
+  Global Styles files must contain a JSON object.
+
+Raw block files are validated before import. Malformed Gutenberg delimiters,
+malformed JSON attributes, mismatched or unclosed blocks, NUL bytes, and content
+that would normalize into surprising block structure are rejected.
+
+## 8. Import Safety
+
+WP Origin validates and plans the full pushed range before mutating WordPress.
+This is required for single-commit and multi-commit pushes: if any changed file
+or later commit is invalid, no earlier WordPress writes may remain.
+
+Push validation rejects:
+
+- Unsupported paths or extensions.
+- Path traversal and non-canonical slugs.
+- User-authored symlinks, except generated checkout guidance that remains
+  unchanged.
+- Executable file modes.
+- NUL bytes and binary content in text formats.
+- Malformed Markdown front matter.
+- Unsupported front matter fields or scalar types.
+- Malformed Gutenberg block markup.
+- Edits to read-only theme JSON files.
+- Invalid Global Styles JSON, including JSON arrays.
+- Deletes or renames for template, template part, navigation, and Global Styles
+  files.
+- Creates, edits, or deletes of generated guidance symlinks.
+- Parent page deletes while child page files still exist.
+- Multi-ref pushes, non-`trunk` pushes, and `trunk` deletion.
+- Pushes based on a stale remote state.
+
+Errors should be actionable from a Git client and should explain whether the
+user needs to pull/rebase, fix a file, change permissions, or avoid an
+unsupported operation.
+
+## 9. Conflict Model
+
+Before accepting a push, WP Origin refreshes the remote view from WordPress. If
+WordPress changed since the client's base commit, the push is rejected. The user
+or agent must pull, rebase or merge locally, resolve conflicts, and push again.
+
+This keeps WordPress as the source of truth and avoids overwriting WP-Admin
+edits with stale local content.
+
+## 10. Core User Flows
+
+### 10.1 Clone
+
+1. A user authenticates with Basic Auth and an application password.
+2. The user runs `git clone https://example.com/wp-json/git/v1/md.git`.
+3. The clone checks out `trunk`.
+4. The working tree contains supported WordPress content and agent guidance.
+
+### 10.2 Edit A Post Or Page
+
+1. The user edits `post/{slug}.md`, `page/{slug}.md`, or a nested page path.
+2. The user commits locally.
+3. The user pushes to `trunk`.
+4. WP Origin validates the whole push, checks permissions, updates WordPress,
+   and lets WordPress create revisions.
+
+### 10.3 Create Content
+
+1. The user adds a new `post/{slug}.md` or page file.
+2. Front matter is optional except where WordPress behavior requires a value.
+3. WP Origin creates the matching post or page using safe WordPress defaults.
+4. Nested pages require an existing exported parent path.
+
+### 10.4 Delete And Restore Content
+
+1. Deleting a post or page file trashes the matching WordPress object.
+2. Re-adding the same file path restores that trashed object.
+3. The plugin rejects deletes that would leave exported child pages orphaned.
+
+### 10.5 Edit Block Theme Content
+
+1. The user edits a supported `.html` block entity file or
+   `wp_global_styles/{theme}.json`.
+2. WP Origin validates raw block markup or JSON before writing.
+3. Theme source files remain read-only.
+4. Deletes and renames are rejected.
+
+### 10.6 Resolve A Stale Push
+
+1. A user edits content in WP-Admin after another user cloned.
+2. The stale local clone attempts to push.
+3. WP Origin rejects the push before writing WordPress content.
+4. The local user pulls, rebases or merges, resolves conflicts, and pushes the
+   resolved tree.
+
+## 11. Testing And Reliability
+
+The plugin should keep a mix of focused unit tests and end-to-end Git flow tests.
+
+Required coverage:
+
+- Clone, pull, commit, push, and fresh clone verification.
+- Basic Auth for clone and push.
+- REST/WP-Admin edits flowing back through Git.
+- Stale push rejection.
+- Multi-file and multi-commit push rejection without partial WordPress writes.
+- Malformed front matter rejection.
+- Rejection of `id`, `slug`, `type`, and unknown front matter fields.
+- Malformed Gutenberg block markup rejection.
+- Template/global-style delete and rename rejection.
+- Read-only theme JSON rejection.
+- Nested page export, creation, update, conflict, and parent delete behavior.
+- Delete-to-trash and restore-from-trash behavior.
+- Editor/admin permission boundaries for clone and push.
+- Symlink, executable mode, unsupported path, binary/NUL, and path traversal
+  rejection.
+
+The smoke-test script should remain usable by agents as an acceptance harness
+against a local WordPress playground or sandbox site.
+
+## 12. Future Work
+
+- Media mirroring for referenced attachments, including relative Markdown links,
+  binary hashing, and safe import of new media.
+- Explicit reset semantics for templates, template parts, navigation, and Global
+  Styles.
+- Additional post types with explicit path and permission rules.
+- Better large-site pagination, streaming, and memory limits.
+- Optional mapping between Git commits and WordPress revision sets.
+- WordPress.com or Jetpack transport once the standalone plugin behavior is
+  stable.
+
+## 13. Success Metrics
+
+- A user can clone a test site and see supported content as files.
+- A user can edit an existing post/page locally and push it without data loss.
+- A user can create a new post/page from a pushed file.
+- A user can safely trash and restore content through file deletion/re-addition.
+- Block theme files and Global Styles overlays round-trip through supported
+  create/update flows.
+- Unsafe pushes fail before any WordPress content changes.
+- Stale pushes are rejected and recoverable through normal Git pull/rebase
+  workflows.
+- End-to-end tests can prove the repository view and WordPress state agree after
+  each supported flow.

--- a/plugins/wp-origin/readme.txt
+++ b/plugins/wp-origin/readme.txt
@@ -12,49 +12,64 @@ Use Git to read, review, and edit WordPress content as Markdown and block files.
 
 == Description ==
 
-WP Origin makes a WordPress site available as a Git remote for content. Authenticated users can run familiar Git commands such as `clone`, `pull`, and `push` against a WordPress REST API endpoint, then edit supported content locally in Markdown-friendly tools, even while offline.
+WP Origin makes a WordPress site available as a Git remote for supported content. Authenticated users can run familiar Git commands such as `clone`, `pull`, and `push` against a WordPress REST API endpoint, then edit content locally in Markdown-friendly tools or coding-agent workspaces.
 
-WordPress remains the source of truth. WP Origin stores the Git object data it needs in WordPress database tables, exports supported WordPress entities into a working tree, and imports pushed changes back into WordPress posts and related content.
+WordPress remains the source of truth. WP Origin stores the Git object data it needs in WordPress database tables, exports the current WordPress state into a repository tree, and imports pushed changes back through WordPress post APIs.
 
 The result is a static-site-generator-like workflow for a dynamic WordPress site: content can be cloned, diffed, edited, committed, and reviewed as files, while WordPress still handles publishing, previews, permissions, revisions, the editor, and the front end.
-
-The goal is to make site content easier to review, version, automate, and edit with developer tools while keeping normal WP-Admin editing available.
 
 = Common use cases =
 
 * Edit posts and pages in a local editor, Markdown vault, or coding-agent workspace.
-* Work offline after cloning or pulling content, then push changes back when a connection is available.
 * Review content changes with normal Git diffs before they are applied to WordPress.
+* Pull recent WP-Admin edits before local work and use normal Git conflict handling.
 * Let an authenticated coding agent pull current site content, make a scoped edit, commit it, and push it back.
-* Keep local Git history for content review and rollback while WordPress continues to manage publishing, permissions, and revisions.
 * Work with block theme templates, template parts, navigation posts, and Global Styles as files when those WordPress entities are available.
 * Pull site content into automation workflows without exporting the whole database or copying plugin/theme code.
 
 = How it works =
 
-After activation, WP Origin prepares an initial Git view of supported site content. The Git endpoint is:
+The Git endpoint is:
 
 `/wp-json/git/v1/md.git`
 
-Users authenticate through WordPress REST authentication. The built-in Application Passwords feature is the usual Git-over-HTTPS option when it is available, and other REST authentication plugins can work if they authenticate the request as a WordPress user. A local clone contains files such as:
+The repository branch is `trunk`. WP Origin accepts pushes to `trunk` only.
+
+Users authenticate through WordPress REST authentication. The built-in Application Passwords feature is the usual Git-over-HTTPS option when it is available, and other REST authentication plugins can work if they authenticate the request as a WordPress user.
+
+A local clone can contain files such as:
 
 * `post/{slug}.md` for posts.
-* `page/{slug}.md` for pages.
-* `wp_template/{slug}.html` and `wp_template_part/{theme}/{slug}.html` for supported block theme entities.
+* `page/{slug}.md` and `page/{parent}/{child}.md` for pages.
+* `wp_template/{slug}.html` and `wp_template/{theme}/{slug}.html` for templates.
+* `wp_template_part/{theme}/{slug}.html` for template parts.
+* `wp_navigation/{slug}.html` for navigation posts.
+* `wp_theme/{theme}/theme.json` as read-only theme context.
 * `wp_global_styles/{theme}.json` for editable Global Styles overlays.
-* `wp_guideline/skills/{slug}/SKILL.md` for Gutenberg Guidelines skills when available.
+* `wp_guideline/skills/{slug}/SKILL.md` for Gutenberg Guidelines skills and WP Origin's built-in agent skills.
+* `AGENTS.md`, `CLAUDE.md`, `.agents/skills`, and `.claude/skills` for agent guidance when available.
 
-Markdown files include front matter for WordPress metadata. Structural block files use raw Gutenberg block markup so they can round-trip through WordPress without being forced into Markdown.
+Markdown files use a small front matter contract: `title`, `date`, `status`, and optional `description`. Identity comes from the file path, so `id`, `slug`, `type`, and unknown front matter fields are rejected.
+
+Structural block files use raw Gutenberg block markup with no front matter so they can round-trip through WordPress without being forced into Markdown.
+
+WP Origin's built-in agent skills are generated when no matching Guideline exists. If Gutenberg Guidelines are unavailable, those generated skills are read-only checkout context. If Guidelines are available, edit the canonical `wp_guideline/skills/{slug}/SKILL.md` file; generated aliases such as `AGENTS.md` and `.agents/skills` remain read-only.
 
 = Safety model =
 
-WP Origin is designed to fail closed. It rejects pushes that would overwrite newer WordPress edits, rejects unsupported file modes, and trashes deleted post/page files instead of permanently deleting WordPress content.
+WP Origin is designed to fail closed. Before applying a push, it validates and plans all changed files across the pushed range. If any file or later commit is unsafe, the whole push is rejected before WordPress content is changed.
+
+Push validation rejects stale remote state, unsupported paths, path traversal, non-canonical slugs, unsupported file modes, user-authored symlinks, generated symlink edits, NUL bytes, malformed front matter, unsupported front matter fields, malformed Gutenberg block markup, invalid Global Styles JSON, edits to read-only theme JSON, and unsafe page hierarchy changes.
+
+Deleted post and page files move the matching WordPress content to trash instead of permanently deleting it. Re-adding the same path restores the trashed object instead of creating a duplicate.
+
+Template, template part, navigation, and Global Styles deletes or renames are rejected until reset semantics are explicit. Theme JSON files are exported only as read-only context.
 
 Pushed updates go through WordPress permissions and post APIs, so users can only change content their WordPress account is allowed to edit. Existing WP-Admin workflows can continue alongside Git-based edits.
 
 = What this is not =
 
-WP Origin is not a full database backup, theme deployment tool, plugin sync tool, or media-library mirror. It exposes supported content entities only. PHP code, plugins, themes, uploads, and arbitrary database tables are outside the release scope.
+WP Origin is not a full database backup, theme deployment tool, plugin sync tool, media-library mirror, or arbitrary custom post type exporter. It exposes supported content entities only. PHP code, plugins, theme source, uploads, and arbitrary database tables are outside the current release scope.
 
 == Installation ==
 
@@ -66,25 +81,33 @@ WP Origin is not a full database backup, theme deployment tool, plugin sync tool
 
 = Which content types are exported? =
 
-Posts, pages, supported block theme templates, template parts, navigation posts, Global Styles overlays, and Gutenberg Guidelines when available.
+Posts, pages, supported block theme templates, template parts, navigation posts, read-only theme JSON context, Global Styles overlays, Gutenberg Guidelines when available, and WP Origin's built-in agent guidance.
+
+= Which branch should I use? =
+
+Use `trunk`. WP Origin rejects pushes to other branches and rejects attempts to delete `trunk`.
+
+= Who can clone or pull? =
+
+Users must be authenticated and allowed to read the exported repository. Users with broad editorial access can clone the full export; otherwise every exported WordPress object must be readable to that user. This avoids exposing private, draft, pending, or future content through Git history.
 
 = Who can push changes? =
 
-Users must be authenticated and able to read every exported WordPress object to clone or pull the Git repository. This avoids exposing private, draft, pending, or future content through Git history.
+WP Origin checks permissions for each changed object. Updating or trashing existing content requires permission to edit or delete that specific post. Creating new files requires permission to create that post type, and publishing, scheduling, or making content private requires the relevant WordPress capability.
 
-For pushes, WP Origin checks permissions for each changed object. Updating or trashing existing content requires permission to edit that specific post. Creating new files requires permission to create that post type, and publishing or scheduling content requires the relevant publish capability.
+= Can I change a post or page slug in front matter? =
 
-Administrators can also use the seeder status screen.
+No. File paths are the identity model. WP Origin rejects `id`, `slug`, `type`, and unknown front matter fields. Rename or move files only when the corresponding path operation is supported and safe.
+
+= Can I still edit content in WP-Admin? =
+
+Yes. WordPress remains the source of truth. Pull before editing locally to pick up recent WP-Admin changes, and WP Origin will reject stale pushes that could overwrite newer WordPress edits.
 
 = Does WP Origin enable Application Passwords? =
 
 No. WP Origin does not enable or force any authentication method. It works with WordPress users that are already authenticated for REST requests and have the required capabilities.
 
 The built-in WordPress Application Passwords feature is the default way to use Git over HTTPS when it is available on the site. Other REST authentication plugins may also work if they authenticate the request as a WordPress user before WP Origin's permission checks run.
-
-= Can I still edit content in WP-Admin? =
-
-Yes. WordPress remains the source of truth. Pull before editing locally to pick up recent WP-Admin changes, and WP Origin will reject stale pushes that could overwrite newer WordPress edits.
 
 = Does this sync my site to GitHub or another Git host? =
 
@@ -93,6 +116,10 @@ No. WP Origin makes WordPress itself behave like a Git remote for supported cont
 = Does this export plugin or theme source code? =
 
 No. The checkout is scoped to supported WordPress content. Theme-provided files such as `wp_theme/{theme}/theme.json` may appear as read-only context, but WP Origin does not deploy theme or plugin code.
+
+= Does this export media files? =
+
+No. Media mirroring is planned future work. The current release does not mirror uploads or import attachment binaries.
 
 == Changelog ==
 


### PR DESCRIPTION
## Summary

Harden WP Origin's Git import/export flows around content safety, path identity, and validation.

This PR makes pushed content fail closed before WordPress writes occur, rejects ambiguous front matter identity, validates raw Gutenberg and Global Styles payloads more strictly, handles nested page identity and trash/restore behavior, and expands the E2E coverage for the user flows and edge cases we exercised.

It also refreshes the WP Origin PRD/readme so the docs describe the current implementation rather than the older proposal shape.

## Why

Manual testing found several reliability bugs where rejected pushes could still leave WordPress content changed, malformed Markdown/block files could import surprising content, trashed file re-adds could duplicate posts, and page/template/global-style edge cases were under-specified.

The root issue was that push handling was applying WordPress writes before all changed files and commits had been validated and planned. The fix is to validate the pushed range first, make file paths the content identity, and reject unsafe operations explicitly.

## Validation

- `vendor/bin/phpcs -d memory_limit=1G plugins/wp-origin/class-wp-origin-plugin.php plugins/wp-origin/Tests/EndToEndTest.php`
- `bash -n bin/test-wp-origin-git-actions.sh`
- `git diff --check`
- `bash bin/test-wp-origin-git-actions.sh`
- `vendor/bin/phpunit --filter WP_Origin_End_To_End_Test plugins/wp-origin/Tests` skipped as expected without `WP_ORIGIN_E2E_*` environment variables.

Note: `composer lint` is not usable as-is in this checkout because it scans checked-in/generated `node_modules` and `dist` files; the initial run also hit PHPCS's 1G memory cap. A memory-unlimited repo-wide PHPCS run then failed on those pre-existing generated/vendor paths, so this PR used targeted PHPCS for the changed PHP files.
