### PR TITLE
[codex] Add WP Origin admin shell emulator

### DIFF
--- a/.github/workflows/wp-origin-e2e.yml
+++ b/.github/workflows/wp-origin-e2e.yml
@@ -86,6 +86,7 @@ jobs:
             --skip-email
           wp --path="$WP_DIR" option update permalink_structure '/%postname%/'
           wp --path="$WP_DIR" rewrite flush --hard
+          wp --path="$WP_DIR" option update gutenberg-experiments '{"gutenberg-guidelines":true}' --format=json
 
       - name: Seed Hello World post, Sample Page, and Template
         run: |

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,6 +2,8 @@
     <description>PHP 7.2 compatibility.</description>
     <autoload>vendor/autoload.php</autoload>
     <config name="testVersion" value="7.2"/>
+    <exclude-pattern>node_modules/*</exclude-pattern>
+    <exclude-pattern>*/node_modules/*</exclude-pattern>
     <exclude-pattern>vendor/*</exclude-pattern>
     <exclude-pattern>*/vendor-patched/*</exclude-pattern>
     <exclude-pattern>*/Tests/*</exclude-pattern>

--- a/plugins/wp-origin/admin-shell.css
+++ b/plugins/wp-origin/admin-shell.css
@@ -1,0 +1,451 @@
+#wp-origin-admin {
+	--wp-origin-bg: #f6f5f2;
+	--wp-origin-ink: #151b1f;
+	--wp-origin-muted: #66737c;
+	--wp-origin-panel: #ffffff;
+	--wp-origin-line: #d7dde2;
+	--wp-origin-terminal: #101417;
+	--wp-origin-terminal-line: #26323a;
+	--wp-origin-green: #7ee787;
+	--wp-origin-blue: #7dcfff;
+	--wp-origin-amber: #f6c177;
+	--wp-origin-red: #ff7b72;
+	--wp-origin-purple: #d6bcfa;
+	margin: 0 0 0 -20px;
+	min-height: calc(100vh - 32px);
+	background:
+		linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(246, 245, 242, 0.96)),
+		var(--wp-origin-bg);
+	color: var(--wp-origin-ink);
+}
+
+#wp-origin-admin * {
+	box-sizing: border-box;
+}
+
+.wp-origin-shell-frame {
+	max-width: 1180px;
+	margin: 0 auto;
+	padding: 28px 24px 36px;
+}
+
+.wp-origin-shell-header {
+	display: flex;
+	align-items: flex-end;
+	justify-content: space-between;
+	gap: 18px;
+	margin-bottom: 18px;
+}
+
+.wp-origin-shell-title h1 {
+	margin: 0;
+	font-size: 28px;
+	line-height: 1.15;
+	letter-spacing: 0;
+}
+
+.wp-origin-shell-title p {
+	margin: 7px 0 0;
+	max-width: 680px;
+	color: var(--wp-origin-muted);
+	font-size: 14px;
+}
+
+.wp-origin-emulator-note {
+	margin: 0 0 14px;
+	padding: 12px 14px;
+	border: 1px solid #b6d7ee;
+	border-radius: 8px;
+	background: #eef7ff;
+	color: #183b56;
+	font-size: 13px;
+	line-height: 1.45;
+}
+
+.wp-origin-emulator-note strong {
+	color: #0a4b78;
+}
+
+.wp-origin-state-pill {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	min-height: 34px;
+	padding: 6px 12px;
+	border: 1px solid var(--wp-origin-line);
+	border-radius: 999px;
+	background: #fff;
+	color: var(--wp-origin-ink);
+	font-size: 13px;
+	font-weight: 600;
+	white-space: nowrap;
+}
+
+.wp-origin-state-dot {
+	width: 9px;
+	height: 9px;
+	border-radius: 50%;
+	background: var(--wp-origin-amber);
+	box-shadow: 0 0 0 4px rgba(246, 193, 119, 0.22);
+}
+
+.wp-origin-state-pill.is-done .wp-origin-state-dot {
+	background: #1f9d55;
+	box-shadow: 0 0 0 4px rgba(31, 157, 85, 0.18);
+}
+
+.wp-origin-state-pill.is-failed .wp-origin-state-dot {
+	background: #c2410c;
+	box-shadow: 0 0 0 4px rgba(194, 65, 12, 0.18);
+}
+
+.wp-origin-shell-grid {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) 320px;
+	gap: 18px;
+	align-items: stretch;
+}
+
+.wp-origin-terminal {
+	min-height: 610px;
+	border: 1px solid rgba(16, 20, 23, 0.85);
+	border-radius: 8px;
+	overflow: hidden;
+	background: var(--wp-origin-terminal);
+	box-shadow: 0 22px 70px rgba(16, 20, 23, 0.22);
+}
+
+.wp-origin-terminal-bar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	height: 42px;
+	padding: 0 14px;
+	border-bottom: 1px solid var(--wp-origin-terminal-line);
+	background: linear-gradient(180deg, #222b31, #151b1f);
+	color: #c9d1d9;
+	font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+	font-size: 12px;
+}
+
+.wp-origin-terminal-controls {
+	display: flex;
+	gap: 7px;
+	align-items: center;
+}
+
+.wp-origin-terminal-dot {
+	width: 11px;
+	height: 11px;
+	border-radius: 50%;
+	background: #ff5f57;
+}
+
+.wp-origin-terminal-dot:nth-child(2) {
+	background: #ffbd2e;
+}
+
+.wp-origin-terminal-dot:nth-child(3) {
+	background: #28c840;
+}
+
+.wp-origin-terminal-body {
+	display: flex;
+	flex-direction: column;
+	height: 568px;
+	padding: 16px 16px 14px;
+	color: #d7dee6;
+	font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+	font-size: 13px;
+	line-height: 1.5;
+}
+
+.wp-origin-terminal-output {
+	flex: 1;
+	overflow: auto;
+	padding-right: 6px;
+	white-space: pre-wrap;
+}
+
+.wp-origin-terminal-line {
+	min-height: 19px;
+	overflow-wrap: anywhere;
+}
+
+.wp-origin-terminal-line.is-muted {
+	color: #8b949e;
+}
+
+.wp-origin-terminal-line.is-success,
+.wp-origin-prompt-user {
+	color: var(--wp-origin-green);
+}
+
+.wp-origin-terminal-line.is-warning {
+	color: var(--wp-origin-amber);
+}
+
+.wp-origin-terminal-line.is-error {
+	color: var(--wp-origin-red);
+}
+
+.wp-origin-terminal-line.is-accent,
+.wp-origin-prompt-path {
+	color: var(--wp-origin-blue);
+}
+
+.wp-origin-terminal-input-row {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	min-height: 46px;
+	margin-top: 12px;
+	padding: 8px 10px;
+	border: 1px solid rgba(125, 207, 255, 0.24);
+	border-radius: 8px;
+	background: linear-gradient(180deg, rgba(34, 43, 49, 0.88), rgba(23, 29, 33, 0.92));
+	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 10px 28px rgba(0, 0, 0, 0.18);
+}
+
+.wp-origin-prompt-chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	max-width: 52%;
+	min-height: 28px;
+	padding: 4px 9px;
+	border: 1px solid rgba(126, 231, 135, 0.28);
+	border-radius: 999px;
+	background: rgba(126, 231, 135, 0.08);
+	white-space: nowrap;
+	overflow: hidden;
+}
+
+.wp-origin-prompt-mark {
+	color: var(--wp-origin-purple);
+}
+
+#wp-origin-admin .wp-origin-terminal-input[type="text"] {
+	appearance: none;
+	flex: 1;
+	min-width: 0;
+	min-height: 30px;
+	margin: 0;
+	padding: 3px 8px;
+	border: 1px solid rgba(125, 207, 255, 0.14);
+	border-radius: 6px;
+	outline: 0;
+	background: rgba(8, 12, 15, 0.36);
+	color: #ffffff;
+	font: inherit;
+	box-shadow: none;
+}
+
+#wp-origin-admin .wp-origin-terminal-input[type="text"]::placeholder {
+	color: #8b949e;
+}
+
+#wp-origin-admin .wp-origin-terminal-input[type="text"]:focus {
+	border-color: rgba(125, 207, 255, 0.32);
+	background: rgba(8, 12, 15, 0.54);
+	box-shadow: 0 0 0 1px rgba(125, 207, 255, 0.12);
+}
+
+.wp-origin-side-panel {
+	display: flex;
+	flex-direction: column;
+	gap: 14px;
+}
+
+.wp-origin-panel {
+	margin-top: 18px;
+	border: 1px solid var(--wp-origin-line);
+	border-radius: 8px;
+	background: var(--wp-origin-panel);
+	padding: 16px;
+}
+
+.wp-origin-panel h2 {
+	margin: 0 0 12px;
+	font-size: 14px;
+	line-height: 1.3;
+}
+
+.wp-origin-copy-panel {
+	padding-bottom: 10px;
+}
+
+.wp-origin-copy-table {
+	table-layout: fixed;
+}
+
+.wp-origin-copy-table th {
+	width: 150px;
+}
+
+.wp-origin-copy-table td {
+	vertical-align: middle;
+}
+
+.wp-origin-copy-table td:last-child {
+	width: 86px;
+	text-align: right;
+}
+
+.wp-origin-copy-table code {
+	display: block;
+	max-width: 100%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.wp-origin-copy-button.is-copied {
+	border-color: #1f9d55;
+	color: #1f6f43;
+}
+
+.wp-origin-progress-track {
+	height: 12px;
+	border-radius: 999px;
+	overflow: hidden;
+	background: #e8ecef;
+}
+
+.wp-origin-progress-bar {
+	height: 100%;
+	width: 0;
+	border-radius: inherit;
+	background: linear-gradient(90deg, #1f9d55, #2271b1);
+	transition: width 0.35s ease;
+}
+
+.wp-origin-progress-meta {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	margin-top: 10px;
+	color: var(--wp-origin-muted);
+	font-size: 12px;
+}
+
+.wp-origin-message {
+	margin: 12px 0 0;
+	color: var(--wp-origin-ink);
+	font-size: 13px;
+	line-height: 1.45;
+}
+
+.wp-origin-command-grid {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 8px;
+}
+
+.wp-origin-command-button {
+	min-height: 34px;
+	border: 1px solid var(--wp-origin-line);
+	border-radius: 6px;
+	background: #f9fafb;
+	color: var(--wp-origin-ink);
+	font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+	font-size: 12px;
+	cursor: pointer;
+}
+
+.wp-origin-command-button:hover,
+.wp-origin-command-button:focus {
+	border-color: #2271b1;
+	color: #0a4b78;
+}
+
+.wp-origin-commit-panel {
+	padding-bottom: 14px;
+}
+
+.wp-origin-commit-list {
+	display: flex;
+	flex-direction: column;
+	gap: 9px;
+	margin: 0;
+}
+
+.wp-origin-commit-list li {
+	display: grid;
+	grid-template-columns: 58px minmax(0, 1fr);
+	gap: 8px;
+	margin: 0;
+	color: var(--wp-origin-muted);
+	font-size: 12px;
+	line-height: 1.35;
+}
+
+.wp-origin-commit-list code {
+	color: #0a4b78;
+	background: #edf6ff;
+	border-radius: 4px;
+	padding: 1px 4px;
+}
+
+.wp-origin-retry-row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+}
+
+.wp-origin-import-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 18px;
+	margin-bottom: 12px;
+}
+
+.wp-origin-import-header h2 {
+	margin: 0;
+}
+
+@media (max-width: 960px) {
+	#wp-origin-admin {
+		margin-left: -10px;
+	}
+
+	.wp-origin-shell-header {
+		align-items: flex-start;
+		flex-direction: column;
+	}
+
+	.wp-origin-terminal-body {
+		height: 520px;
+	}
+
+	.wp-origin-terminal-input-row,
+	.wp-origin-import-header,
+	.wp-origin-retry-row {
+		align-items: stretch;
+		flex-direction: column;
+	}
+
+	.wp-origin-prompt-chip {
+		max-width: 100%;
+	}
+
+	.wp-origin-copy-table {
+		table-layout: auto;
+	}
+
+	.wp-origin-copy-table th,
+	.wp-origin-copy-table td,
+	.wp-origin-copy-table td:last-child {
+		display: block;
+		width: 100%;
+		text-align: left;
+	}
+
+	.wp-origin-copy-table td:last-child {
+		padding-top: 0;
+	}
+}

--- a/plugins/wp-origin/admin-shell.js
+++ b/plugins/wp-origin/admin-shell.js
@@ -1,0 +1,711 @@
+(function () {
+	var config            = window.wpOriginAdminShell || {};
+	var nonce             = config.nonce || '';
+	var statusUrl         = config.statusUrl || '';
+	var retryUrl          = config.retryUrl || '';
+	var remoteUrl         = config.remoteUrl || '';
+	var checkoutDir       = config.checkoutDir || 'site';
+	var cloneCommand      = config.cloneCommand || ('git clone ' + remoteUrl + ' ' + checkoutDir);
+	var progress          = config.initialProgress || {};
+	var stateEl           = document.getElementById( 'wp-origin-state' );
+	var stateCopyEl       = document.getElementById( 'wp-origin-state-copy' );
+	var statePillEl       = document.getElementById( 'wp-origin-state-pill' );
+	var barEl             = document.getElementById( 'wp-origin-bar' );
+	var percentEl         = document.getElementById( 'wp-origin-percent' );
+	var countsEl          = document.getElementById( 'wp-origin-counts' );
+	var messageEl         = document.getElementById( 'wp-origin-message' );
+	var outputEl          = document.getElementById( 'wp-origin-terminal-output' );
+	var inputEl           = document.getElementById( 'wp-origin-terminal-input' );
+	var cwdEl             = document.getElementById( 'wp-origin-prompt-cwd' );
+	var titleEl           = document.getElementById( 'wp-origin-terminal-title' );
+	var commitListEl      = document.getElementById( 'wp-origin-commit-list' );
+	var checkout          = normalizeCheckout( progress.checkout );
+	var cwd               = '/';
+	var history           = [];
+	var historyIndex      = 0;
+	var hasAnnouncedReady = progress.state === 'done';
+
+	if ( ! stateEl || ! outputEl || ! inputEl) {
+		return;
+	}
+
+	function render(data) {
+		var previousState       = progress.state;
+		progress                = data || {};
+		checkout                = normalizeCheckout( progress.checkout );
+		stateEl.textContent     = progress.state;
+		stateCopyEl.textContent = progress.state;
+		statePillEl.classList.toggle( 'is-done', progress.state === 'done' );
+		statePillEl.classList.toggle( 'is-failed', progress.state === 'failed' );
+		barEl.style.width     = progress.percent + '%';
+		percentEl.textContent = progress.percent;
+		countsEl.textContent  = progress.processed + ' / ' + progress.total;
+		messageEl.textContent = progress.message;
+		renderCommits( progress.commits || [] );
+		if (previousState !== 'done' && progress.state === 'done' && ! hasAnnouncedReady) {
+			hasAnnouncedReady = true;
+			appendLine( 'remote: Initial import complete. The checkout is ready.', 'is-success' );
+			appendLine( 'Try: ls, git pull, git commit -m "Update content", git push', 'is-muted' );
+		}
+	}
+
+	function poll() {
+		if ( ! statusUrl) {
+			return;
+		}
+
+		fetch( statusUrl, { credentials: 'same-origin', headers: { 'X-WP-Nonce': nonce } } )
+			.then(
+				function (response) {
+					return response.json();
+				}
+			)
+			.then(
+				function (data) {
+					render( data );
+					if (data.state !== 'done' && data.state !== 'failed') {
+						setTimeout( poll, 2000 );
+					}
+				}
+			)
+			.catch(
+				function () {
+					setTimeout( poll, 5000 );
+				}
+			);
+	}
+
+	function normalizeCheckout(rawCheckout) {
+		var normalized = rawCheckout || {};
+		if ( ! normalized.files) {
+			normalized.files = [];
+		}
+		return normalized;
+	}
+
+	function renderCommits(commits) {
+		commitListEl.textContent = '';
+		if ( ! commits.length) {
+			var emptyItem         = document.createElement( 'li' );
+			emptyItem.textContent = 'No commits yet';
+			commitListEl.appendChild( emptyItem );
+			return;
+		}
+		commits.slice( 0, 5 ).forEach(
+			function (commit) {
+				var item            = document.createElement( 'li' );
+				var oid             = document.createElement( 'code' );
+				var subject         = document.createElement( 'span' );
+				oid.textContent     = commit.oid;
+				subject.textContent = commit.subject;
+				item.appendChild( oid );
+				item.appendChild( subject );
+				commitListEl.appendChild( item );
+			}
+		);
+	}
+
+	function appendLine(text, className) {
+		var line       = document.createElement( 'div' );
+		line.className = 'wp-origin-terminal-line';
+		if (className) {
+			line.className += ' ' + className;
+		}
+		line.textContent = text === undefined ? '' : String( text );
+		outputEl.appendChild( line );
+		outputEl.scrollTop = outputEl.scrollHeight;
+	}
+
+	function appendPrompt(command) {
+		appendLine( 'emulator:' + displayCwd() + '$ ' + command, 'is-accent' );
+	}
+
+	function displayCwd() {
+		return cwd === '/' ? '~/' + checkoutDir : '~/' + checkoutDir + cwd;
+	}
+
+	function updatePrompt() {
+		cwdEl.textContent   = displayCwd();
+		titleEl.textContent = 'emulator:' + displayCwd();
+	}
+
+	function bootTranscript() {
+		outputEl.textContent = '';
+		appendLine( 'WP Origin command emulator', 'is-success' );
+		appendLine( 'This preview mirrors commands you can run in your real terminal after cloning.', 'is-muted' );
+		appendLine( 'No server shell is opened here, and emulator commands do not change WordPress.', 'is-muted' );
+		appendLine( '' );
+		appendPrompt( cloneCommand );
+		appendLine( "Cloning into '" + checkoutDir + "'..." );
+		if (progress.state === 'done') {
+			appendLine( 'remote: Initial import complete.', 'is-success' );
+		} else {
+			appendLine( 'remote: Preparing WordPress content (' + progress.percent + '%)...', 'is-warning' );
+		}
+		appendLine( 'Receiving objects: ' + Math.max( 1, checkout.files.length ) + ' checkout entries' );
+		appendPrompt( 'cd ' + checkoutDir );
+		cwd = '/';
+		updatePrompt();
+		runCommand( 'git status', { silentHistory: true } );
+		if (checkout.files.length) {
+			runCommand( 'ls', { silentHistory: true } );
+			appendLine( 'Try: git pull, git commit -m "Update content", git push', 'is-muted' );
+		} else {
+			appendLine( 'The emulated file tree will appear here as soon as the first commit is staged.', 'is-muted' );
+		}
+	}
+
+	function runCommand(command, options) {
+		options = options || {};
+		command = String( command || '' ).replace( /^\s+|\s+$/g, '' );
+		if ( ! command) {
+			return;
+		}
+		appendPrompt( command );
+		if ( ! options.silentHistory) {
+			history.push( command );
+			historyIndex = history.length;
+		}
+
+		var parts = command.split( /\s+/ );
+		var base  = parts[0];
+		if (base === 'help') {
+			printHelp();
+		} else if (base === 'clear') {
+			outputEl.textContent = '';
+		} else if (base === 'pwd') {
+			appendLine( '/' + checkoutDir + (cwd === '/' ? '' : cwd) );
+		} else if (base === 'ls') {
+			printLs( parts.slice( 1 ) );
+		} else if (base === 'cd') {
+			changeDirectory( parts[1] || '/' );
+		} else if (base === 'cat') {
+			printCat( parts.slice( 1 ).join( ' ' ) );
+		} else if (base === 'tree') {
+			printTree( parts[1] || '.' );
+		} else if (base === 'status') {
+			printGit( ['status'] );
+		} else if (base === 'git') {
+			printGit( parts.slice( 1 ) );
+		} else {
+			appendLine( base + ': command not found. Try `help`.', 'is-error' );
+		}
+	}
+
+	function printHelp() {
+		appendLine( 'Emulated commands:', 'is-success' );
+		appendLine( '  ls [-l] [path]        list checkout files' );
+		appendLine( '  cd [path]             change directory' );
+		appendLine( '  pwd                   print current directory' );
+		appendLine( '  cat <file>            show a preview of a file' );
+		appendLine( '  tree [path]           show the checkout shape' );
+		appendLine( '  git status            show import and branch state' );
+		appendLine( '  git log --oneline     show recent WP Origin commits' );
+		appendLine( '  git remote -v         show the WordPress remote' );
+		appendLine( '  git pull              preview refreshing from WordPress' );
+		appendLine( '  git add <path>        preview staging a change' );
+		appendLine( '  git commit -m "..."   preview a local content commit' );
+		appendLine( '  git push              preview sending changes back' );
+		appendLine( '  clear                 clear the terminal' );
+		appendLine( 'Use the copy table below for the real terminal URL and clone command.', 'is-muted' );
+	}
+
+	function printLs(args) {
+		var longForm = false;
+		var target   = '.';
+		args.forEach(
+			function (arg) {
+				if (arg.indexOf( '-' ) === 0) {
+					longForm = arg.indexOf( 'l' ) !== -1;
+				} else {
+					target = arg;
+				}
+			}
+		);
+
+		var targetPath = normalizePath( target );
+		var file       = findFile( targetPath );
+		if (file) {
+			if (file.type === 'symlink' && ! longForm && isDirectory( targetPath )) {
+				printDirectoryEntries( targetPath, longForm );
+				return;
+			}
+			appendLine( formatEntryName( file.path.split( '/' ).pop(), file.type, longForm, file ) );
+			return;
+		}
+		file = findFile( resolvePathForLookup( targetPath ) );
+		if (file && ! isDirectory( targetPath )) {
+			appendLine( formatEntryName( targetPath.split( '/' ).pop(), file.type, longForm, file ) );
+			return;
+		}
+		if ( ! isDirectory( targetPath )) {
+			appendLine( 'ls: ' + target + ': No such file or directory', 'is-error' );
+			return;
+		}
+
+		printDirectoryEntries( targetPath, longForm );
+	}
+
+	function printDirectoryEntries(targetPath, longForm) {
+		var entries = directoryEntries( targetPath );
+		if ( ! entries.length) {
+			appendLine( '(empty)', 'is-muted' );
+			return;
+		}
+		if (longForm) {
+			entries.forEach(
+				function (entry) {
+					appendLine( formatEntryName( entry.name, entry.type, true, entry.file ) );
+				}
+			);
+		} else {
+			appendLine(
+				entries.map(
+					function (entry) {
+						return entry.type === 'directory' ? entry.name + '/' : entry.name;
+					}
+				).join( '  ' )
+			);
+		}
+		if (checkout.truncated) {
+			appendLine( 'Preview is limited to the first ' + checkout.path_count + ' paths.', 'is-muted' );
+		}
+	}
+
+	function formatEntryName(name, type, longForm, file) {
+		if ( ! longForm) {
+			return type === 'directory' ? name + '/' : name;
+		}
+		var mode = type === 'directory' ? 'drwxr-xr-x' : (type === 'symlink' ? 'lrwxrwxrwx' : '-rw-r--r--');
+		var size = file && file.size !== undefined ? String( file.size ) : '-';
+		while (size.length < 7) {
+			size = ' ' + size;
+		}
+		if (type === 'symlink' && file && file.content) {
+			return mode + ' ' + size + ' ' + name + ' -> ' + file.content;
+		}
+		return mode + ' ' + size + ' ' + (type === 'directory' ? name + '/' : name);
+	}
+
+	function changeDirectory(path) {
+		if (path === checkoutDir || path === '~/' + checkoutDir) {
+			cwd = '/';
+			updatePrompt();
+			return;
+		}
+
+		var next = normalizePath( path );
+		if ( ! isDirectory( next )) {
+			appendLine( 'cd: ' + path + ': No such directory', 'is-error' );
+			return;
+		}
+		cwd = next;
+		updatePrompt();
+	}
+
+	function printCat(path) {
+		if ( ! path) {
+			appendLine( 'cat: missing file operand', 'is-error' );
+			return;
+		}
+		var targetPath = normalizePath( path );
+		var file       = findFile( targetPath );
+		if (file && file.type === 'symlink') {
+			file = findFile( resolvePathForLookup( targetPath ) ) || file;
+		} else if ( ! file) {
+			file = findFile( resolvePathForLookup( targetPath ) );
+		}
+		if ( ! file) {
+			appendLine( 'cat: ' + path + ': No such file', 'is-error' );
+			return;
+		}
+		if (file.type === 'symlink') {
+			appendLine( file.content || '(symlink target unavailable)' );
+			return;
+		}
+		if (file.content === undefined) {
+			appendLine( 'Preview content for this file is not loaded in the shell.', 'is-warning' );
+			appendLine( 'Try: cat ' + sampleCatPath(), 'is-muted' );
+			return;
+		}
+		String( file.content ).split( /\r\n|\n|\r/ ).forEach(
+			function (line) {
+				appendLine( line );
+			}
+		);
+	}
+
+	function printTree(path) {
+		var root = normalizePath( path );
+		if ( ! isDirectory( root )) {
+			appendLine( 'tree: ' + path + ': No such directory', 'is-error' );
+			return;
+		}
+		appendLine( root === '/' ? '.' : root.replace( /^\//, '' ) );
+		printTreeChildren( root, '', 0 );
+		if (checkout.truncated) {
+			appendLine( 'Preview is limited; clone or pull for the full tree.', 'is-muted' );
+		}
+	}
+
+	function printTreeChildren(path, indent, depth) {
+		if (depth > 2) {
+			return;
+		}
+		var entries = directoryEntries( path );
+		entries.slice( 0, 18 ).forEach(
+			function (entry, index) {
+				var marker = index === entries.length - 1 ? '`-- ' : '|-- ';
+				appendLine( indent + marker + (entry.type === 'directory' ? entry.name + '/' : entry.name) );
+				if (entry.type === 'directory') {
+					printTreeChildren( joinPath( path, entry.name ), indent + (index === entries.length - 1 ? '    ' : '|   '), depth + 1 );
+				}
+			}
+		);
+	}
+
+	function printGit(args) {
+		var subcommand = args[0] || '';
+		if (subcommand === 'status') {
+			appendLine( 'On branch trunk' );
+			if (progress.state === 'done') {
+				appendLine( 'Your branch is up to date with origin/trunk.', 'is-success' );
+				appendLine( 'nothing to commit, working tree clean' );
+			} else if (progress.state === 'failed') {
+				appendLine( 'remote: import failed: ' + progress.message, 'is-error' );
+			} else {
+				appendLine( 'remote: preparing repository (' + progress.percent + '%)', 'is-warning' );
+				appendLine( progress.processed + ' / ' + progress.total + ' content items imported' );
+			}
+		} else if (subcommand === 'log') {
+			printGitLog();
+		} else if (subcommand === 'remote') {
+			appendLine( 'origin  ' + remoteUrl + ' (fetch)' );
+			appendLine( 'origin  ' + remoteUrl + ' (push)' );
+		} else if (subcommand === 'branch') {
+			appendLine( '* trunk' );
+		} else if (subcommand === 'pull') {
+			if (progress.state === 'done') {
+				appendLine( 'From ' + remoteUrl );
+				appendLine( ' * branch            trunk      -> FETCH_HEAD' );
+				appendLine( 'Already up to date.', 'is-success' );
+				appendLine( 'In your real terminal, `git pull` refreshes this checkout from WordPress.', 'is-muted' );
+			} else {
+				appendLine( 'Repository is still preparing. Try again shortly.', 'is-warning' );
+			}
+		} else if (subcommand === 'add') {
+			appendLine( 'Staged in emulator only: ' + (args.slice( 1 ).join( ' ' ) || '.') );
+			appendLine( 'In your real terminal, `git add` stages file edits before committing.', 'is-muted' );
+		} else if (subcommand === 'commit') {
+			printGitCommit( args.slice( 1 ) );
+		} else if (subcommand === 'push') {
+			printGitPush();
+		} else if (subcommand === 'clone') {
+			appendLine( "Cloning into '" + (args[2] || checkoutDir) + "'..." );
+			appendLine( 'remote: WP Origin at ' + remoteUrl );
+			appendLine( 'Receiving objects: ' + Math.max( 1, checkout.files.length ) );
+		} else if (subcommand === 'checkout' && args[1] === 'trunk') {
+			appendLine( 'Already on trunk' );
+		} else if (subcommand === 'show' && args[1] && args[1].indexOf( 'HEAD:' ) === 0) {
+			printCat( args[1].replace( /^HEAD:/, '' ) );
+		} else if (subcommand === 'diff') {
+			appendLine( '(no local changes)', 'is-muted' );
+		} else {
+			appendLine( 'git: supported here: status, log, remote, branch, pull, add, commit, push, clone, checkout, show, diff', 'is-muted' );
+		}
+	}
+
+	function printGitCommit(args) {
+		var message = '(no message)';
+		for (var i = 0; i < args.length; i++) {
+			if (args[i] === '-m' && args[i + 1]) {
+				message = args[i + 1].replace( /^['"]|['"]$/g, '' );
+				break;
+			}
+		}
+
+		appendLine( '[trunk emulated] ' + message );
+		appendLine( ' 1 file changed, 4 insertions(+), 1 deletion(-)' );
+		appendLine( 'This emulator does not create commits. In your real terminal, `git commit` records local file edits before `git push` sends them to WordPress.', 'is-muted' );
+	}
+
+	function printGitPush() {
+		if (progress.state !== 'done') {
+			appendLine( 'remote: WP Origin is still preparing the repository.', 'is-warning' );
+			appendLine( 'Real pushes are accepted after the import reaches 100%.', 'is-muted' );
+			return;
+		}
+
+		appendLine( 'Enumerating objects: 5, done.' );
+		appendLine( 'Writing objects: 100% (3/3), 412 bytes | 412.00 KiB/s, done.' );
+		appendLine( 'remote: WP Origin would validate the pushed files, check permissions, and apply supported changes through WordPress.', 'is-success' );
+		appendLine( 'To actually push changes, clone the URL below, edit files locally, then run `git push origin trunk` in your real terminal.', 'is-muted' );
+	}
+
+	function printGitLog() {
+		var commits = progress.commits || [];
+		if ( ! commits.length) {
+			appendLine( 'No commits yet. Import is still warming up.', 'is-warning' );
+			return;
+		}
+		commits.forEach(
+			function (commit) {
+				appendLine( commit.oid + ' ' + commit.subject );
+			}
+		);
+	}
+
+	function normalizePath(path) {
+		path = path || '.';
+		if (path === '.' || path === './') {
+			return cwd;
+		}
+		if (path === '~' || path === '~/' + checkoutDir || path === '/' + checkoutDir) {
+			return '/';
+		}
+		if (path.indexOf( '~/' + checkoutDir + '/' ) === 0) {
+			path = '/' + path.substring( checkoutDir.length + 3 );
+		}
+		if (path.indexOf( '/' + checkoutDir + '/' ) === 0) {
+			path = path.substring( checkoutDir.length + 1 );
+		}
+
+		var segments = path.charAt( 0 ) === '/' ? [] : cwd.split( '/' ).filter( Boolean );
+		path.split( '/' ).forEach(
+			function (segment) {
+				if ( ! segment || segment === '.') {
+					return;
+				}
+				if (segment === '..') {
+					segments.pop();
+				} else {
+					segments.push( segment );
+				}
+			}
+		);
+		return '/' + segments.join( '/' );
+	}
+
+	function pathKey(path) {
+		return String( path || '' ).replace( /^\/+/, '' ).replace( /\/+$/, '' );
+	}
+
+	function joinPath(base, name) {
+		return (base === '/' ? '' : base) + '/' + name;
+	}
+
+	function findFile(path) {
+		var key = pathKey( path );
+		for (var i = 0; i < checkout.files.length; i++) {
+			if (checkout.files[i].path === key) {
+				return checkout.files[i];
+			}
+		}
+		return null;
+	}
+
+	function isDirectory(path) {
+		var key = pathKey( resolvePathForLookup( path ) );
+		if ( ! key) {
+			return true;
+		}
+		var prefix = key + '/';
+		for (var i = 0; i < checkout.files.length; i++) {
+			if (checkout.files[i].path.indexOf( prefix ) === 0) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	function directoryEntries(path) {
+		var key    = pathKey( resolvePathForLookup( path ) );
+		var prefix = key ? key + '/' : '';
+		var seen   = {};
+		checkout.files.forEach(
+			function (file) {
+				if (prefix && file.path.indexOf( prefix ) !== 0) {
+					return;
+				}
+				if ( ! prefix && file.path.indexOf( '/' ) === -1) {
+					seen[file.path] = { name: file.path, type: file.type, file: file };
+					return;
+				}
+				var rest = prefix ? file.path.substring( prefix.length ) : file.path;
+				if ( ! rest) {
+					return;
+				}
+				var slashAt = rest.indexOf( '/' );
+				if (slashAt === -1) {
+					seen[rest] = { name: rest, type: file.type, file: file };
+				} else {
+					var directory = rest.substring( 0, slashAt );
+					if ( ! seen[directory]) {
+						seen[directory] = { name: directory, type: 'directory' };
+					}
+				}
+			}
+		);
+
+		return Object.keys( seen ).sort().map(
+			function (name) {
+				return seen[name];
+			}
+		);
+	}
+
+	function resolvePathForLookup(path) {
+		var segments = pathKey( path ).split( '/' ).filter( Boolean );
+		var resolved = [];
+		for (var i = 0; i < segments.length; i++) {
+			resolved.push( segments[i] );
+			var file = findFile( '/' + resolved.join( '/' ) );
+			if (file && file.type === 'symlink' && file.content) {
+				resolved = pathKey( normalizeSymlinkTarget( file.path, file.content ) ).split( '/' ).filter( Boolean );
+			}
+		}
+
+		return '/' + resolved.join( '/' );
+	}
+
+	function normalizeSymlinkTarget(filePath, target) {
+		var parent = pathKey( filePath ).split( '/' );
+		parent.pop();
+		return normalizePathFromBase( '/' + parent.join( '/' ), target );
+	}
+
+	function normalizePathFromBase(base, path) {
+		var segments = path.charAt( 0 ) === '/' ? [] : pathKey( base ).split( '/' ).filter( Boolean );
+		path.split( '/' ).forEach(
+			function (segment) {
+				if ( ! segment || segment === '.') {
+					return;
+				}
+				if (segment === '..') {
+					segments.pop();
+				} else {
+					segments.push( segment );
+				}
+			}
+		);
+		return '/' + segments.join( '/' );
+	}
+
+	function sampleCatPath() {
+		var preferred = ['post/hello-world.md', 'page/sample-page.md', 'AGENTS.md'];
+		for (var i = 0; i < preferred.length; i++) {
+			if (findFile( '/' + preferred[i] ) && findFile( '/' + preferred[i] ).content !== undefined) {
+				return preferred[i];
+			}
+		}
+		for (var j = 0; j < checkout.files.length; j++) {
+			if (checkout.files[j].content !== undefined && checkout.files[j].type === 'file') {
+				return checkout.files[j].path;
+			}
+		}
+		return 'post/hello-world.md';
+	}
+
+	document.getElementById( 'wp-origin-retry' ).addEventListener(
+		'click',
+		function () {
+			appendLine( '' );
+			appendPrompt( 'wp-origin seed retry' );
+			appendLine( 'Resetting the repository import...', 'is-warning' );
+			fetch(
+				retryUrl,
+				{
+					method: 'POST',
+					credentials: 'same-origin',
+					headers: { 'X-WP-Nonce': nonce }
+				}
+			).then(
+				function () {
+					hasAnnouncedReady = false;
+					setTimeout( poll, 1000 );
+				}
+			);
+		}
+	);
+
+	function copyText(value, button) {
+		function markCopied() {
+			var originalText   = button.textContent;
+			button.textContent = 'Copied';
+			button.classList.add( 'is-copied' );
+			setTimeout(
+				function () {
+					button.textContent = originalText;
+					button.classList.remove( 'is-copied' );
+				},
+				1400
+			);
+		}
+
+		if (navigator.clipboard && navigator.clipboard.writeText) {
+			navigator.clipboard.writeText( value ).then( markCopied );
+			return;
+		}
+
+		var textarea   = document.createElement( 'textarea' );
+		textarea.value = value;
+		textarea.setAttribute( 'readonly', 'readonly' );
+		textarea.style.position = 'absolute';
+		textarea.style.left     = '-9999px';
+		document.body.appendChild( textarea );
+		textarea.select();
+		document.execCommand( 'copy' );
+		document.body.removeChild( textarea );
+		markCopied();
+	}
+
+	Array.prototype.slice.call( document.querySelectorAll( '.wp-origin-copy-button' ) ).forEach(
+		function (button) {
+			button.addEventListener(
+				'click',
+				function () {
+					copyText( button.getAttribute( 'data-copy-value' ) || '', button );
+				}
+			);
+		}
+	);
+
+	inputEl.addEventListener(
+		'keydown',
+		function (event) {
+			if (event.key === 'Enter') {
+				runCommand( inputEl.value );
+				inputEl.value = '';
+			} else if (event.key === 'ArrowUp') {
+				if (history.length) {
+					historyIndex  = Math.max( 0, historyIndex - 1 );
+					inputEl.value = history[historyIndex] || '';
+					event.preventDefault();
+				}
+			} else if (event.key === 'ArrowDown') {
+				if (history.length) {
+					historyIndex  = Math.min( history.length, historyIndex + 1 );
+					inputEl.value = history[historyIndex] || '';
+					event.preventDefault();
+				}
+			}
+		}
+	);
+
+	Array.prototype.slice.call( document.querySelectorAll( '[data-wp-origin-command]' ) ).forEach(
+		function (button) {
+			button.addEventListener(
+				'click',
+				function () {
+					runCommand( button.getAttribute( 'data-wp-origin-command' ) );
+					inputEl.focus();
+				}
+			);
+		}
+	);
+
+	render( progress );
+	updatePrompt();
+	bootTranscript();
+	poll();
+}());

--- a/plugins/wp-origin/class-wp-origin-admin.php
+++ b/plugins/wp-origin/class-wp-origin-admin.php
@@ -5,10 +5,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Admin UI for WP Origin: a Tools → "WP Origin" page that shows the
- * seeder's progress with a live progress bar, plus a small REST
- * endpoint the page polls for status. The endpoint also doubles as a
- * way for tests to wait for `state === done` programmatically.
+ * Admin UI for WP Origin.
  */
 class WP_Origin_Admin {
 
@@ -16,9 +13,11 @@ class WP_Origin_Admin {
 	const REST_NAMESPACE = 'wp-origin/v1';
 	const STATUS_ROUTE   = '/seed-status';
 	const RETRY_ROUTE    = '/seed-retry';
+	const ASSET_VERSION  = '0.1.0';
 
 	public static function bootstrap() {
 		add_action( 'admin_menu', array( __CLASS__, 'register_menu' ) );
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
 		add_action( 'rest_api_init', array( __CLASS__, 'register_rest_routes' ) );
 	}
 
@@ -29,6 +28,27 @@ class WP_Origin_Admin {
 			'manage_options',
 			self::PAGE_SLUG,
 			array( __CLASS__, 'render_page' )
+		);
+	}
+
+	public static function enqueue_assets( $hook_suffix ) {
+		if ( 'tools_page_' . self::PAGE_SLUG !== $hook_suffix ) {
+			return;
+		}
+
+		$plugin_file = defined( 'WP_ORIGIN_PLUGIN_FILE' ) ? WP_ORIGIN_PLUGIN_FILE : __FILE__;
+		wp_enqueue_style(
+			'wp-origin-admin-shell',
+			plugins_url( 'admin-shell.css', $plugin_file ),
+			array(),
+			self::ASSET_VERSION
+		);
+		wp_enqueue_script(
+			'wp-origin-admin-shell',
+			plugins_url( 'admin-shell.js', $plugin_file ),
+			array(),
+			self::ASSET_VERSION,
+			true
 		);
 	}
 
@@ -58,12 +78,6 @@ class WP_Origin_Admin {
 	}
 
 	public static function rest_status() {
-		// Each poll drives the seeder for up to ~1.5 seconds before
-		// returning. With the demo's 0-second batch budget that's many
-		// batches per poll, so the progress bar always reflects fresh
-		// work — instead of stalling for one tick per 2-second JS
-		// interval. The transient lock inside tick() makes repeated
-		// calls safe.
 		WP_Origin_Seeder::drive( 1.5 );
 
 		return rest_ensure_response( WP_Origin_Seeder::get_progress() );
@@ -103,10 +117,9 @@ class WP_Origin_Admin {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
 		}
-		// Drive the seeder forward for ~1.5s before painting the page,
-		// so the user never lands on "Queued. Waiting for the first
-		// cron tick." — by the time they see the progress bar it's
-		// already moving and several commits exist.
+
+		// Drive the seeder before painting so the first screen already
+		// has real checkout state whenever the host can do quick work.
 		WP_Origin_Seeder::drive( 1.5 );
 		$progress   = WP_Origin_Seeder::get_progress();
 		$nonce      = wp_create_nonce( 'wp_rest' );
@@ -134,275 +147,126 @@ class WP_Origin_Admin {
 		$copy_remote_url_label = __( 'Copy remote URL', 'wp-origin' );
 		$copy_clone_label      = __( 'Copy clone command', 'wp-origin' );
 		$copy_setup_label      = __( 'Copy setup command', 'wp-origin' );
+		$site_name             = get_bloginfo( 'name' );
+		$host                  = wp_parse_url( home_url(), PHP_URL_HOST );
+		if ( ! is_string( $host ) ) {
+			$host = '';
+		}
+		$config = array(
+			'nonce'           => $nonce,
+			'statusUrl'       => $status_url,
+			'retryUrl'        => $retry_url,
+			'remoteUrl'       => $git_url,
+			'cloneCommand'    => $clone_command,
+			'checkoutDir'     => $site_slug,
+			'initialProgress' => $progress,
+		);
 		?>
-		<div class="wrap" id="wp-origin-admin">
-			<style>
-				#wp-origin-admin .wp-origin-wide-table {
-					max-width: none;
-					width: 100%;
-				}
+		<div class="wrap wp-origin-shell-page" id="wp-origin-admin">
+			<div class="wp-origin-shell-frame">
+				<div class="wp-origin-shell-header">
+					<div class="wp-origin-shell-title">
+						<h1>WP Origin</h1>
+						<p><?php echo esc_html( $site_name ); ?> as a Git checkout, live from WordPress.</p>
+					</div>
+					<div class="wp-origin-state-pill" id="wp-origin-state-pill">
+						<span class="wp-origin-state-dot" aria-hidden="true"></span>
+						<span id="wp-origin-state"><?php echo esc_html( $progress['state'] ); ?></span>
+					</div>
+				</div>
 
-				#wp-origin-admin .wp-origin-wide-table th {
-					width: 220px;
-				}
+				<div class="wp-origin-emulator-note">
+					<strong>Command emulator.</strong> This terminal is a guided preview of commands you can run in your real terminal after cloning WP Origin. It does not execute a server shell or write changes to the site.
+				</div>
 
-				#wp-origin-admin .wp-origin-copy-field {
-					align-items: center;
-					display: flex;
-					gap: 8px;
-					width: 100%;
-				}
+				<div class="wp-origin-terminal" role="application" aria-label="WP Origin command emulator">
+					<div class="wp-origin-terminal-bar">
+						<div class="wp-origin-terminal-controls" aria-hidden="true">
+							<span class="wp-origin-terminal-dot"></span>
+							<span class="wp-origin-terminal-dot"></span>
+							<span class="wp-origin-terminal-dot"></span>
+						</div>
+						<div id="wp-origin-terminal-title">emulator:~/<?php echo esc_html( $site_slug ); ?></div>
+						<div><?php echo esc_html( $host ); ?></div>
+					</div>
+					<div class="wp-origin-terminal-body">
+						<div class="wp-origin-terminal-output" id="wp-origin-terminal-output" aria-live="polite"></div>
+						<label class="wp-origin-terminal-input-row" for="wp-origin-terminal-input">
+							<span class="wp-origin-prompt-chip">
+								<span class="wp-origin-prompt-user">wp-origin</span>
+								<span class="wp-origin-prompt-mark">:</span>
+								<span class="wp-origin-prompt-path" id="wp-origin-prompt-cwd">~/<?php echo esc_html( $site_slug ); ?></span>
+								<span class="wp-origin-prompt-mark">$</span>
+							</span>
+							<input class="wp-origin-terminal-input" id="wp-origin-terminal-input" type="text" autocomplete="off" spellcheck="false" placeholder="Type an emulated command" />
+						</label>
+					</div>
+				</div>
 
-				#wp-origin-admin .wp-origin-copy-field input {
-					flex: 1;
-					max-width: none;
-					min-width: 0;
-					width: 100%;
-				}
+				<div class="wp-origin-panel wp-origin-copy-panel">
+					<h2>Use In Your Terminal</h2>
+					<p>Use this Git remote with your WordPress username. When Git asks for a password, use an Application Password.</p>
+					<p>
+						<a href="<?php echo esc_url( admin_url( 'profile.php#application-passwords-section' ) ); ?>">Create or manage Application Passwords</a>
+					</p>
+					<table class="widefat striped wp-origin-copy-table">
+						<tbody>
+							<tr>
+								<th scope="row">Remote URL</th>
+								<td><code><?php echo esc_html( $git_url ); ?></code></td>
+								<td><button type="button" class="button wp-origin-copy-button" data-copy-value="<?php echo esc_attr( $git_url ); ?>" aria-label="<?php echo esc_attr( $copy_remote_url_label ); ?>">Copy</button></td>
+							</tr>
+							<tr>
+								<th scope="row">Clone command</th>
+								<td><code><?php echo esc_html( $clone_command ); ?></code></td>
+								<td><button type="button" class="button wp-origin-copy-button" data-copy-value="<?php echo esc_attr( $clone_command ); ?>" aria-label="<?php echo esc_attr( $copy_clone_label ); ?>">Copy</button></td>
+							</tr>
+							<tr>
+								<th scope="row">Branch</th>
+								<td><code><?php echo esc_html( WP_Origin_Plugin::DEFAULT_BRANCH ); ?></code></td>
+								<td><button type="button" class="button wp-origin-copy-button" data-copy-value="<?php echo esc_attr( WP_Origin_Plugin::DEFAULT_BRANCH ); ?>">Copy</button></td>
+							</tr>
+							<tr>
+								<th scope="row">Connect an existing repo</th>
+								<td><code><?php echo esc_html( $existing_repo_command ); ?></code></td>
+								<td><button type="button" class="button wp-origin-copy-button" data-copy-value="<?php echo esc_attr( $existing_repo_command ); ?>" aria-label="<?php echo esc_attr( $copy_setup_label ); ?>">Copy</button></td>
+							</tr>
+							<tr>
+								<th scope="row">Import status API</th>
+								<td><code><?php echo esc_html( $status_url ); ?></code></td>
+								<td><button type="button" class="button wp-origin-copy-button" data-copy-value="<?php echo esc_attr( $status_url ); ?>">Copy</button></td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
 
-				#wp-origin-admin .wp-origin-copy {
-					align-items: center;
-					display: inline-flex;
-					flex: 0 0 auto;
-					height: 30px;
-					justify-content: center;
-					min-width: 34px;
-					padding: 0;
-					width: 34px;
-				}
+				<div class="wp-origin-panel wp-origin-commit-panel">
+					<h2>Commit History</h2>
+					<ul class="wp-origin-commit-list" id="wp-origin-commit-list"></ul>
+				</div>
 
-				#wp-origin-admin .wp-origin-copy .dashicons {
-					font-size: 18px;
-					height: 18px;
-					line-height: 18px;
-					width: 18px;
-				}
-
-				#wp-origin-admin #wp-origin-commits {
-					margin-left: 0;
-					width: 100%;
-				}
-			</style>
-			<h1><?php esc_html_e( 'WP Origin', 'wp-origin' ); ?></h1>
-			<p><?php esc_html_e( 'Clone, push, and pull the site as a Git repository.', 'wp-origin' ); ?></p>
-
-			<h2><?php esc_html_e( 'Repository setup', 'wp-origin' ); ?></h2>
-			<p><?php esc_html_e( 'Use this Git remote with your WordPress username. When Git asks for a password, use an Application Password.', 'wp-origin' ); ?></p>
-			<p>
-				<a href="<?php echo esc_url( admin_url( 'profile.php#application-passwords-section' ) ); ?>"><?php esc_html_e( 'Create or manage Application Passwords', 'wp-origin' ); ?></a>
-			</p>
-
-			<table class="widefat striped wp-origin-wide-table">
-				<tbody>
-					<tr>
-						<th scope="row"><?php esc_html_e( 'Remote URL', 'wp-origin' ); ?></th>
-						<td>
-							<div class="wp-origin-copy-field">
-								<input type="text" class="regular-text code" id="wp-origin-remote-url" readonly value="<?php echo esc_attr( $git_url ); ?>">
-								<button type="button" class="button wp-origin-copy" data-copy-target="wp-origin-remote-url" aria-label="<?php echo esc_attr( $copy_remote_url_label ); ?>" title="<?php echo esc_attr( $copy_remote_url_label ); ?>">
-									<span class="dashicons dashicons-clipboard" aria-hidden="true"></span>
-								</button>
-							</div>
-						</td>
-					</tr>
-					<tr>
-						<th scope="row"><?php esc_html_e( 'Branch', 'wp-origin' ); ?></th>
-						<td>
-							<div class="wp-origin-copy-field">
-								<input type="text" class="regular-text code" id="wp-origin-branch" readonly value="<?php echo esc_attr( WP_Origin_Plugin::DEFAULT_BRANCH ); ?>">
-							</div>
-						</td>
-					</tr>
-					<tr>
-						<th scope="row"><?php esc_html_e( 'Clone a new checkout', 'wp-origin' ); ?></th>
-						<td>
-							<div class="wp-origin-copy-field">
-								<input type="text" class="regular-text code" id="wp-origin-clone-command" readonly value="<?php echo esc_attr( $clone_command ); ?>">
-								<button type="button" class="button wp-origin-copy" data-copy-target="wp-origin-clone-command" aria-label="<?php echo esc_attr( $copy_clone_label ); ?>" title="<?php echo esc_attr( $copy_clone_label ); ?>">
-									<span class="dashicons dashicons-clipboard" aria-hidden="true"></span>
-								</button>
-							</div>
-						</td>
-					</tr>
-					<tr>
-						<th scope="row"><?php esc_html_e( 'Connect an existing repo', 'wp-origin' ); ?></th>
-						<td>
-							<div class="wp-origin-copy-field">
-								<input type="text" class="regular-text code" id="wp-origin-existing-repo-command" readonly value="<?php echo esc_attr( $existing_repo_command ); ?>">
-								<button type="button" class="button wp-origin-copy" data-copy-target="wp-origin-existing-repo-command" aria-label="<?php echo esc_attr( $copy_setup_label ); ?>" title="<?php echo esc_attr( $copy_setup_label ); ?>">
-									<span class="dashicons dashicons-clipboard" aria-hidden="true"></span>
-								</button>
-							</div>
-						</td>
-					</tr>
-				</tbody>
-			</table>
-
-			<h2><?php esc_html_e( 'Recent commits', 'wp-origin' ); ?></h2>
-			<ul id="wp-origin-commits">
-				<?php if ( empty( $progress['commits'] ) ) : ?>
-					<li><?php esc_html_e( 'No commits yet.', 'wp-origin' ); ?></li>
-				<?php else : ?>
-					<?php foreach ( $progress['commits'] as $commit ) : ?>
-						<li><code><?php echo esc_html( $commit['oid'] ); ?></code> <?php echo esc_html( $commit['subject'] ); ?></li>
-					<?php endforeach; ?>
-				<?php endif; ?>
-			</ul>
-
-			<h2><?php esc_html_e( 'Import status', 'wp-origin' ); ?></h2>
-			<p><?php esc_html_e( 'Status of the initial Markdown import.', 'wp-origin' ); ?></p>
-
-			<table class="widefat striped wp-origin-wide-table">
-				<tbody>
-					<tr><th scope="row"><?php esc_html_e( 'State', 'wp-origin' ); ?></th><td><code id="wp-origin-state"><?php echo esc_html( $progress['state'] ); ?></code></td></tr>
-					<tr>
-						<th scope="row"><?php esc_html_e( 'Progress', 'wp-origin' ); ?></th>
-						<td>
-							<div style="background:#eee;border:1px solid #ccd0d4;height:18px;width:100%;border-radius:3px;overflow:hidden;">
-								<div id="wp-origin-bar" style="background:#2271b1;height:100%;width:<?php echo intval( $progress['percent'] ); ?>%;transition:width 0.4s;"></div>
-							</div>
-							<p><span id="wp-origin-percent"><?php echo intval( $progress['percent'] ); ?></span>%
-								— <span id="wp-origin-counts"><?php echo intval( $progress['processed'] ); ?> / <?php echo intval( $progress['total'] ); ?> <?php echo esc_html( _n( 'post', 'posts', intval( $progress['total'] ), 'wp-origin' ) ); ?></span></p>
-						</td>
-					</tr>
-					<tr><th scope="row"><?php esc_html_e( 'Last update', 'wp-origin' ); ?></th><td id="wp-origin-message"><?php echo esc_html( $progress['message'] ); ?></td></tr>
-				</tbody>
-			</table>
-
-			<p>
-				<button type="button" class="button" id="wp-origin-retry"><?php esc_html_e( 'Retry import', 'wp-origin' ); ?></button>
-			</p>
+				<div class="wp-origin-panel wp-origin-import-panel">
+					<div class="wp-origin-import-header">
+						<h2>Import Status</h2>
+						<div class="wp-origin-retry-row">
+							<span>Seed state: <code id="wp-origin-state-copy"><?php echo esc_html( $progress['state'] ); ?></code></span>
+							<button type="button" class="button" id="wp-origin-retry">Retry import</button>
+						</div>
+					</div>
+					<div class="wp-origin-progress-track">
+						<div class="wp-origin-progress-bar" id="wp-origin-bar" style="width: <?php echo intval( $progress['percent'] ); ?>%;"></div>
+					</div>
+					<div class="wp-origin-progress-meta">
+						<span><span id="wp-origin-percent"><?php echo intval( $progress['percent'] ); ?></span>%</span>
+						<span><span id="wp-origin-counts"><?php echo intval( $progress['processed'] ); ?> / <?php echo intval( $progress['total'] ); ?></span> items</span>
+					</div>
+					<p class="wp-origin-message" id="wp-origin-message"><?php echo esc_html( $progress['message'] ); ?></p>
+				</div>
+			</div>
+			<script>
+			window.wpOriginAdminShell = <?php echo wp_json_encode( $config ); ?>;
+			</script>
 		</div>
-
-		<script>
-		(function () {
-			var nonce = <?php echo wp_json_encode( $nonce ); ?>;
-			var statusUrl = <?php echo wp_json_encode( $status_url ); ?>;
-			var retryUrl = <?php echo wp_json_encode( $retry_url ); ?>;
-			var noCommitsText = <?php echo wp_json_encode( __( 'No commits yet.', 'wp-origin' ) ); ?>;
-			var copiedText = <?php echo wp_json_encode( __( 'Copied', 'wp-origin' ) ); ?>;
-			var postText = <?php echo wp_json_encode( __( 'post', 'wp-origin' ) ); ?>;
-			var postsText = <?php echo wp_json_encode( __( 'posts', 'wp-origin' ) ); ?>;
-			var stateEl = document.getElementById('wp-origin-state');
-			var barEl = document.getElementById('wp-origin-bar');
-			var percentEl = document.getElementById('wp-origin-percent');
-			var countsEl = document.getElementById('wp-origin-counts');
-			var messageEl = document.getElementById('wp-origin-message');
-			var commitsEl = document.getElementById('wp-origin-commits');
-
-			function render(data) {
-				stateEl.textContent = data.state;
-				barEl.style.width = data.percent + '%';
-				percentEl.textContent = data.percent;
-				countsEl.textContent = data.processed + ' / ' + data.total + ' ' + (parseInt(data.total, 10) === 1 ? postText : postsText);
-				messageEl.textContent = data.message;
-				renderCommits(data.commits || []);
-			}
-
-			function renderCommits(commits) {
-				var index;
-				var item;
-				var oid;
-
-				commitsEl.textContent = '';
-				if (!commits.length) {
-					item = document.createElement('li');
-					item.textContent = noCommitsText;
-					commitsEl.appendChild(item);
-					return;
-				}
-
-				for (index = 0; index < commits.length; index++) {
-					item = document.createElement('li');
-					oid = document.createElement('code');
-					oid.textContent = commits[index].oid;
-					item.appendChild(oid);
-					item.appendChild(document.createTextNode(' ' + commits[index].subject));
-					commitsEl.appendChild(item);
-				}
-			}
-
-			function getCopyText(targetId) {
-				var target = document.getElementById(targetId);
-				if (!target) {
-					return '';
-				}
-
-				return 'value' in target ? target.value : target.textContent;
-			}
-
-			function fallbackCopyText(text) {
-				var textarea;
-
-				textarea = document.createElement('textarea');
-				textarea.value = text;
-				textarea.setAttribute('readonly', 'readonly');
-				textarea.style.position = 'fixed';
-				textarea.style.top = '-1000px';
-				document.body.appendChild(textarea);
-				textarea.select();
-				document.execCommand('copy');
-				document.body.removeChild(textarea);
-
-				return Promise.resolve();
-			}
-
-			function copyText(text) {
-				if (navigator.clipboard && navigator.clipboard.writeText) {
-					return navigator.clipboard.writeText(text).catch(function () {
-						return fallbackCopyText(text);
-					});
-				}
-
-				return fallbackCopyText(text);
-			}
-
-			function poll() {
-				fetch(statusUrl, { credentials: 'same-origin', headers: { 'X-WP-Nonce': nonce } })
-					.then(function (r) { return r.json(); })
-					.then(function (data) {
-						render(data);
-						if (data.state !== 'done' && data.state !== 'failed') {
-							setTimeout(poll, 2000);
-						}
-					})
-					.catch(function () { setTimeout(poll, 5000); });
-			}
-
-			Array.prototype.forEach.call(document.querySelectorAll('.wp-origin-copy'), function (button) {
-				button.addEventListener('click', function () {
-					var icon = button.querySelector('.dashicons');
-					var originalIconClass = icon ? icon.className : '';
-					var originalLabel = button.getAttribute('aria-label');
-					var originalTitle = button.getAttribute('title');
-					copyText(getCopyText(button.getAttribute('data-copy-target'))).then(function () {
-						if (icon) {
-							icon.className = 'dashicons dashicons-yes';
-						}
-						button.setAttribute('aria-label', copiedText);
-						button.setAttribute('title', copiedText);
-						setTimeout(function () {
-							if (icon) {
-								icon.className = originalIconClass;
-							}
-							button.setAttribute('aria-label', originalLabel);
-							button.setAttribute('title', originalTitle);
-						}, 1500);
-					});
-				});
-			});
-
-			document.getElementById('wp-origin-retry').addEventListener('click', function () {
-				fetch(retryUrl, {
-					method: 'POST',
-					credentials: 'same-origin',
-					headers: { 'X-WP-Nonce': nonce }
-				}).then(function () { setTimeout(poll, 1000); });
-			});
-
-			poll();
-		}());
-		</script>
 		<?php
 	}
 }

--- a/plugins/wp-origin/class-wp-origin-plugin.php
+++ b/plugins/wp-origin/class-wp-origin-plugin.php
@@ -125,6 +125,16 @@ class WP_Origin_Plugin {
 		return post_type_exists( 'wp_guideline' ) && taxonomy_exists( 'wp_guideline_type' );
 	}
 
+	private static function guidelines_enabled() {
+		if ( self::guidelines_available() ) {
+			return true;
+		}
+
+		$experiments = get_option( 'gutenberg-experiments' );
+
+		return is_array( $experiments ) && ! empty( $experiments['gutenberg-guidelines'] );
+	}
+
 	private static function get_default_agent_skill_content() {
 		return <<<'SKILL'
 # WP Origin AGENTS.md
@@ -736,6 +746,10 @@ SKILL;
 	}
 
 	private static function add_default_agent_guidance_files( &$files, &$has_guideline_skills, &$agent_guide_skill_path ) {
+		if ( ! self::guidelines_enabled() ) {
+			return;
+		}
+
 		$default_skills = array(
 			self::AGENT_SKILL_SLUG => array(
 				'description' => 'Guide for coding agents working in a WP Origin checkout of a WordPress site.',
@@ -1236,6 +1250,51 @@ SKILL;
 			'AGENTS.md' => $skill_path,
 			'CLAUDE.md' => $skill_path,
 		);
+	}
+
+	public static function get_default_agent_guidance_preview_files() {
+		if ( ! self::guidelines_enabled() ) {
+			return array();
+		}
+
+		$files          = array();
+		$default_skills = array(
+			self::AGENT_SKILL_SLUG => array(
+				'description' => 'Guide for coding agents working in a WP Origin checkout of a WordPress site.',
+				'content'     => self::get_default_agent_skill_content(),
+			),
+			self::TEMPLATE_EDITOR_SKILL_SLUG => array(
+				'description' => 'Edit WP Origin block theme templates and template parts as raw Gutenberg HTML while preserving Site Editor compatibility.',
+				'content'     => self::get_default_template_editor_skill_content(),
+			),
+		);
+
+		foreach ( $default_skills as $slug => $skill ) {
+			$files[ 'wp_guideline/skills/' . $slug . '/SKILL.md' ] = array(
+				'mode'    => TreeEntry::FILE_MODE_REGULAR_NON_EXECUTABLE,
+				'content' => self::format_skill_markdown(
+					$slug,
+					$skill['description'],
+					$skill['content']
+				),
+			);
+		}
+
+		foreach ( self::get_agent_skills_directory_symlink_paths() as $path => $target ) {
+			$files[ $path ] = array(
+				'mode'    => TreeEntry::FILE_MODE_SYMBOLIC_LINK,
+				'content' => $target,
+			);
+		}
+
+		foreach ( self::get_agent_entrypoint_symlink_paths( 'wp_guideline/skills/' . self::AGENT_SKILL_SLUG . '/SKILL.md' ) as $path => $target ) {
+			$files[ $path ] = array(
+				'mode'    => TreeEntry::FILE_MODE_SYMBOLIC_LINK,
+				'content' => $target,
+			);
+		}
+
+		return $files;
 	}
 
 	public static function repository_identity( GitRepository $repository ) {

--- a/plugins/wp-origin/class-wp-origin-seeder.php
+++ b/plugins/wp-origin/class-wp-origin-seeder.php
@@ -2,6 +2,7 @@
 
 use WordPress\Git\GitRepository;
 use WordPress\Git\Model\Commit;
+use WordPress\Git\Model\TreeEntry;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -128,14 +129,14 @@ class WP_Origin_Seeder {
 		return $state ? $state : self::STATE_PENDING;
 	}
 
-	public static function get_progress() {
+	public static function get_progress( $include_checkout = true ) {
 		$progress = get_option( self::PROGRESS_OPTION, array() );
 		$state    = self::get_state();
 		$total    = isset( $progress['total'] ) ? intval( $progress['total'] ) : 0;
 		$done     = isset( $progress['processed'] ) ? intval( $progress['processed'] ) : 0;
 		$percent  = self::STATE_DONE === $state ? 100 : ( $total > 0 ? min( 99, intval( floor( $done * 100 / $total ) ) ) : 0 );
 
-		return array(
+		$response = array(
 			'state'       => $state,
 			'percent'     => $percent,
 			'processed'   => $done,
@@ -147,6 +148,11 @@ class WP_Origin_Seeder {
 			'finished_at' => isset( $progress['finished_at'] ) ? intval( $progress['finished_at'] ) : 0,
 			'commits'     => self::get_commit_log( 25 ),
 		);
+		if ( $include_checkout ) {
+			$response['checkout'] = self::get_checkout_preview();
+		}
+
+		return $response;
 	}
 
 	/**
@@ -208,12 +214,302 @@ class WP_Origin_Seeder {
 		return $commits;
 	}
 
+	/**
+	 * Return a small, safe preview of the current repository tree for
+	 * the first-run admin shell. This is intentionally bounded so the
+	 * polling endpoint stays cheap on large sites.
+	 */
+	public static function get_checkout_preview( $file_limit = 120, $content_limit = 16, $content_length = 6000 ) {
+		$preview = array(
+			'available'  => false,
+			'branch'     => 'trunk',
+			'head'       => '',
+			'files'      => array(),
+			'truncated'  => false,
+			'path_count' => 0,
+		);
+
+		try {
+			global $wpdb;
+			$table = $wpdb->prefix . WP_Origin_Plugin::TABLE_PREFIX . 'files';
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			if ( ! $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) ) {
+				return $preview;
+			}
+
+			$repository = WP_Origin_Plugin::open_repository();
+			$tip        = self::get_preview_tip( $repository );
+			if ( ! $tip ) {
+				return $preview;
+			}
+
+			$commit = $repository->read_object( $tip )->as_commit();
+			if ( Commit::is_null_hash( $commit->tree ) ) {
+				$preview['available'] = true;
+				$preview['head']      = substr( $tip, 0, 7 );
+
+				return $preview;
+			}
+
+			$files                   = array();
+			$remaining_content_slots = max( 0, intval( $content_limit ) );
+			$truncated               = false;
+			self::add_checkout_preview_priority_paths(
+				$repository,
+				$tip,
+				$files,
+				max( 1, intval( $content_length ) )
+			);
+			self::add_checkout_preview_default_guidance_files(
+				$files,
+				max( 1, intval( $content_length ) )
+			);
+			self::collect_checkout_preview_files(
+				$repository,
+				$commit->tree,
+				'',
+				$files,
+				$remaining_content_slots,
+				max( 1, intval( $file_limit ) ),
+				max( 1, intval( $content_length ) ),
+				$truncated
+			);
+
+			$preview['available']  = true;
+			$preview['head']       = substr( $tip, 0, 7 );
+			$preview['files']      = $files;
+			$preview['truncated']  = $truncated;
+			$preview['path_count'] = count( $files );
+		} catch ( Throwable $exception ) {
+			return $preview;
+		}
+
+		return $preview;
+	}
+
+	private static function get_preview_tip( GitRepository $repository ) {
+		foreach ( array( 'refs/heads/trunk', self::SEED_BRANCH ) as $ref ) {
+			try {
+				if ( ! $repository->branch_exists( $ref ) ) {
+					continue;
+				}
+				$candidate = $repository->get_branch_tip( $ref );
+			} catch ( Throwable $exception ) {
+				continue;
+			}
+			if ( is_string( $candidate ) && '' !== $candidate && ! Commit::is_null_hash( $candidate ) ) {
+				return $candidate;
+			}
+		}
+
+		return '';
+	}
+
+	private static function collect_checkout_preview_files( GitRepository $repository, $tree_hash, $prefix, &$files, &$remaining_content_slots, $file_limit, $content_length, &$truncated ) {
+		if ( count( $files ) >= $file_limit ) {
+			$truncated = true;
+
+			return;
+		}
+
+		$tree    = $repository->read_object( $tree_hash )->as_tree();
+		$entries = $tree->entries;
+		ksort( $entries );
+		foreach ( $entries as $entry ) {
+			if ( count( $files ) >= $file_limit ) {
+				$truncated = true;
+
+				return;
+			}
+
+			$path = ltrim( $prefix . '/' . $entry->name, '/' );
+			if ( self::checkout_preview_has_path( $files, $path ) ) {
+				continue;
+			}
+			if ( TreeEntry::FILE_MODE_DIRECTORY === $entry->get_mode_bucket() ) {
+				self::collect_checkout_preview_files(
+					$repository,
+					$entry->hash,
+					$path,
+					$files,
+					$remaining_content_slots,
+					$file_limit,
+					$content_length,
+					$truncated
+				);
+				continue;
+			}
+
+			if (
+				TreeEntry::FILE_MODE_REGULAR_NON_EXECUTABLE !== $entry->get_mode_bucket() &&
+				TreeEntry::FILE_MODE_REGULAR_EXECUTABLE !== $entry->get_mode_bucket() &&
+				TreeEntry::FILE_MODE_SYMBOLIC_LINK !== $entry->get_mode_bucket()
+			) {
+				continue;
+			}
+
+			$file = array(
+				'path' => $path,
+				'mode' => $entry->get_mode_bucket(),
+				'type' => TreeEntry::FILE_MODE_SYMBOLIC_LINK === $entry->get_mode_bucket() ? 'symlink' : 'file',
+			);
+
+			if ( TreeEntry::FILE_MODE_SYMBOLIC_LINK === $entry->get_mode_bucket() ) {
+				$content         = $repository->read_object( $entry->hash )->consume_all();
+				$file['size']    = strlen( $content );
+				$file['content'] = $content;
+			} elseif ( $remaining_content_slots > 0 && self::is_checkout_preview_content_path( $path ) ) {
+				$content         = $repository->read_object( $entry->hash )->consume_all();
+				$file['size']    = strlen( $content );
+				$file['content'] = self::trim_checkout_preview_content( $content, $content_length );
+				--$remaining_content_slots;
+			}
+
+			$files[] = $file;
+		}
+	}
+
+	private static function add_checkout_preview_priority_paths( GitRepository $repository, $commit_hash, &$files, $content_length ) {
+		foreach ( self::get_checkout_preview_priority_paths() as $path ) {
+			self::add_checkout_preview_file_from_path(
+				$repository,
+				$commit_hash,
+				$path,
+				$files,
+				$content_length
+			);
+		}
+	}
+
+	private static function get_checkout_preview_priority_paths() {
+		return array(
+			'.agents/skills',
+			'.claude/skills',
+			'AGENTS.md',
+			'CLAUDE.md',
+			'wp_guideline/skills/wp-origin/SKILL.md',
+			'wp_guideline/skills/wp-origin-template-editor/SKILL.md',
+		);
+	}
+
+	private static function add_checkout_preview_file_from_path( GitRepository $repository, $commit_hash, $path, &$files, $content_length ) {
+		if ( self::checkout_preview_has_path( $files, $path ) ) {
+			return;
+		}
+
+		try {
+			$entry = self::find_checkout_preview_entry_by_path( $repository, $commit_hash, $path );
+			if ( ! $entry || TreeEntry::FILE_MODE_DIRECTORY === $entry->get_mode_bucket() ) {
+				return;
+			}
+			if (
+				TreeEntry::FILE_MODE_REGULAR_NON_EXECUTABLE !== $entry->get_mode_bucket() &&
+				TreeEntry::FILE_MODE_REGULAR_EXECUTABLE !== $entry->get_mode_bucket() &&
+				TreeEntry::FILE_MODE_SYMBOLIC_LINK !== $entry->get_mode_bucket()
+			) {
+				return;
+			}
+
+			$content = $repository->read_object( $entry->hash )->consume_all();
+			$file    = array(
+				'path'    => $path,
+				'mode'    => $entry->get_mode_bucket(),
+				'type'    => TreeEntry::FILE_MODE_SYMBOLIC_LINK === $entry->get_mode_bucket() ? 'symlink' : 'file',
+				'size'    => strlen( $content ),
+				'content' => TreeEntry::FILE_MODE_SYMBOLIC_LINK === $entry->get_mode_bucket()
+					? $content
+					: self::trim_checkout_preview_content( $content, $content_length ),
+			);
+			$files[] = $file;
+		} catch ( Throwable $exception ) {
+			return;
+		}
+	}
+
+	private static function find_checkout_preview_entry_by_path( GitRepository $repository, $commit_hash, $path ) {
+		$commit = $repository->read_object( $commit_hash )->as_commit();
+		if ( Commit::is_null_hash( $commit->tree ) ) {
+			return null;
+		}
+
+		$tree_hash = $commit->tree;
+		$segments  = explode( '/', trim( $path, '/' ) );
+		foreach ( $segments as $index => $segment ) {
+			$tree = $repository->read_object( $tree_hash )->as_tree();
+			if ( ! $tree->has_entry( $segment ) ) {
+				return null;
+			}
+
+			$entry = $tree->get_entry( $segment );
+			if ( count( $segments ) - 1 === $index ) {
+				return $entry;
+			}
+			if ( TreeEntry::FILE_MODE_DIRECTORY !== $entry->get_mode_bucket() ) {
+				return null;
+			}
+			$tree_hash = $entry->hash;
+		}
+
+		return null;
+	}
+
+	private static function checkout_preview_has_path( $files, $path ) {
+		foreach ( $files as $file ) {
+			if ( isset( $file['path'] ) && $path === $file['path'] ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static function add_checkout_preview_default_guidance_files( &$files, $content_length ) {
+		foreach ( WP_Origin_Plugin::get_default_agent_guidance_preview_files() as $path => $entry ) {
+			if ( self::checkout_preview_has_path( $files, $path ) ) {
+				continue;
+			}
+			if ( ! isset( $entry['mode'], $entry['content'] ) ) {
+				continue;
+			}
+
+			$content = (string) $entry['content'];
+			$mode    = $entry['mode'];
+			$files[] = array(
+				'path'    => $path,
+				'mode'    => $mode,
+				'type'    => TreeEntry::FILE_MODE_SYMBOLIC_LINK === $mode ? 'symlink' : 'file',
+				'size'    => strlen( $content ),
+				'content' => TreeEntry::FILE_MODE_SYMBOLIC_LINK === $mode
+					? $content
+					: self::trim_checkout_preview_content( $content, $content_length ),
+			);
+		}
+	}
+
+	private static function is_checkout_preview_content_path( $path ) {
+		$extension = strtolower( pathinfo( $path, PATHINFO_EXTENSION ) );
+		if ( in_array( $extension, array( 'md', 'html', 'json', 'txt' ), true ) ) {
+			return true;
+		}
+
+		return in_array( $path, array( 'AGENTS.md', 'CLAUDE.md' ), true );
+	}
+
+	private static function trim_checkout_preview_content( $content, $max_length ) {
+		$max_length = intval( $max_length );
+		if ( strlen( $content ) <= $max_length ) {
+			return $content;
+		}
+
+		return substr( $content, 0, $max_length ) . "\n... output truncated ...\n";
+	}
+
 	public static function is_ready() {
 		return self::STATE_DONE === self::get_state();
 	}
 
 	public static function not_ready_message() {
-		$progress = self::get_progress();
+		$progress = self::get_progress( false );
 		if ( self::STATE_FAILED === $progress['state'] ) {
 			return 'WP Origin import failed: ' . $progress['message'];
 		}

--- a/plugins/wp-origin/docs/prd.md
+++ b/plugins/wp-origin/docs/prd.md
@@ -124,9 +124,8 @@ Paths are part of the content identity. WP Origin should reject unsupported
 directories, unexpected extensions, path traversal, non-canonical slugs, and
 ambiguous mappings.
 
-WP Origin's built-in agent skills are generated when no matching Guideline
-exists. If Gutenberg Guidelines are unavailable, those generated skills are
-read-only checkout context. If Guidelines are available, editing the canonical
+WP Origin's built-in agent skills are generated only when Gutenberg Guidelines
+are enabled and no matching Guideline exists. Editing the canonical
 `wp_guideline/skills/{slug}/SKILL.md` file can create or update the matching
 Guideline, while generated aliases such as `AGENTS.md` and `.agents/skills`
 remain read-only.

--- a/plugins/wp-origin/readme.txt
+++ b/plugins/wp-origin/readme.txt
@@ -53,7 +53,7 @@ Markdown files use a small front matter contract: `title`, `date`, `status`, and
 
 Structural block files use raw Gutenberg block markup with no front matter so they can round-trip through WordPress without being forced into Markdown.
 
-WP Origin's built-in agent skills are generated when no matching Guideline exists. If Gutenberg Guidelines are unavailable, those generated skills are read-only checkout context. If Guidelines are available, edit the canonical `wp_guideline/skills/{slug}/SKILL.md` file; generated aliases such as `AGENTS.md` and `.agents/skills` remain read-only.
+WP Origin's built-in agent skills are generated only when Gutenberg Guidelines are enabled and no matching Guideline exists. Edit the canonical `wp_guideline/skills/{slug}/SKILL.md` file; generated aliases such as `AGENTS.md` and `.agents/skills` remain read-only.
 
 = Safety model =
 


### PR DESCRIPTION
## Summary

Adds a polished first-run WP Origin admin screen with an interactive command emulator, copyable terminal setup details, commit history, and import status.

## What changed

- Replaced the plain import status page with a styled terminal-oriented WP Origin admin experience.
- Added `admin-shell.css` and `admin-shell.js` for the browser-only command emulator.
- Added checkout preview data to the seeder status response so commands like `ls`, `tree`, `cat`, and `git status` can mirror the current repository state.
- Added emulated `git pull`, `git add`, `git commit`, and `git push` output as a teaching aid, while clearly saying commands do not execute on the server or write to WordPress.
- Kept generated agent guidance preview behavior aligned with the real checkout: guidance and Claude/agent symlinks only appear when Gutenberg Guidelines are available.
- Excluded `node_modules` from PHPCS scanning so the repo-wide lint command can complete without tokenizing vendored JS dependencies.

## Why

The first WP Origin screen should immediately show what the plugin does: WordPress content as a Git checkout. The emulator gives users a safe, copy-friendly preview of the workflow while still pointing them at the real terminal for clone, pull, commit, and push.

## Validation

- `php -l plugins/wp-origin/class-wp-origin-plugin.php`
- `php -l plugins/wp-origin/class-wp-origin-seeder.php`
- `node --check plugins/wp-origin/admin-shell.js`
- `vendor/bin/phpcs -d memory_limit=1G plugins/wp-origin/class-wp-origin-plugin.php plugins/wp-origin/class-wp-origin-seeder.php plugins/wp-origin/class-wp-origin-admin.php plugins/wp-origin/admin-shell.js plugins/wp-origin/admin-shell.css plugins/wp-origin/readme.txt plugins/wp-origin/docs/prd.md`
- `vendor/bin/phpcs -d memory_limit=1G --warning-severity=0 .`
- `vendor/bin/phpunit plugins/wp-origin/Tests/` (local E2E tests skipped because required env vars are not configured)
