### PR TITLE
Preserve WP Origin pages across renames

### DIFF
--- a/bin/test-wp-origin-git-actions.sh
+++ b/bin/test-wp-origin-git-actions.sh
@@ -207,7 +207,8 @@ grep -Fq 'title: "Hello World"' "$CLONE_DIR/post/hello-world.md"
 grep -Fq 'status: "published"' "$CLONE_DIR/post/hello-world.md"
 grep -Fq 'description: "Hand-authored summary."' "$CLONE_DIR/post/hello-world.md"
 grep -Eq '^date: "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z"$' "$CLONE_DIR/post/hello-world.md"
-! grep -Eq '^(id|type|slug|date_gmt|modified_gmt):' "$CLONE_DIR/post/hello-world.md"
+grep -Eq '^id: "[1-9][0-9]*"$' "$CLONE_DIR/post/hello-world.md"
+! grep -Eq '^(type|slug|date_gmt|modified_gmt):' "$CLONE_DIR/post/hello-world.md"
 head -n 1 "$CLONE_DIR/wp_guideline/skills/wp-origin/SKILL.md" | grep -Fxq -- '---'
 grep -Fq 'name: "wp-origin"' "$CLONE_DIR/wp_guideline/skills/wp-origin/SKILL.md"
 grep -Fq 'description: "Guide for coding agents working in a WP Origin checkout of a WordPress site."' "$CLONE_DIR/wp_guideline/skills/wp-origin/SKILL.md"
@@ -252,6 +253,39 @@ echo count($revisions);
 cd "$CLONE_DIR"
 git config user.name "WP Origin E2E"
 git config user.email "wp-origin-e2e@example.com"
+
+grep -Fq "id: \"$PAGE_ID\"" "$CLONE_DIR/page/sample-page.md"
+git mv page/sample-page.md page/renamed-sample-page.md
+php -r '
+$path = $argv[1];
+$contents = file_get_contents($path);
+$contents = str_replace("Page from WordPress", "Renamed page from Git", $contents);
+file_put_contents($path, $contents);
+' "$CLONE_DIR/page/renamed-sample-page.md"
+git add -A
+git commit -m "Rename page from Git"
+PUSH_OUTPUT="$(git push origin trunk 2>&1)"
+assert_push_summary_contains "$PUSH_OUTPUT" 'WP Origin applied 1 content change:'
+assert_push_summary_contains "$PUSH_OUTPUT" '/renamed-sample-page/'
+curl -sS -f -H "Authorization: Basic $AUTH_HEADER" "$BASE_URL/wp-json/wp/v2/pages?slug=renamed-sample-page&context=edit" | php -r '
+$pages = json_decode(stream_get_contents(STDIN), true);
+if (!is_array($pages) || empty($pages)) {
+	exit(1);
+}
+if ((int) $argv[1] !== (int) $pages[0]["id"]) {
+	exit(1);
+}
+if (false === strpos($pages[0]["content"]["raw"], "Renamed page from Git")) {
+	exit(1);
+}
+' "$PAGE_ID"
+curl -sS -f -H "Authorization: Basic $AUTH_HEADER" "$BASE_URL/wp-json/wp/v2/pages?slug=sample-page&context=edit" | php -r '
+$pages = json_decode(stream_get_contents(STDIN), true);
+if (array() !== $pages) {
+	exit(1);
+}
+'
+git pull --rebase origin trunk
 
 GIT_CHILD_SLUG="git-child-$HIERARCHY_SUFFIX"
 cat > "$CLONE_DIR/page/$PARENT_A_SLUG/$GIT_CHILD_SLUG.md" <<MARKDOWN
@@ -474,14 +508,14 @@ $markdown = "---\n"
 file_put_contents($path, $markdown);
 ' "$CLONE_DIR/page/page-from-git.md"
 
-rm "$CLONE_DIR/page/sample-page.md"
-git add post/created-from-git.md page/page-from-git.md page/sample-page.md
+rm "$CLONE_DIR/page/renamed-sample-page.md"
+git add post/created-from-git.md page/page-from-git.md page/renamed-sample-page.md
 git commit -m "Create and delete content from Git"
 PUSH_OUTPUT="$(git push origin trunk 2>&1)"
 assert_push_summary_contains "$PUSH_OUTPUT" 'WP Origin applied 3 content changes:'
 assert_push_summary_contains "$PUSH_OUTPUT" '/created-from-git/'
 assert_push_summary_contains "$PUSH_OUTPUT" '/page-from-git/'
-assert_push_summary_contains "$PUSH_OUTPUT" '/sample-page/'
+assert_push_summary_contains "$PUSH_OUTPUT" '/renamed-sample-page/'
 
 CREATED_POST_CONTENT="$(curl -sS -f -H "Authorization: Basic $AUTH_HEADER" "$BASE_URL/wp-json/wp/v2/posts?slug=created-from-git&context=edit" | php -r '
 $posts = json_decode(stream_get_contents(STDIN), true);
@@ -523,7 +557,7 @@ git pull --rebase origin trunk
 php -r '
 $path = $argv[1];
 $markdown = "---\n"
-	. "id: \"1\"\n"
+	. "id: \"0\"\n"
 	. "status: \"publish\"\n"
 	. "title: \"Rejected ID Front Matter\"\n"
 	. "---\n\n"
@@ -536,7 +570,7 @@ if PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
 	echo "Expected id front matter push to fail." >&2
 	exit 1
 fi
-assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because Markdown front matter must not include an id.'
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push rejected because Markdown front matter id must be a positive integer.'
 git reset --hard HEAD~1 >/dev/null
 
 php -r '

--- a/plugins/wp-origin/Tests/EndToEndTest.php
+++ b/plugins/wp-origin/Tests/EndToEndTest.php
@@ -241,11 +241,30 @@ class WP_Origin_End_To_End_Test extends TestCase {
 		);
 
 		// Capture the page ID up front: WordPress mangles the slug to
-		// `sample-page__trashed` once we trash the page in step 6, so a
+		// `renamed-sample-page__trashed` once we trash the page in step 6, so a
 		// later slug lookup would not find it.
 		$sample_page_id = $this->fetch_id_by_slug( 'sample-page', 'pages' );
+		$this->assertStringContainsString(
+			'id: "' . $sample_page_id . '"',
+			file_get_contents( $clone_dir . '/page/sample-page.md' )
+		);
 
 		$this->configure_git( $clone_dir );
+
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'mv', 'page/sample-page.md', 'page/renamed-sample-page.md' ) );
+		$this->edit_file(
+			$clone_dir . '/page/renamed-sample-page.md',
+			'Page from WordPress',
+			'Renamed page from Git'
+		);
+		$this->commit_and_push( $clone_dir, 'page/renamed-sample-page.md', 'Rename page from Git' );
+		$this->assertSame( $sample_page_id, $this->fetch_id_by_slug( 'renamed-sample-page', 'pages' ) );
+		$this->assert_slug_absent( 'sample-page', 'pages' );
+		$this->assertStringContainsString(
+			'Renamed page from Git',
+			$this->fetch_content( $sample_page_id, 'pages' )
+		);
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'pull', '--rebase', 'origin', 'trunk' ) );
 
 		$git_child_slug = 'git-child-' . $hierarchy_suffix;
 		file_put_contents(
@@ -417,7 +436,7 @@ class WP_Origin_End_To_End_Test extends TestCase {
 			$clone_dir . '/post/created-from-git.md',
 			"---\nstatus: \"publish\"\ntitle: \"Created From Git\"\n---\n\nCreated from Git.\n"
 		);
-		unlink( $clone_dir . '/page/sample-page.md' );
+		unlink( $clone_dir . '/page/renamed-sample-page.md' );
 		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', '-A' ) );
 		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Create and delete content from Git' ) );
 		$this->run_cmd( array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ) );
@@ -429,12 +448,12 @@ class WP_Origin_End_To_End_Test extends TestCase {
 		);
 		$this->assertSame( 'trash', $this->fetch_status( $sample_page_id, 'pages' ) );
 
-		// 7) The Git path is the content identity; front matter cannot
-		// smuggle a different ID or slug.
+		// 7) Front matter may carry the WordPress ID for rename
+		// continuity, but invalid IDs, slugs, and types are rejected.
 		$this->run_cmd( array( 'git', '-C', $clone_dir, 'pull', '--rebase', 'origin', 'trunk' ) );
 		file_put_contents(
 			$clone_dir . '/post/rejected-id-frontmatter.md',
-			"---\nid: \"1\"\nstatus: \"publish\"\ntitle: \"Rejected ID Front Matter\"\n---\n\nThis push must be rejected.\n"
+			"---\nid: \"0\"\nstatus: \"publish\"\ntitle: \"Rejected ID Front Matter\"\n---\n\nThis push must be rejected.\n"
 		);
 		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', 'post/rejected-id-frontmatter.md' ) );
 		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject post id front matter' ) );
@@ -443,7 +462,7 @@ class WP_Origin_End_To_End_Test extends TestCase {
 			true
 		);
 		$this->assertNotSame( 0, $push_result['code'], 'ID front matter should have been rejected.' );
-		$this->assertStringContainsString( 'Push rejected because Markdown front matter must not include an id.', $push_result['output'] );
+		$this->assertStringContainsString( 'Push rejected because Markdown front matter id must be a positive integer.', $push_result['output'] );
 		$this->run_cmd( array( 'git', '-C', $clone_dir, 'reset', '--hard', 'HEAD~1' ) );
 
 		file_put_contents(
@@ -867,6 +886,7 @@ class WP_Origin_End_To_End_Test extends TestCase {
 		$this->assertFileExists( $fresh . '/wp_template/custom-blog-card.html' );
 		$this->assertFileExists( $fresh . '/wp_template/custom-acme-block.html' );
 		$this->assertFileDoesNotExist( $fresh . '/page/sample-page.md' );
+		$this->assertFileDoesNotExist( $fresh . '/page/renamed-sample-page.md' );
 		$this->assertFileDoesNotExist( $fresh . '/wp_template/renamed-blog-card.html' );
 		$this->assertFileExists( $fresh . '/post/delete-restore-e2e.md' );
 		$this->assertStringContainsString(
@@ -883,6 +903,7 @@ class WP_Origin_End_To_End_Test extends TestCase {
 		);
 		$log = $this->run_cmd( array( 'git', '-C', $fresh, 'log', '--format=%s' ) );
 		$this->assertStringContainsString( 'Update hello world from Git', $log['output'] );
+		$this->assertStringContainsString( 'Rename page from Git', $log['output'] );
 		$this->assertStringContainsString( 'Update template HTML from Git', $log['output'] );
 		$this->assertStringContainsString( 'Create and delete content from Git', $log['output'] );
 

--- a/plugins/wp-origin/class-wp-origin-plugin.php
+++ b/plugins/wp-origin/class-wp-origin-plugin.php
@@ -159,6 +159,7 @@ This repository is a Git checkout of a WordPress site exposed by WP Origin. Word
 - `git pull` refreshes the checkout from the current WordPress site.
 - `git push` applies supported Markdown changes back to WordPress.
 - Pushed post and page changes create WordPress revisions.
+- Post and page front matter may include `id` so a file rename updates the same WordPress object.
 - Deleted post or page files are trashed in WordPress rather than permanently deleted.
 - If WordPress changed after your last pull, the push is rejected. Pull, review the diff, and then push again.
 
@@ -1107,6 +1108,7 @@ SKILL;
 		}
 
 		$metadata = array(
+			'id'     => array( (string) $post->ID ),
 			'title'  => array( $post->post_title ),
 			'date'   => array( self::format_post_date_for_frontmatter( $post ) ),
 			'status' => array( self::frontmatter_status_from_post_status( $post->post_status ) ),
@@ -1398,6 +1400,9 @@ SKILL;
 			);
 			$post_id = $planned['post_id'];
 			if ( $post_id ) {
+				if ( isset( $updated_post_ids[ $post_id ] ) ) {
+					throw new Exception( 'Push rejected because multiple Markdown files reference the same WordPress post ID.' );
+				}
 				$updated_post_ids[ $post_id ] = true;
 			}
 			$upsert_plans[] = array(
@@ -1636,10 +1641,10 @@ SKILL;
 			$metadata[ $key ] = is_array( $value ) ? reset( $value ) : $value;
 		}
 
-		self::reject_identity_frontmatter( $metadata );
+		self::reject_path_identity_frontmatter( $metadata );
 		$metadata       = self::normalize_supported_frontmatter(
 			$metadata,
-			array( 'title', 'date', 'status', 'description' )
+			array( 'id', 'title', 'date', 'status', 'description' )
 		);
 		$post_id        = self::find_post_id_by_path_metadata( $path, $metadata );
 		$existing_post  = $post_id ? get_post( $post_id ) : null;
@@ -2007,7 +2012,7 @@ SKILL;
 			$metadata       = $skill_document['metadata'];
 			$markdown       = $skill_document['content'];
 			self::assert_block_markup_is_safe( $markdown );
-			self::reject_identity_frontmatter( $metadata );
+			self::reject_path_identity_frontmatter( $metadata );
 			$metadata = self::normalize_supported_frontmatter(
 				$metadata,
 				array( 'name', 'description' )
@@ -2274,10 +2279,7 @@ SKILL;
 		return isset( $statuses[ $key ] ) ? $statuses[ $key ] : $post_status;
 	}
 
-	private static function reject_identity_frontmatter( $metadata ) {
-		if ( isset( $metadata['id'] ) ) {
-			throw new Exception( 'Push rejected because Markdown front matter must not include an id. The file path is the content identity.' );
-		}
+	private static function reject_path_identity_frontmatter( $metadata ) {
 		if ( isset( $metadata['slug'] ) ) {
 			throw new Exception( 'Push rejected because Markdown front matter must not include a slug. Rename the file path only when creating distinct content.' );
 		}
@@ -2347,10 +2349,16 @@ SKILL;
 			);
 		}
 		if ( 'page' === $post_type ) {
+			if ( isset( $metadata['id'] ) ) {
+				return self::find_post_id_by_frontmatter_id( $path, $metadata, $include_trash );
+			}
+
 			return self::find_page_id_by_path( $path, $include_trash );
 		}
 
-		unset( $metadata );
+		if ( isset( $metadata['id'] ) ) {
+			return self::find_post_id_by_frontmatter_id( $path, $metadata, $include_trash );
+		}
 
 		$slug     = self::path_to_slug( $path );
 		$statuses = $include_trash
@@ -2392,6 +2400,44 @@ SKILL;
 		}
 
 		return intval( $posts[0] );
+	}
+
+	private static function find_post_id_by_frontmatter_id( $path, $metadata, $include_trash ) {
+		$post_type = self::path_to_post_type( $path );
+		$id        = self::normalize_frontmatter_post_id( $metadata['id'] );
+		$post      = get_post( $id );
+
+		if ( ! $post ) {
+			throw new Exception( 'Push rejected because Markdown front matter id does not reference an existing WordPress post.' );
+		}
+		if ( $post_type !== $post->post_type ) {
+			throw new Exception( 'Push rejected because Markdown front matter id references a different WordPress post type.' );
+		}
+
+		$statuses = $include_trash
+			? array_merge( self::$supported_post_statuses, array( 'trash' ) )
+			: self::$supported_post_statuses;
+		if ( ! in_array( $post->post_status, $statuses, true ) ) {
+			throw new Exception( 'Push rejected because Markdown front matter id references a non-exported WordPress post.' );
+		}
+
+		$path_metadata = $metadata;
+		unset( $path_metadata['id'] );
+		$path_post_id = self::find_post_id_by_path_metadata( $path, $path_metadata, $include_trash );
+		if ( $path_post_id && $path_post_id !== $id ) {
+			throw new Exception( 'Push rejected because Markdown front matter id conflicts with the WordPress post already mapped to this file path.' );
+		}
+
+		return $id;
+	}
+
+	private static function normalize_frontmatter_post_id( $id ) {
+		$id = trim( (string) $id );
+		if ( ! preg_match( '/^[1-9][0-9]*$/', $id ) ) {
+			throw new Exception( 'Push rejected because Markdown front matter id must be a positive integer.' );
+		}
+
+		return intval( $id );
 	}
 
 	private static function find_page_id_by_path( $path, $include_trash = true ) {

--- a/plugins/wp-origin/docs/prd.md
+++ b/plugins/wp-origin/docs/prd.md
@@ -58,7 +58,7 @@ partial writes, lossy conversion, ambiguous identity, or silent normalization.
 - Do not mirror the full media library. Media import/export remains future work.
 - Do not support arbitrary custom post types until each content mapping is
   explicit and tested.
-- Do not rely on front matter IDs, slugs, or post types for identity.
+- Do not rely on front matter slugs or post types for identity.
 - Do not provide reset/delete semantics for template and Global Styles files
   until the product behavior is explicit.
 - Do not require Composer packages or PHP extensions beyond this repository's
@@ -138,13 +138,14 @@ Posts and pages are Markdown files with a small YAML-style front matter block.
 Supported front matter fields are:
 
 - `title`
+- `id`
 - `date`
 - `status`
 - `description`
 
-Unsupported front matter is rejected. This includes `id`, `slug`, `type`,
-unknown keys, arrays, booleans, and null values. Machine identity stays out of
-Markdown so that users and agents do not accidentally edit hidden routing data.
+Unsupported front matter is rejected. This includes `slug`, `type`, unknown
+keys, arrays, booleans, and null values. The optional `id` field preserves
+WordPress identity across file renames.
 
 `date_gmt` and `modified_gmt` are not exported. WordPress remains responsible
 for canonical timestamps and revisions.
@@ -167,9 +168,11 @@ future date is rejected.
 
 ### 6.3 Identity And Page Hierarchy
 
-Post identity comes from `post/{slug}.md`.
+Post identity comes from front matter `id` when present, otherwise from
+`post/{slug}.md`.
 
-Page identity comes from the page path:
+Page identity comes from front matter `id` when present, otherwise from the
+page path:
 
 - `page/about.md` maps to the top-level `about` page.
 - `page/company/about.md` maps to the child page `about` under parent `company`.


### PR DESCRIPTION
## Summary

Adds optional `id` front matter to WP Origin post/page Markdown exports and uses it during import to resolve an existing WordPress object before falling back to path identity. This lets a renamed page file update the same WordPress page instead of trashing the old path and creating a new page.

The import path now validates front matter IDs, rejects path/ID conflicts, and rejects pushes where multiple Markdown files point at the same WordPress post ID. Docs, generated agent guidance, PHPUnit E2E coverage, and the shell E2E script were updated for the new behavior.

## Validation

- `php -l plugins/wp-origin/class-wp-origin-plugin.php && php -l plugins/wp-origin/Tests/EndToEndTest.php && bash -n bin/test-wp-origin-git-actions.sh`
- `vendor/bin/phpunit plugins/wp-origin/Tests/` (skipped locally because WP Origin E2E environment variables are not set)
- `vendor/bin/phpcs -d memory_limit=1G plugins/wp-origin/class-wp-origin-plugin.php plugins/wp-origin/Tests/EndToEndTest.php`
- `git diff --check`

`composer lint` was also run, but the full repo lint still exits 2 on pre-existing warnings in unrelated components.