### PR TITLE
[codex] Add Push MD landing page draft

### DIFF
--- a/plugins/push-md/docs/README.md
+++ b/plugins/push-md/docs/README.md
@@ -6,6 +6,18 @@ copy lives in `plugins/push-md/readme.txt`; this README explains
 implementation choices, release packaging, lifecycle behavior, and
 review-sensitive details.
 
+## Public Landing Page Draft
+
+A standalone public landing page draft lives in:
+
+```text
+plugins/push-md/docs/landing/index.html
+```
+
+It is intentionally static so it can be opened directly in a browser while the
+public site target is still undecided. The page positions Push MD as
+WordPress-as-source-of-truth for Git, agents, and Markdown workflows.
+
 ## What Push MD Does
 
 Push MD exposes supported WordPress content as a Git Smart HTTP remote at:

--- a/plugins/push-md/docs/landing/index.html
+++ b/plugins/push-md/docs/landing/index.html
@@ -27,12 +27,11 @@
 	<main id="main" class="markdown-document">
 		<section class="hero" id="top" aria-labelledby="hero-title">
 			<div class="hero-copy">
-				<p class="file-label">page/push-md.md</p>
-				<h1 id="hero-title"><span class="md-token">#</span> Write Markdown with agents. Keep WordPress in charge.</h1>
+				<h1 id="hero-title"><span class="md-token">#</span> Markdown in Git. WordPress in charge.</h1>
 				<p class="hero-subhead">
-					Push MD makes WordPress the Git remote for Markdown-first content work:
-					agents edit <code>.md</code> files, WordPress enforces roles, creates
-					revisions, and renders the final site.
+					Agents work in Git on ordinary <code>.md</code> files. Push MD makes
+					WordPress the remote that checks roles, creates revisions, rejects stale
+					pushes, and renders the site.
 				</p>
 				<div class="hero-actions" aria-label="Primary actions">
 					<a class="button button-primary" href="#install">Install plugin</a>
@@ -40,84 +39,69 @@
 				</div>
 			</div>
 
-			<div class="markdown-workbench" aria-label="Markdown editor and rendered Push MD preview">
-				<div class="editor-card">
-					<div class="editor-topline">
-						<span>page/home.md</span>
-						<span>trunk</span>
-					</div>
-					<pre class="markdown-source" aria-label="Markdown source"><code><span class="md-line md-muted">---</span>
-<span class="md-line md-key">title: Markdown for WordPress agents</span>
-<span class="md-line md-key">status: draft</span>
-<span class="md-line md-muted">---</span>
-<span class="md-line"></span>
-<span class="md-line md-heading"># Markdown in Git</span>
-<span class="md-line">Agents edit ordinary Markdown files in a checkout.</span>
-<span class="md-line"></span>
-<span class="md-line md-heading">## WordPress stays in charge</span>
-<span class="md-line">- WordPress is the Git remote and source of truth.</span>
-<span class="md-line">- Roles decide who can read or push.</span>
-<span class="md-line">- Accepted pushes create WordPress revisions.</span>
-<span class="md-line">- WordPress renders the published page.</span>
-<span class="md-line"></span>
-<span class="md-line md-heading">## Agent run</span>
-<span class="md-line md-code">git clone https://example.com/wp-json/git/v1/md.git my-site</span>
-<span class="md-line md-code">codex "Update the homepage CTA"</span>
-<span class="md-line md-code">git push origin trunk</span></code></pre>
+			<div class="terminal-card" aria-label="Push MD terminal workflow">
+				<div class="terminal-topline">
+					<span class="terminal-dots" aria-hidden="true">
+						<span></span>
+						<span></span>
+						<span></span>
+					</span>
+					<span>push-md / trunk</span>
+					<span>WordPress remote</span>
 				</div>
-
-				<div class="format-bridge" aria-hidden="true">
-					<span>Markdown</span>
-					<strong>-&gt;</strong>
-					<span>WordPress</span>
+				<pre class="terminal-source" aria-label="Terminal transcript"><code><span class="terminal-line"><span class="terminal-prompt">$</span> git clone https://example.com/wp-json/git/v1/md.git site</span>
+<span class="terminal-line terminal-muted">remote: exported posts and pages as Markdown</span>
+<span class="terminal-line"><span class="terminal-prompt">$</span> cd site</span>
+<span class="terminal-line"><span class="terminal-prompt">$</span> codex "Update page/home.md"</span>
+<span class="terminal-line terminal-comment">edit: page/home.md</span>
+<span class="terminal-line"><span class="terminal-prompt">$</span> git diff -- page/home.md</span>
+<span class="terminal-line terminal-muted">@@</span>
+<span class="terminal-line terminal-diff-remove">- Old CTA copy</span>
+<span class="terminal-line terminal-diff-add">+ Keep WordPress in charge</span>
+<span class="terminal-line"><span class="terminal-prompt">$</span> git push origin trunk</span>
+<span class="terminal-line terminal-success">remote: checked WordPress permissions</span>
+<span class="terminal-line terminal-success">remote: stale state check passed</span>
+<span class="terminal-line terminal-success">remote: created WordPress revision #184</span>
+<span class="terminal-line terminal-success">remote: applied 1 Markdown change</span></code></pre>
+				<div class="terminal-summary">
+					<span>
+						<strong>.md</strong>
+						Markdown in Git
+					</span>
+					<span>
+						<strong>WP</strong>
+						Roles and revisions
+					</span>
+					<span>
+						<strong>pull</strong>
+						Admin edits show up
+					</span>
 				</div>
-
-				<article class="preview-card">
-					<p class="preview-kicker">Rendered by WordPress</p>
-					<h2>Markdown for WordPress agents</h2>
-					<p>Agents edit Markdown. WordPress publishes the page, enforces access, and keeps the revision trail.</p>
-					<h3>WordPress guarantees</h3>
-					<ul>
-						<li>Role-aware clone and push access.</li>
-						<li>Accepted pushes create revisions.</li>
-						<li>WP-Admin edits are visible on pull.</li>
-					</ul>
-					<div class="remote-output">
-						<span>remote: checked WordPress permissions</span>
-						<span>remote: stale pushes are rejected before writing</span>
-						<span>remote: created WordPress revision</span>
-					</div>
-				</article>
 			</div>
 		</section>
 
 		<section class="authority-strip" id="permissions" aria-label="Why WordPress stays authoritative">
 			<article>
-				<p class="section-path">## markdown-files</p>
-				<h2>Edit Markdown.</h2>
-				<p>Posts and pages appear as readable <code>.md</code> files, so agents and local editors can use familiar diffs and commits.</p>
+				<h2><span class="md-token">##</span> Markdown files</h2>
+				<p>Posts and pages appear as readable <code>.md</code> files for agents, diffs, and local editors.</p>
 			</article>
 			<article>
-				<p class="section-path">## wordpress-remote</p>
-				<h2>Publish WordPress.</h2>
-				<p>Git clients clone directly from <code>/wp-json/git/v1/md.git</code>; WordPress remains the remote and source of truth.</p>
+				<h2><span class="md-token">##</span> WordPress remote</h2>
+				<p>Git clients clone directly from <code>/wp-json/git/v1/md.git</code>. There is no second repository to reconcile.</p>
 			</article>
 			<article>
-				<p class="section-path">## wordpress-roles</p>
-				<h2>Respect roles.</h2>
-				<p>Git over HTTPS uses WordPress authentication, including Application Passwords, and respects existing capabilities.</p>
+				<h2><span class="md-token">##</span> Existing roles</h2>
+				<p>Git over HTTPS uses WordPress authentication and respects current capabilities.</p>
 			</article>
 			<article>
-				<p class="section-path">## wordpress-revisions</p>
-				<h2>Keep revisions.</h2>
-				<p>Accepted Markdown changes go through WordPress APIs, create revisions, and preserve publishing behavior.</p>
+				<h2><span class="md-token">##</span> Revisions</h2>
+				<p>Accepted Markdown pushes go through WordPress APIs and create WordPress revisions.</p>
 			</article>
 		</section>
 
 		<section class="doc-section workflow-section" id="how-it-works" aria-labelledby="workflow-title">
 			<div class="section-copy">
-				<p class="section-path"># how-it-works</p>
-				<h2 id="workflow-title">Use WordPress as the sync engine between agents.</h2>
+				<h2 id="workflow-title"><span class="md-token">##</span> WordPress coordinates the work.</h2>
 				<p>
 					Push MD gives every authenticated worker the same Git-shaped view of supported
 					content. Coding agents, local editors, and WP-Admin all coordinate through
@@ -125,10 +109,10 @@
 				</p>
 			</div>
 			<div class="flow-note" aria-label="WordPress coordinates agents and editors">
-				<pre><code>Agent A     -- git pull  --&gt; WordPress
-Agent B     -- git push  --&gt; WordPress
-Local editor -- Markdown --&gt; WordPress
-WP-Admin    -- revisions --&gt; WordPress</code></pre>
+				<pre><code>Agent A      -- git pull  --&gt; WordPress
+Agent B      -- git push  --&gt; WordPress
+Local editor -- Markdown  --&gt; WordPress
+WP-Admin     -- revisions --&gt; WordPress</code></pre>
 				<div class="flow-core">
 					<strong>WordPress</strong>
 					<span>Git remote + permissions + revisions</span>
@@ -138,8 +122,7 @@ WP-Admin    -- revisions --&gt; WordPress</code></pre>
 
 		<section class="doc-section skills-section" id="agent-skills" aria-labelledby="skills-title">
 			<div class="section-copy">
-				<p class="section-path"># agent-skills</p>
-				<h2 id="skills-title">The same WordPress guidance can travel with the checkout.</h2>
+				<h2 id="skills-title"><span class="md-token">##</span> Portable agent skills.</h2>
 				<p>
 					Push MD can export agent guidance through WordPress content guidelines. The
 					instructions your WordPress agent uses can appear in the coding-agent checkout,
@@ -148,7 +131,7 @@ WP-Admin    -- revisions --&gt; WordPress</code></pre>
 				</p>
 			</div>
 			<div class="markdown-callout">
-				<p class="section-path">> portable skill files</p>
+				<p class="callout-label">portable skill files</p>
 				<h3><code>AGENTS.md</code> and <code>SKILL.md</code></h3>
 				<p>Generated guidance lands beside Markdown, templates, and Global Styles so coding agents inherit the same site rules.</p>
 			</div>
@@ -156,8 +139,7 @@ WP-Admin    -- revisions --&gt; WordPress</code></pre>
 
 		<section class="doc-section markdown-section" aria-labelledby="markdown-title">
 			<div class="section-copy">
-				<p class="section-path"># markdown-and-ssg-workflows</p>
-				<h2 id="markdown-title">Markdown is the editing format. WordPress is the publishing system.</h2>
+				<h2 id="markdown-title"><span class="md-token">##</span> Markdown edits, WordPress publishing.</h2>
 				<p>
 					If you like Astro, Jekyll, or a Markdown vault, Push MD gives you a familiar
 					file tree while WordPress keeps handling previews, publishing, permissions,
@@ -167,19 +149,19 @@ WP-Admin    -- revisions --&gt; WordPress</code></pre>
 			<div class="markdown-table" aria-label="Supported checkout file types">
 				<div class="table-row table-head">
 					<span>Path</span>
-					<span>What WordPress does with it</span>
+					<span>What WordPress does</span>
 				</div>
 				<div class="table-row">
 					<code>post/*.md</code>
-					<span>Turns Markdown into WordPress posts and revisions</span>
+					<span>Turns Markdown into posts and revisions</span>
 				</div>
 				<div class="table-row">
 					<code>page/**/*.md</code>
-					<span>Preserves page hierarchy and WordPress identity</span>
+					<span>Preserves page hierarchy and identity</span>
 				</div>
 				<div class="table-row">
 					<code>wp_template_part/**/*.html</code>
-					<span>Keeps block markup compatible with the Site Editor</span>
+					<span>Keeps block markup Site Editor friendly</span>
 				</div>
 				<div class="table-row">
 					<code>wp_global_styles/*.json</code>
@@ -190,8 +172,7 @@ WP-Admin    -- revisions --&gt; WordPress</code></pre>
 
 		<section class="doc-section install-section" id="install" aria-labelledby="install-title">
 			<div class="section-copy">
-				<p class="section-path"># install-and-clone</p>
-				<h2 id="install-title">Start with the tools every agent already understands.</h2>
+				<h2 id="install-title"><span class="md-token">##</span> Clone WordPress like a Git remote.</h2>
 				<p>
 					Install Push MD, authenticate with a WordPress Application Password, then clone
 					the <code>trunk</code> branch from your site. Your Git client talks to WordPress directly.

--- a/plugins/push-md/docs/landing/index.html
+++ b/plugins/push-md/docs/landing/index.html
@@ -16,7 +16,7 @@
 			<span>Push MD</span>
 		</a>
 		<nav class="site-nav" aria-label="Main navigation">
-			<a href="#how-it-works">How it works</a>
+			<a href="#how-it-works">Use cases</a>
 			<a href="#permissions">Permissions</a>
 			<a href="#agent-skills">Agent skills</a>
 			<a href="../README.md">Docs</a>
@@ -99,74 +99,64 @@
 			</article>
 		</section>
 
-		<section class="doc-section workflow-section" id="how-it-works" aria-labelledby="workflow-title">
+		<section class="doc-section use-cases-section" id="how-it-works" aria-labelledby="use-cases-title">
 			<div class="section-copy">
-				<h2 id="workflow-title"><span class="md-token">##</span> WordPress coordinates the work.</h2>
+				<h2 id="use-cases-title"><span class="md-token">##</span> Use cases</h2>
 				<p>
-					Push MD gives every authenticated worker the same Git-shaped view of supported
-					content. Coding agents, local editors, and WP-Admin all coordinate through
-					WordPress, so there is no second source of truth drifting out of date.
+					Push MD is for teams that want Git-shaped work without moving the source of
+					truth out of WordPress. Use it for agent runs, local Markdown edits, and
+					static-site-style publishing flows that still need WordPress roles and revisions.
 				</p>
 			</div>
-			<div class="flow-note" aria-label="WordPress coordinates agents and editors">
-				<pre><code>Agent A      -- git pull  --&gt; WordPress
-Agent B      -- git push  --&gt; WordPress
-Local editor -- Markdown  --&gt; WordPress
-WP-Admin     -- revisions --&gt; WordPress</code></pre>
-				<div class="flow-core">
-					<strong>WordPress</strong>
-					<span>Git remote + permissions + revisions</span>
-				</div>
-			</div>
-		</section>
 
-		<section class="doc-section skills-section" id="agent-skills" aria-labelledby="skills-title">
-			<div class="section-copy">
-				<h2 id="skills-title"><span class="md-token">##</span> Portable agent skills.</h2>
-				<p>
-					Push MD can export agent guidance through WordPress content guidelines. The
-					instructions your WordPress agent uses can appear in the coding-agent checkout,
-					so edits carry the same expectations about blocks, paths, permissions, and safe
-					operations.
-				</p>
-			</div>
-			<div class="markdown-callout">
-				<p class="callout-label">portable skill files</p>
-				<h3><code>AGENTS.md</code> and <code>SKILL.md</code></h3>
-				<p>Generated guidance lands beside Markdown, templates, and Global Styles so coding agents inherit the same site rules.</p>
-			</div>
-		</section>
+			<div class="use-case-list">
+				<article class="use-case-card" id="agent-skills">
+					<p class="callout-label">### coding agents</p>
+					<h3>Agents complete WordPress work through Git.</h3>
+					<p>
+						Give agents a normal checkout instead of a separate sync repo. WordPress
+						coordinates each run through authentication, stale-state checks, and revisions.
+					</p>
+					<ul class="task-list">
+						<li><code>[x]</code> Clone supported content from WordPress.</li>
+						<li><code>[x]</code> Edit Markdown, block templates, and styles locally.</li>
+						<li><code>[x]</code> Carry site guidance in <code>AGENTS.md</code> and <code>SKILL.md</code>.</li>
+						<li><code>[x]</code> Push only after WordPress accepts the change.</li>
+					</ul>
+				</article>
 
-		<section class="doc-section markdown-section" aria-labelledby="markdown-title">
-			<div class="section-copy">
-				<h2 id="markdown-title"><span class="md-token">##</span> Markdown edits, WordPress publishing.</h2>
-				<p>
-					If you like Astro, Jekyll, or a Markdown vault, Push MD gives you a familiar
-					file tree while WordPress keeps handling previews, publishing, permissions,
-					rendering, and the front end.
-				</p>
-			</div>
-			<div class="markdown-table" aria-label="Supported checkout file types">
-				<div class="table-row table-head">
-					<span>Path</span>
-					<span>What WordPress does</span>
-				</div>
-				<div class="table-row">
-					<code>post/*.md</code>
-					<span>Turns Markdown into posts and revisions</span>
-				</div>
-				<div class="table-row">
-					<code>page/**/*.md</code>
-					<span>Preserves page hierarchy and identity</span>
-				</div>
-				<div class="table-row">
-					<code>wp_template_part/**/*.html</code>
-					<span>Keeps block markup Site Editor friendly</span>
-				</div>
-				<div class="table-row">
-					<code>wp_global_styles/*.json</code>
-					<span>Applies editable Global Styles overlays</span>
-				</div>
+				<article class="use-case-card">
+					<p class="callout-label">### static site generators</p>
+					<h3>Work like a static site generator. Publish like WordPress.</h3>
+					<p>
+						If you like Astro, Jekyll, or a Markdown vault, use a local file tree while
+						WordPress keeps handling previews, roles, rendering, publishing, and revisions.
+					</p>
+					<ul class="task-list">
+						<li><code>[x]</code> Write posts and pages as Markdown.</li>
+						<li><code>[x]</code> Keep template parts as block HTML.</li>
+						<li><code>[x]</code> Version Global Styles as JSON.</li>
+						<li><code>[x]</code> Pull WP-Admin edits before the next local run.</li>
+					</ul>
+					<div class="file-map" aria-label="Static-site style file map">
+						<div>
+							<code>post/*.md</code>
+							<span>posts and revisions</span>
+						</div>
+						<div>
+							<code>page/**/*.md</code>
+							<span>pages and hierarchy</span>
+						</div>
+						<div>
+							<code>wp_template_part/**/*.html</code>
+							<span>Site Editor block markup</span>
+						</div>
+						<div>
+							<code>wp_global_styles/*.json</code>
+							<span>Global Styles overlays</span>
+						</div>
+					</div>
+				</article>
 			</div>
 		</section>
 

--- a/plugins/push-md/docs/landing/index.html
+++ b/plugins/push-md/docs/landing/index.html
@@ -127,7 +127,7 @@
 
 				<article class="use-case-card">
 					<p class="callout-label">### static site generators</p>
-					<h3>Work like a static site generator. Publish like WordPress.</h3>
+					<h3>Static Site Generator or WordPress? Why not both?</h3>
 					<p>
 						If you like Astro, Jekyll, or a Markdown vault, use a local file tree while
 						WordPress keeps handling previews, roles, rendering, publishing, and revisions.

--- a/plugins/push-md/docs/landing/index.html
+++ b/plugins/push-md/docs/landing/index.html
@@ -24,11 +24,11 @@
 		<a class="button button-primary" href="#install">Install plugin</a>
 	</header>
 
-	<main id="main">
+	<main id="main" class="markdown-document">
 		<section class="hero" id="top" aria-labelledby="hero-title">
-			<div class="hero-text">
-				<p class="eyebrow">WordPress-native Git for coding agents</p>
-				<h1 id="hero-title">Let coding agents work in Git. Keep WordPress in charge.</h1>
+			<div class="hero-copy">
+				<p class="file-label">page/push-md.md</p>
+				<h1 id="hero-title"><span class="md-token">#</span> Let coding agents work in Git. Keep WordPress in charge.</h1>
 				<p class="hero-subhead">
 					Push MD turns WordPress into a Git remote for supported content, so agents and
 					Markdown-first teams can clone, diff, commit, and push while WordPress remains
@@ -40,74 +40,72 @@
 				</div>
 			</div>
 
-			<div class="hero-visual" aria-label="Terminal showing a Push MD agent workflow">
-				<div class="terminal-window">
-					<div class="terminal-bar">
-						<div class="window-dots" aria-hidden="true">
-							<span></span>
-							<span></span>
-							<span></span>
-						</div>
-						<span>agent-workspace:~/my-site</span>
+			<div class="markdown-workbench" aria-label="Markdown editor and rendered Push MD preview">
+				<div class="editor-card">
+					<div class="editor-topline">
+						<span>page/home.md</span>
 						<span>trunk</span>
 					</div>
-					<pre class="terminal-transcript" aria-label="Push MD terminal transcript"><code><span class="line command">$ git clone https://example.com/wp-json/git/v1/md.git my-site</span>
-<span class="line output">Cloning into 'my-site'...</span>
-<span class="line success">remote: WordPress exported posts, pages, templates, styles, and skills</span>
-<span class="line command">$ cd my-site && tree -L 2</span>
-<span class="line output">.</span>
-<span class="line output">|-- AGENTS.md -> wp_guideline/skills/push-md/SKILL.md</span>
-<span class="line output">|-- page/home.md</span>
-<span class="line output">|-- post/launch-notes.md</span>
-<span class="line output">|-- wp_template_part/theme/footer.html</span>
-<span class="line command">$ codex "Update the homepage CTA and keep WordPress in charge"</span>
-<span class="line success">agent: edited page/home.md using Push MD guidance</span>
-<span class="line command">$ git diff -- page/home.md</span>
-<span class="line diff">- Build faster with another sync pipeline.</span>
-<span class="line diff">+ Let agents work in Git while WordPress stays authoritative.</span>
-<span class="line command">$ git commit -am "Update homepage CTA"</span>
-<span class="line output">[trunk 4f31a8c] Update homepage CTA</span>
-<span class="line command">$ git push origin trunk</span>
-<span class="line success">remote: checked WordPress permissions</span>
-<span class="line success">remote: stale pushes are rejected before writing</span>
-<span class="line success">remote: created WordPress revision</span>
-<span class="line success">remote: applied 1 content change through WordPress</span></code></pre>
+					<pre class="markdown-source" aria-label="Markdown source"><code><span class="md-line md-heading"># Let coding agents work in Git</span>
+<span class="md-line">WordPress stays authoritative while agents edit files.</span>
+<span class="md-line"></span>
+<span class="md-line md-heading">## Why this works</span>
+<span class="md-line">- WordPress is the Git remote.</span>
+<span class="md-line">- Existing roles decide who can read or push.</span>
+<span class="md-line">- Accepted pushes create WordPress revisions.</span>
+<span class="md-line">- WP-Admin edits become visible on pull.</span>
+<span class="md-line"></span>
+<span class="md-line md-heading">## Agent run</span>
+<span class="md-line md-code">git clone https://example.com/wp-json/git/v1/md.git my-site</span>
+<span class="md-line md-code">codex "Update the homepage CTA"</span>
+<span class="md-line md-code">git push origin trunk</span></code></pre>
 				</div>
 
-				<div class="source-badge" aria-label="Source of truth status">
-					<span class="source-badge-label">Source of truth</span>
-					<strong>WordPress</strong>
-					<span>REST auth, roles, revisions, and content APIs</span>
-				</div>
+				<article class="preview-card">
+					<p class="preview-kicker">Rendered by WordPress</p>
+					<h2>Let coding agents work in Git</h2>
+					<p>WordPress stays authoritative while agents edit files.</p>
+					<h3>Why this works</h3>
+					<ul>
+						<li>WordPress is the Git remote.</li>
+						<li>Roles decide who can read or push.</li>
+						<li>Accepted pushes create revisions.</li>
+					</ul>
+					<div class="remote-output">
+						<span>remote: checked WordPress permissions</span>
+						<span>remote: stale pushes are rejected before writing</span>
+						<span>remote: created WordPress revision</span>
+					</div>
+				</article>
 			</div>
 		</section>
 
 		<section class="authority-strip" id="permissions" aria-label="Why WordPress stays authoritative">
 			<article>
-				<span class="proof-kicker">No sync layer</span>
+				<p class="section-path">## no-sync-layer</p>
 				<h2>WordPress is the remote.</h2>
 				<p>Agents and editors clone directly from <code>/wp-json/git/v1/md.git</code> instead of pushing through another canonical repository.</p>
 			</article>
 			<article>
-				<span class="proof-kicker">No new users</span>
+				<p class="section-path">## no-new-users</p>
 				<h2>Use WordPress roles.</h2>
 				<p>Git over HTTPS uses WordPress authentication, including Application Passwords, and respects existing capabilities.</p>
 			</article>
 			<article>
-				<span class="proof-kicker">Revision-backed</span>
+				<p class="section-path">## revision-backed</p>
 				<h2>Pushes create revisions.</h2>
 				<p>Accepted content changes go through WordPress APIs, so publishing behavior, permissions, and revisions remain intact.</p>
 			</article>
 			<article>
-				<span class="proof-kicker">Admin-safe</span>
+				<p class="section-path">## admin-safe</p>
 				<h2>Pull admin edits first.</h2>
 				<p>WP-Admin edits become Git-visible on pull, and stale pushes are rejected before WordPress content is changed.</p>
 			</article>
 		</section>
 
-		<section class="workflow-section" id="how-it-works" aria-labelledby="workflow-title">
+		<section class="doc-section workflow-section" id="how-it-works" aria-labelledby="workflow-title">
 			<div class="section-copy">
-				<p class="eyebrow">One authority, many workers</p>
+				<p class="section-path"># how-it-works</p>
 				<h2 id="workflow-title">Use WordPress as the sync engine between agents.</h2>
 				<p>
 					Push MD gives every authenticated worker the same Git-shaped view of supported
@@ -115,33 +113,21 @@
 					WordPress, so there is no second source of truth drifting out of date.
 				</p>
 			</div>
-			<div class="flow-map" aria-label="WordPress coordinates agents and editors">
-				<div class="flow-node worker agent-a">
-					<span>Agent A</span>
-					<code>git pull</code>
-				</div>
-				<div class="flow-node worker agent-b">
-					<span>Agent B</span>
-					<code>git push</code>
-				</div>
-				<div class="flow-node worker editor">
-					<span>Local editor</span>
-					<code>Markdown</code>
-				</div>
-				<div class="flow-node worker admin">
-					<span>WP-Admin</span>
-					<code>revisions</code>
-				</div>
-				<div class="flow-node core">
-					<span>WordPress</span>
-					<strong>Git remote + permissions + revisions</strong>
+			<div class="flow-note" aria-label="WordPress coordinates agents and editors">
+				<pre><code>Agent A     -- git pull  --&gt; WordPress
+Agent B     -- git push  --&gt; WordPress
+Local editor -- Markdown --&gt; WordPress
+WP-Admin    -- revisions --&gt; WordPress</code></pre>
+				<div class="flow-core">
+					<strong>WordPress</strong>
+					<span>Git remote + permissions + revisions</span>
 				</div>
 			</div>
 		</section>
 
-		<section class="skills-section" id="agent-skills" aria-labelledby="skills-title">
+		<section class="doc-section skills-section" id="agent-skills" aria-labelledby="skills-title">
 			<div class="section-copy">
-				<p class="eyebrow">Portable guidance</p>
+				<p class="section-path"># agent-skills</p>
 				<h2 id="skills-title">The same WordPress guidance can travel with the checkout.</h2>
 				<p>
 					Push MD can export agent guidance through WordPress content guidelines. The
@@ -150,23 +136,16 @@
 					operations.
 				</p>
 			</div>
-			<div class="skills-grid">
-				<article class="skill-card">
-					<span class="skill-label">WordPress</span>
-					<h3>Content guidelines</h3>
-					<p>Site-specific editing rules live with WordPress content and stay visible to teams using WP-Admin.</p>
-				</article>
-				<article class="skill-card highlight">
-					<span class="skill-label">Push MD checkout</span>
-					<h3><code>AGENTS.md</code> and <code>SKILL.md</code></h3>
-					<p>Generated guidance lands beside Markdown, templates, and Global Styles so coding agents inherit the same rules.</p>
-				</article>
+			<div class="markdown-callout">
+				<p class="section-path">> portable skill files</p>
+				<h3><code>AGENTS.md</code> and <code>SKILL.md</code></h3>
+				<p>Generated guidance lands beside Markdown, templates, and Global Styles so coding agents inherit the same site rules.</p>
 			</div>
 		</section>
 
-		<section class="markdown-section" aria-labelledby="markdown-title">
+		<section class="doc-section markdown-section" aria-labelledby="markdown-title">
 			<div class="section-copy">
-				<p class="eyebrow">For Markdown and SSG people</p>
+				<p class="section-path"># markdown-and-ssg-workflows</p>
 				<h2 id="markdown-title">Use local-file workflows without replacing WordPress.</h2>
 				<p>
 					If you like Astro, Jekyll, or a Markdown vault, Push MD gives you a familiar
@@ -174,29 +153,33 @@
 					rendering, and the front end.
 				</p>
 			</div>
-			<div class="file-matrix" aria-label="Supported checkout file types">
-				<div>
+			<div class="markdown-table" aria-label="Supported checkout file types">
+				<div class="table-row table-head">
+					<span>Path</span>
+					<span>What it edits</span>
+				</div>
+				<div class="table-row">
 					<code>post/*.md</code>
 					<span>Posts as Markdown</span>
 				</div>
-				<div>
+				<div class="table-row">
 					<code>page/**/*.md</code>
 					<span>Pages and hierarchy</span>
 				</div>
-				<div>
+				<div class="table-row">
 					<code>wp_template_part/**/*.html</code>
 					<span>Raw Gutenberg block files</span>
 				</div>
-				<div>
+				<div class="table-row">
 					<code>wp_global_styles/*.json</code>
 					<span>Editable Global Styles overlays</span>
 				</div>
 			</div>
 		</section>
 
-		<section class="install-section" id="install" aria-labelledby="install-title">
-			<div class="install-copy">
-				<p class="eyebrow">Install and clone</p>
+		<section class="doc-section install-section" id="install" aria-labelledby="install-title">
+			<div class="section-copy">
+				<p class="section-path"># install-and-clone</p>
 				<h2 id="install-title">Start with the tools every agent already understands.</h2>
 				<p>
 					Install Push MD, authenticate with a WordPress Application Password, then clone
@@ -209,7 +192,7 @@
 					<li>Create or use a WordPress Application Password.</li>
 					<li>Clone the WordPress Git remote and work on <code>trunk</code>.</li>
 				</ol>
-				<div class="command-copy">
+				<div class="code-block">
 					<code id="clone-command">git clone https://example.com/wp-json/git/v1/md.git my-site</code>
 					<button class="copy-button" type="button" data-copy-target="clone-command">Copy</button>
 				</div>

--- a/plugins/push-md/docs/landing/index.html
+++ b/plugins/push-md/docs/landing/index.html
@@ -1,0 +1,232 @@
+<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>Push MD - WordPress as the Git remote for agents</title>
+	<meta name="description" content="Push MD lets coding agents and Markdown-first teams work with WordPress content through Git while WordPress remains the source of truth.">
+	<link rel="stylesheet" href="landing.css">
+</head>
+<body>
+	<a class="skip-link" href="#main">Skip to content</a>
+
+	<header class="site-header">
+		<a class="brand" href="#top" aria-label="Push MD home">
+			<span class="brand-mark" aria-hidden="true">PMD</span>
+			<span>Push MD</span>
+		</a>
+		<nav class="site-nav" aria-label="Main navigation">
+			<a href="#how-it-works">How it works</a>
+			<a href="#permissions">Permissions</a>
+			<a href="#agent-skills">Agent skills</a>
+			<a href="../README.md">Docs</a>
+		</nav>
+		<a class="button button-primary" href="#install">Install plugin</a>
+	</header>
+
+	<main id="main">
+		<section class="hero" id="top" aria-labelledby="hero-title">
+			<div class="hero-text">
+				<p class="eyebrow">WordPress-native Git for coding agents</p>
+				<h1 id="hero-title">Let coding agents work in Git. Keep WordPress in charge.</h1>
+				<p class="hero-subhead">
+					Push MD turns WordPress into a Git remote for supported content, so agents and
+					Markdown-first teams can clone, diff, commit, and push while WordPress remains
+					the source of truth.
+				</p>
+				<div class="hero-actions" aria-label="Primary actions">
+					<a class="button button-primary" href="#install">Install plugin</a>
+					<a class="button button-secondary" href="../README.md">Read docs</a>
+				</div>
+			</div>
+
+			<div class="hero-visual" aria-label="Terminal showing a Push MD agent workflow">
+				<div class="terminal-window">
+					<div class="terminal-bar">
+						<div class="window-dots" aria-hidden="true">
+							<span></span>
+							<span></span>
+							<span></span>
+						</div>
+						<span>agent-workspace:~/my-site</span>
+						<span>trunk</span>
+					</div>
+					<pre class="terminal-transcript" aria-label="Push MD terminal transcript"><code><span class="line command">$ git clone https://example.com/wp-json/git/v1/md.git my-site</span>
+<span class="line output">Cloning into 'my-site'...</span>
+<span class="line success">remote: WordPress exported posts, pages, templates, styles, and skills</span>
+<span class="line command">$ cd my-site && tree -L 2</span>
+<span class="line output">.</span>
+<span class="line output">|-- AGENTS.md -> wp_guideline/skills/push-md/SKILL.md</span>
+<span class="line output">|-- page/home.md</span>
+<span class="line output">|-- post/launch-notes.md</span>
+<span class="line output">|-- wp_template_part/theme/footer.html</span>
+<span class="line command">$ codex "Update the homepage CTA and keep WordPress in charge"</span>
+<span class="line success">agent: edited page/home.md using Push MD guidance</span>
+<span class="line command">$ git diff -- page/home.md</span>
+<span class="line diff">- Build faster with another sync pipeline.</span>
+<span class="line diff">+ Let agents work in Git while WordPress stays authoritative.</span>
+<span class="line command">$ git commit -am "Update homepage CTA"</span>
+<span class="line output">[trunk 4f31a8c] Update homepage CTA</span>
+<span class="line command">$ git push origin trunk</span>
+<span class="line success">remote: checked WordPress permissions</span>
+<span class="line success">remote: stale pushes are rejected before writing</span>
+<span class="line success">remote: created WordPress revision</span>
+<span class="line success">remote: applied 1 content change through WordPress</span></code></pre>
+				</div>
+
+				<div class="source-badge" aria-label="Source of truth status">
+					<span class="source-badge-label">Source of truth</span>
+					<strong>WordPress</strong>
+					<span>REST auth, roles, revisions, and content APIs</span>
+				</div>
+			</div>
+		</section>
+
+		<section class="authority-strip" id="permissions" aria-label="Why WordPress stays authoritative">
+			<article>
+				<span class="proof-kicker">No sync layer</span>
+				<h2>WordPress is the remote.</h2>
+				<p>Agents and editors clone directly from <code>/wp-json/git/v1/md.git</code> instead of pushing through another canonical repository.</p>
+			</article>
+			<article>
+				<span class="proof-kicker">No new users</span>
+				<h2>Use WordPress roles.</h2>
+				<p>Git over HTTPS uses WordPress authentication, including Application Passwords, and respects existing capabilities.</p>
+			</article>
+			<article>
+				<span class="proof-kicker">Revision-backed</span>
+				<h2>Pushes create revisions.</h2>
+				<p>Accepted content changes go through WordPress APIs, so publishing behavior, permissions, and revisions remain intact.</p>
+			</article>
+			<article>
+				<span class="proof-kicker">Admin-safe</span>
+				<h2>Pull admin edits first.</h2>
+				<p>WP-Admin edits become Git-visible on pull, and stale pushes are rejected before WordPress content is changed.</p>
+			</article>
+		</section>
+
+		<section class="workflow-section" id="how-it-works" aria-labelledby="workflow-title">
+			<div class="section-copy">
+				<p class="eyebrow">One authority, many workers</p>
+				<h2 id="workflow-title">Use WordPress as the sync engine between agents.</h2>
+				<p>
+					Push MD gives every authenticated worker the same Git-shaped view of supported
+					content. Coding agents, local editors, and WP-Admin all coordinate through
+					WordPress, so there is no second source of truth drifting out of date.
+				</p>
+			</div>
+			<div class="flow-map" aria-label="WordPress coordinates agents and editors">
+				<div class="flow-node worker agent-a">
+					<span>Agent A</span>
+					<code>git pull</code>
+				</div>
+				<div class="flow-node worker agent-b">
+					<span>Agent B</span>
+					<code>git push</code>
+				</div>
+				<div class="flow-node worker editor">
+					<span>Local editor</span>
+					<code>Markdown</code>
+				</div>
+				<div class="flow-node worker admin">
+					<span>WP-Admin</span>
+					<code>revisions</code>
+				</div>
+				<div class="flow-node core">
+					<span>WordPress</span>
+					<strong>Git remote + permissions + revisions</strong>
+				</div>
+			</div>
+		</section>
+
+		<section class="skills-section" id="agent-skills" aria-labelledby="skills-title">
+			<div class="section-copy">
+				<p class="eyebrow">Portable guidance</p>
+				<h2 id="skills-title">The same WordPress guidance can travel with the checkout.</h2>
+				<p>
+					Push MD can export agent guidance through WordPress content guidelines. The
+					instructions your WordPress agent uses can appear in the coding-agent checkout,
+					so edits carry the same expectations about blocks, paths, permissions, and safe
+					operations.
+				</p>
+			</div>
+			<div class="skills-grid">
+				<article class="skill-card">
+					<span class="skill-label">WordPress</span>
+					<h3>Content guidelines</h3>
+					<p>Site-specific editing rules live with WordPress content and stay visible to teams using WP-Admin.</p>
+				</article>
+				<article class="skill-card highlight">
+					<span class="skill-label">Push MD checkout</span>
+					<h3><code>AGENTS.md</code> and <code>SKILL.md</code></h3>
+					<p>Generated guidance lands beside Markdown, templates, and Global Styles so coding agents inherit the same rules.</p>
+				</article>
+			</div>
+		</section>
+
+		<section class="markdown-section" aria-labelledby="markdown-title">
+			<div class="section-copy">
+				<p class="eyebrow">For Markdown and SSG people</p>
+				<h2 id="markdown-title">Use local-file workflows without replacing WordPress.</h2>
+				<p>
+					If you like Astro, Jekyll, or a Markdown vault, Push MD gives you a familiar
+					file tree while WordPress keeps handling previews, publishing, permissions,
+					rendering, and the front end.
+				</p>
+			</div>
+			<div class="file-matrix" aria-label="Supported checkout file types">
+				<div>
+					<code>post/*.md</code>
+					<span>Posts as Markdown</span>
+				</div>
+				<div>
+					<code>page/**/*.md</code>
+					<span>Pages and hierarchy</span>
+				</div>
+				<div>
+					<code>wp_template_part/**/*.html</code>
+					<span>Raw Gutenberg block files</span>
+				</div>
+				<div>
+					<code>wp_global_styles/*.json</code>
+					<span>Editable Global Styles overlays</span>
+				</div>
+			</div>
+		</section>
+
+		<section class="install-section" id="install" aria-labelledby="install-title">
+			<div class="install-copy">
+				<p class="eyebrow">Install and clone</p>
+				<h2 id="install-title">Start with the tools every agent already understands.</h2>
+				<p>
+					Install Push MD, authenticate with a WordPress Application Password, then clone
+					the <code>trunk</code> branch from your site. Your Git client talks to WordPress directly.
+				</p>
+			</div>
+			<div class="install-panel">
+				<ol class="install-steps">
+					<li>Install and activate the Push MD plugin.</li>
+					<li>Create or use a WordPress Application Password.</li>
+					<li>Clone the WordPress Git remote and work on <code>trunk</code>.</li>
+				</ol>
+				<div class="command-copy">
+					<code id="clone-command">git clone https://example.com/wp-json/git/v1/md.git my-site</code>
+					<button class="copy-button" type="button" data-copy-target="clone-command">Copy</button>
+				</div>
+				<p class="install-note">Pushes to other branches are rejected. WordPress remains the source of truth.</p>
+			</div>
+		</section>
+	</main>
+
+	<footer class="site-footer">
+		<p>Push MD is part of the WordPress PHP Toolkit.</p>
+		<div>
+			<a href="../README.md">Developer docs</a>
+			<a href="../prd.md">PRD</a>
+			<a href="https://github.com/WordPress/php-toolkit/tree/trunk/plugins/push-md">GitHub</a>
+		</div>
+	</footer>
+
+	<script src="landing.js"></script>
+</body>
+</html>

--- a/plugins/push-md/docs/landing/index.html
+++ b/plugins/push-md/docs/landing/index.html
@@ -20,9 +20,9 @@
 			<a href="#permissions">Permissions</a>
 			<a href="#agent-skills">Agent skills</a>
 			<a href="#faq">FAQ</a>
-			<a href="../README.md">Docs</a>
+			<a href="https://github.com/Automattic/php-toolkit/tree/trunk/plugins/push-md/docs">Docs</a>
 		</nav>
-		<a class="button button-primary" href="#install">Install plugin</a>
+		<a class="button button-primary" href="#install">Download plugin</a>
 	</header>
 
 	<main id="main" class="markdown-document">
@@ -35,48 +35,49 @@
 					revisions, rejects stale pushes, and lets WordPress render the site.
 				</p>
 				<div class="hero-actions" aria-label="Primary actions">
-					<a class="button button-primary" href="#install">Install plugin</a>
-					<a class="button button-secondary" href="../README.md">Read docs</a>
+					<a class="button button-primary" href="#install">Download plugin</a>
+					<a class="button button-secondary" href="https://github.com/Automattic/php-toolkit/tree/trunk/plugins/push-md/docs">Read docs</a>
 				</div>
 			</div>
 
-			<div class="terminal-card" aria-label="Push MD terminal workflow">
+			<div class="terminal-card" role="application" aria-label="Push MD command emulator">
 				<div class="terminal-topline">
 					<span class="terminal-dots" aria-hidden="true">
 						<span></span>
 						<span></span>
 						<span></span>
 					</span>
-					<span>push-md / trunk</span>
-					<span>WordPress remote</span>
+					<span id="landing-terminal-title">emulator:~/site</span>
+					<span class="terminal-status">trunk / WordPress remote</span>
 				</div>
-				<pre class="terminal-source" aria-label="Terminal transcript"><code><span class="terminal-line"><span class="terminal-prompt">$</span> git clone https://example.com/wp-json/git/v1/md.git site</span>
-<span class="terminal-line terminal-muted">remote: exported posts and pages as Markdown</span>
-<span class="terminal-line"><span class="terminal-prompt">$</span> cd site</span>
-<span class="terminal-line"><span class="terminal-prompt">$</span> codex "Update page/home.md"</span>
-<span class="terminal-line terminal-comment">edit: page/home.md</span>
-<span class="terminal-line"><span class="terminal-prompt">$</span> git diff -- page/home.md</span>
-<span class="terminal-line terminal-muted">@@</span>
-<span class="terminal-line terminal-diff-remove">- Old CTA copy</span>
-<span class="terminal-line terminal-diff-add">+ Keep WordPress in charge</span>
-<span class="terminal-line"><span class="terminal-prompt">$</span> git push origin trunk</span>
-<span class="terminal-line terminal-success">remote: checked WordPress permissions</span>
-<span class="terminal-line terminal-success">remote: stale state check passed</span>
-<span class="terminal-line terminal-success">remote: created WordPress revision #184</span>
-<span class="terminal-line terminal-success">remote: applied 1 Markdown change</span></code></pre>
-				<div class="terminal-summary">
-					<span>
+				<div class="terminal-summary" aria-label="Terminal tabs">
+					<span class="is-active">
 						<strong>.md</strong>
-						Markdown in Git
+						Markdown
 					</span>
 					<span>
 						<strong>WP</strong>
-						Roles and revisions
+						Roles
 					</span>
 					<span>
 						<strong>pull</strong>
-						Admin edits show up
+						Admin edits
 					</span>
+				</div>
+				<div class="terminal-body">
+					<div class="terminal-output" id="landing-terminal-output" aria-live="polite"></div>
+					<label class="terminal-input-row" for="landing-terminal-input">
+						<span class="terminal-prompt-chip">
+							<span class="terminal-prompt-user">push-md</span>
+							<span class="terminal-prompt-mark">:</span>
+							<span class="terminal-prompt-path" id="landing-terminal-cwd">~/site</span>
+							<span class="terminal-prompt-mark">$</span>
+						</span>
+						<span class="terminal-entry">
+							<input class="terminal-input" id="landing-terminal-input" type="text" autocomplete="off" spellcheck="false" placeholder="Type an emulated command" aria-label="Type an emulated command">
+							<span class="terminal-input-ghost" id="landing-terminal-input-ghost" aria-hidden="true"></span>
+						</span>
+					</label>
 				</div>
 			</div>
 		</section>
@@ -247,7 +248,7 @@
 	<footer class="site-footer">
 		<p>Push MD is part of the WordPress PHP Toolkit.</p>
 		<div>
-			<a href="../README.md">Developer docs</a>
+			<a href="https://github.com/Automattic/php-toolkit/tree/trunk/plugins/push-md/docs">Developer docs</a>
 			<a href="../prd.md">PRD</a>
 			<a href="https://github.com/WordPress/php-toolkit/tree/trunk/plugins/push-md">GitHub</a>
 		</div>

--- a/plugins/push-md/docs/landing/index.html
+++ b/plugins/push-md/docs/landing/index.html
@@ -19,6 +19,7 @@
 			<a href="#how-it-works">Use cases</a>
 			<a href="#permissions">Permissions</a>
 			<a href="#agent-skills">Agent skills</a>
+			<a href="#faq">FAQ</a>
 			<a href="../README.md">Docs</a>
 		</nav>
 		<a class="button button-primary" href="#install">Install plugin</a>
@@ -156,6 +157,66 @@
 							<span>Global Styles overlays</span>
 						</div>
 					</div>
+				</article>
+			</div>
+		</section>
+
+		<section class="doc-section faq-section" id="faq" aria-labelledby="faq-title">
+			<div class="section-copy">
+				<h2 id="faq-title"><span class="md-token">##</span> FAQ</h2>
+				<p>
+					Short answers for the places where Git workflows usually get tangled with
+					WordPress publishing, permissions, and revision history.
+				</p>
+			</div>
+
+			<div class="faq-list">
+				<article class="faq-item">
+					<h3><span class="md-token">###</span> Is WordPress still the source of truth?</h3>
+					<p>
+						Yes. Your WordPress database stays authoritative. Git clients read and write
+						through Push MD, so there is no separate repository to reconcile.
+					</p>
+				</article>
+
+				<article class="faq-item">
+					<h3><span class="md-token">###</span> Does this work with any Git client?</h3>
+					<p>
+						Yes. Agents, terminals, desktop apps, and editors can use normal Git over HTTPS
+						against the WordPress remote.
+					</p>
+				</article>
+
+				<article class="faq-item">
+					<h3><span class="md-token">###</span> What happens when someone edits in WP-Admin?</h3>
+					<p>
+						WP-Admin edits become Git-visible on pull. If a local checkout is stale, Push MD
+						rejects the push before writing over newer WordPress content.
+					</p>
+				</article>
+
+				<article class="faq-item">
+					<h3><span class="md-token">###</span> How do permissions work?</h3>
+					<p>
+						Push MD uses WordPress authentication and Application Passwords, then respects the
+						current user's capabilities before accepting a write.
+					</p>
+				</article>
+
+				<article class="faq-item">
+					<h3><span class="md-token">###</span> Do pushes create revisions?</h3>
+					<p>
+						Accepted Markdown content pushes go through WordPress APIs and create WordPress
+						revisions, so changes remain reviewable in the usual WordPress history.
+					</p>
+				</article>
+
+				<article class="faq-item">
+					<h3><span class="md-token">###</span> Is this a static site generator?</h3>
+					<p>
+						No. It gives you the local-file workflow people like in static site generators,
+						while WordPress still handles previews, rendering, publishing, roles, and revisions.
+					</p>
 				</article>
 			</div>
 		</section>

--- a/plugins/push-md/docs/landing/index.html
+++ b/plugins/push-md/docs/landing/index.html
@@ -28,11 +28,11 @@
 		<section class="hero" id="top" aria-labelledby="hero-title">
 			<div class="hero-copy">
 				<p class="file-label">page/push-md.md</p>
-				<h1 id="hero-title"><span class="md-token">#</span> Let coding agents work in Git. Keep WordPress in charge.</h1>
+				<h1 id="hero-title"><span class="md-token">#</span> Write Markdown with agents. Keep WordPress in charge.</h1>
 				<p class="hero-subhead">
-					Push MD turns WordPress into a Git remote for supported content, so agents and
-					Markdown-first teams can clone, diff, commit, and push while WordPress remains
-					the source of truth.
+					Push MD makes WordPress the Git remote for Markdown-first content work:
+					agents edit <code>.md</code> files, WordPress enforces roles, creates
+					revisions, and renders the final site.
 				</p>
 				<div class="hero-actions" aria-label="Primary actions">
 					<a class="button button-primary" href="#install">Install plugin</a>
@@ -46,14 +46,19 @@
 						<span>page/home.md</span>
 						<span>trunk</span>
 					</div>
-					<pre class="markdown-source" aria-label="Markdown source"><code><span class="md-line md-heading"># Let coding agents work in Git</span>
-<span class="md-line">WordPress stays authoritative while agents edit files.</span>
+					<pre class="markdown-source" aria-label="Markdown source"><code><span class="md-line md-muted">---</span>
+<span class="md-line md-key">title: Markdown for WordPress agents</span>
+<span class="md-line md-key">status: draft</span>
+<span class="md-line md-muted">---</span>
 <span class="md-line"></span>
-<span class="md-line md-heading">## Why this works</span>
-<span class="md-line">- WordPress is the Git remote.</span>
-<span class="md-line">- Existing roles decide who can read or push.</span>
+<span class="md-line md-heading"># Markdown in Git</span>
+<span class="md-line">Agents edit ordinary Markdown files in a checkout.</span>
+<span class="md-line"></span>
+<span class="md-line md-heading">## WordPress stays in charge</span>
+<span class="md-line">- WordPress is the Git remote and source of truth.</span>
+<span class="md-line">- Roles decide who can read or push.</span>
 <span class="md-line">- Accepted pushes create WordPress revisions.</span>
-<span class="md-line">- WP-Admin edits become visible on pull.</span>
+<span class="md-line">- WordPress renders the published page.</span>
 <span class="md-line"></span>
 <span class="md-line md-heading">## Agent run</span>
 <span class="md-line md-code">git clone https://example.com/wp-json/git/v1/md.git my-site</span>
@@ -61,15 +66,21 @@
 <span class="md-line md-code">git push origin trunk</span></code></pre>
 				</div>
 
+				<div class="format-bridge" aria-hidden="true">
+					<span>Markdown</span>
+					<strong>-&gt;</strong>
+					<span>WordPress</span>
+				</div>
+
 				<article class="preview-card">
 					<p class="preview-kicker">Rendered by WordPress</p>
-					<h2>Let coding agents work in Git</h2>
-					<p>WordPress stays authoritative while agents edit files.</p>
-					<h3>Why this works</h3>
+					<h2>Markdown for WordPress agents</h2>
+					<p>Agents edit Markdown. WordPress publishes the page, enforces access, and keeps the revision trail.</p>
+					<h3>WordPress guarantees</h3>
 					<ul>
-						<li>WordPress is the Git remote.</li>
-						<li>Roles decide who can read or push.</li>
+						<li>Role-aware clone and push access.</li>
 						<li>Accepted pushes create revisions.</li>
+						<li>WP-Admin edits are visible on pull.</li>
 					</ul>
 					<div class="remote-output">
 						<span>remote: checked WordPress permissions</span>
@@ -82,24 +93,24 @@
 
 		<section class="authority-strip" id="permissions" aria-label="Why WordPress stays authoritative">
 			<article>
-				<p class="section-path">## no-sync-layer</p>
-				<h2>WordPress is the remote.</h2>
-				<p>Agents and editors clone directly from <code>/wp-json/git/v1/md.git</code> instead of pushing through another canonical repository.</p>
+				<p class="section-path">## markdown-files</p>
+				<h2>Edit Markdown.</h2>
+				<p>Posts and pages appear as readable <code>.md</code> files, so agents and local editors can use familiar diffs and commits.</p>
 			</article>
 			<article>
-				<p class="section-path">## no-new-users</p>
-				<h2>Use WordPress roles.</h2>
+				<p class="section-path">## wordpress-remote</p>
+				<h2>Publish WordPress.</h2>
+				<p>Git clients clone directly from <code>/wp-json/git/v1/md.git</code>; WordPress remains the remote and source of truth.</p>
+			</article>
+			<article>
+				<p class="section-path">## wordpress-roles</p>
+				<h2>Respect roles.</h2>
 				<p>Git over HTTPS uses WordPress authentication, including Application Passwords, and respects existing capabilities.</p>
 			</article>
 			<article>
-				<p class="section-path">## revision-backed</p>
-				<h2>Pushes create revisions.</h2>
-				<p>Accepted content changes go through WordPress APIs, so publishing behavior, permissions, and revisions remain intact.</p>
-			</article>
-			<article>
-				<p class="section-path">## admin-safe</p>
-				<h2>Pull admin edits first.</h2>
-				<p>WP-Admin edits become Git-visible on pull, and stale pushes are rejected before WordPress content is changed.</p>
+				<p class="section-path">## wordpress-revisions</p>
+				<h2>Keep revisions.</h2>
+				<p>Accepted Markdown changes go through WordPress APIs, create revisions, and preserve publishing behavior.</p>
 			</article>
 		</section>
 
@@ -146,7 +157,7 @@ WP-Admin    -- revisions --&gt; WordPress</code></pre>
 		<section class="doc-section markdown-section" aria-labelledby="markdown-title">
 			<div class="section-copy">
 				<p class="section-path"># markdown-and-ssg-workflows</p>
-				<h2 id="markdown-title">Use local-file workflows without replacing WordPress.</h2>
+				<h2 id="markdown-title">Markdown is the editing format. WordPress is the publishing system.</h2>
 				<p>
 					If you like Astro, Jekyll, or a Markdown vault, Push MD gives you a familiar
 					file tree while WordPress keeps handling previews, publishing, permissions,
@@ -156,23 +167,23 @@ WP-Admin    -- revisions --&gt; WordPress</code></pre>
 			<div class="markdown-table" aria-label="Supported checkout file types">
 				<div class="table-row table-head">
 					<span>Path</span>
-					<span>What it edits</span>
+					<span>What WordPress does with it</span>
 				</div>
 				<div class="table-row">
 					<code>post/*.md</code>
-					<span>Posts as Markdown</span>
+					<span>Turns Markdown into WordPress posts and revisions</span>
 				</div>
 				<div class="table-row">
 					<code>page/**/*.md</code>
-					<span>Pages and hierarchy</span>
+					<span>Preserves page hierarchy and WordPress identity</span>
 				</div>
 				<div class="table-row">
 					<code>wp_template_part/**/*.html</code>
-					<span>Raw Gutenberg block files</span>
+					<span>Keeps block markup compatible with the Site Editor</span>
 				</div>
 				<div class="table-row">
 					<code>wp_global_styles/*.json</code>
-					<span>Editable Global Styles overlays</span>
+					<span>Applies editable Global Styles overlays</span>
 				</div>
 			</div>
 		</section>

--- a/plugins/push-md/docs/landing/index.html
+++ b/plugins/push-md/docs/landing/index.html
@@ -29,9 +29,9 @@
 			<div class="hero-copy">
 				<h1 id="hero-title"><span class="md-token">#</span> Markdown in Git. WordPress in charge.</h1>
 				<p class="hero-subhead">
-					Agents work in Git on ordinary <code>.md</code> files. Push MD makes
-					WordPress the remote that checks roles, creates revisions, rejects stale
-					pushes, and renders the site.
+					Agents work in Git on ordinary <code>.md</code> files while your WordPress
+					database remains the source of truth. Push MD checks roles, creates revisions,
+					rejects stale pushes, and lets WordPress render the site.
 				</p>
 				<div class="hero-actions" aria-label="Primary actions">
 					<a class="button button-primary" href="#install">Install plugin</a>

--- a/plugins/push-md/docs/landing/index.html
+++ b/plugins/push-md/docs/landing/index.html
@@ -29,9 +29,9 @@
 			<div class="hero-copy">
 				<h1 id="hero-title"><span class="md-token">#</span> Markdown in Git. WordPress in charge.</h1>
 				<p class="hero-subhead">
-					Agents work in Git on ordinary <code>.md</code> files while your WordPress
-					database remains the source of truth. Push MD checks roles, creates revisions,
-					rejects stale pushes, and lets WordPress render the site.
+					Agents and any Git client work on ordinary <code>.md</code> files while your
+					WordPress database remains the source of truth. Push MD checks roles, creates
+					revisions, rejects stale pushes, and lets WordPress render the site.
 				</p>
 				<div class="hero-actions" aria-label="Primary actions">
 					<a class="button button-primary" href="#install">Install plugin</a>
@@ -104,8 +104,8 @@
 				<h2 id="use-cases-title"><span class="md-token">##</span> Use cases</h2>
 				<p>
 					Push MD is for teams that want Git-shaped work without moving the source of
-					truth out of WordPress. Use it for agent runs, local Markdown edits, and
-					static-site-style publishing flows that still need WordPress roles and revisions.
+					truth out of WordPress. Use any Git client for agent runs, local Markdown edits,
+					and static-site-style publishing flows that still need WordPress roles and revisions.
 				</p>
 			</div>
 
@@ -118,7 +118,7 @@
 						coordinates each run through authentication, stale-state checks, and revisions.
 					</p>
 					<ul class="task-list">
-						<li><code>[x]</code> Clone supported content from WordPress.</li>
+						<li><code>[x]</code> Clone supported content from WordPress with any Git client.</li>
 						<li><code>[x]</code> Edit Markdown, block templates, and styles locally.</li>
 						<li><code>[x]</code> Carry site guidance in <code>AGENTS.md</code> and <code>SKILL.md</code>.</li>
 						<li><code>[x]</code> Push only after WordPress accepts the change.</li>
@@ -165,7 +165,7 @@
 				<h2 id="install-title"><span class="md-token">##</span> Clone WordPress like a Git remote.</h2>
 				<p>
 					Install Push MD, authenticate with a WordPress Application Password, then clone
-					the <code>trunk</code> branch from your site. Your Git client talks to WordPress directly.
+					the <code>trunk</code> branch from your site. Any Git client can talk to WordPress directly.
 				</p>
 			</div>
 			<div class="install-panel">

--- a/plugins/push-md/docs/landing/landing.css
+++ b/plugins/push-md/docs/landing/landing.css
@@ -464,8 +464,8 @@ pre {
 }
 
 .task-list li {
-	display: grid;
-	grid-template-columns: auto minmax(0, 1fr);
+	display: flex;
+	flex-wrap: wrap;
 	gap: 10px;
 	align-items: start;
 }

--- a/plugins/push-md/docs/landing/landing.css
+++ b/plugins/push-md/docs/landing/landing.css
@@ -397,15 +397,20 @@ pre {
 
 .doc-section {
 	display: grid;
-	grid-template-columns: minmax(0, 0.82fr) minmax(0, 1.18fr);
-	gap: clamp(28px, 5vw, 76px);
-	align-items: center;
+	grid-template-columns: minmax(0, 1fr);
+	justify-items: start;
+	gap: 28px;
+	align-items: start;
 	padding: 78px 0;
 	border-top: 1px solid rgba(222, 214, 199, 0.7);
 }
 
+.doc-section > :not(.section-copy) {
+	width: min(100%, 980px);
+}
+
 .section-copy h2 {
-	max-width: 660px;
+	max-width: 920px;
 	font-family: var(--serif);
 	font-size: clamp(34px, 4.2vw, 58px);
 	line-height: 1.08;
@@ -413,7 +418,7 @@ pre {
 }
 
 .section-copy p {
-	max-width: 590px;
+	max-width: 720px;
 	margin: 18px 0 0;
 	font-size: 17px;
 }

--- a/plugins/push-md/docs/landing/landing.css
+++ b/plugins/push-md/docs/landing/landing.css
@@ -1,0 +1,853 @@
+:root {
+	--bg: #f7f9f4;
+	--paper: #ffffff;
+	--ink: #182018;
+	--muted: #5e6b63;
+	--line: #dce3d6;
+	--green: #2f6f4e;
+	--green-soft: #e6f3ea;
+	--blue: #276b8f;
+	--blue-soft: #e4f2f8;
+	--coral: #d95c44;
+	--yellow: #e4b53b;
+	--terminal: #101510;
+	--terminal-line: #263029;
+	--terminal-text: #dce8dc;
+	--shadow: 0 24px 80px rgba(24, 32, 24, 0.18);
+	--mono: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+	--sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+	box-sizing: border-box;
+}
+
+html {
+	scroll-behavior: smooth;
+}
+
+body {
+	margin: 0;
+	background:
+		radial-gradient(circle at 12px 12px, rgba(47, 111, 78, 0.08) 1px, transparent 1px),
+		var(--bg);
+	background-size: 24px 24px;
+	color: var(--ink);
+	font-family: var(--sans);
+	font-size: 16px;
+	line-height: 1.55;
+}
+
+a {
+	color: inherit;
+}
+
+code,
+pre {
+	font-family: var(--mono);
+}
+
+.skip-link {
+	position: absolute;
+	left: 16px;
+	top: -80px;
+	z-index: 100;
+	padding: 10px 12px;
+	border-radius: 6px;
+	background: var(--ink);
+	color: #ffffff;
+	text-decoration: none;
+}
+
+.skip-link:focus {
+	top: 16px;
+}
+
+.site-header {
+	position: sticky;
+	top: 0;
+	z-index: 20;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 20px;
+	min-height: 72px;
+	padding: 14px clamp(18px, 4vw, 48px);
+	border-bottom: 1px solid rgba(220, 227, 214, 0.78);
+	background: rgba(247, 249, 244, 0.88);
+	backdrop-filter: blur(16px);
+}
+
+.brand {
+	display: inline-flex;
+	align-items: center;
+	gap: 10px;
+	color: var(--ink);
+	font-weight: 760;
+	text-decoration: none;
+	white-space: nowrap;
+}
+
+.brand-mark {
+	display: inline-grid;
+	place-items: center;
+	width: 38px;
+	height: 38px;
+	border: 1px solid rgba(24, 32, 24, 0.22);
+	border-radius: 8px;
+	background: var(--ink);
+	color: #ffffff;
+	font-size: 11px;
+	letter-spacing: 0.06em;
+}
+
+.site-nav {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: clamp(12px, 2vw, 28px);
+	color: var(--muted);
+	font-size: 14px;
+}
+
+.site-nav a,
+.site-footer a {
+	text-decoration: none;
+}
+
+.site-nav a:hover,
+.site-nav a:focus,
+.site-footer a:hover,
+.site-footer a:focus {
+	color: var(--green);
+}
+
+.button {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 42px;
+	padding: 10px 16px;
+	border: 1px solid transparent;
+	border-radius: 8px;
+	font-weight: 700;
+	text-decoration: none;
+	white-space: nowrap;
+	transition: transform 0.16s ease, box-shadow 0.16s ease, background 0.16s ease;
+}
+
+.button:hover,
+.button:focus {
+	transform: translateY(-1px);
+}
+
+.button-primary {
+	background: var(--ink);
+	color: #ffffff;
+	box-shadow: 0 12px 30px rgba(24, 32, 24, 0.2);
+}
+
+.button-secondary {
+	border-color: rgba(24, 32, 24, 0.18);
+	background: rgba(255, 255, 255, 0.72);
+	color: var(--ink);
+}
+
+.hero {
+	position: relative;
+	display: grid;
+	grid-template-columns: minmax(0, 0.82fr) minmax(520px, 1.18fr);
+	gap: clamp(26px, 4vw, 64px);
+	align-items: center;
+	max-width: 1340px;
+	min-height: 0;
+	margin: 0 auto;
+	padding: clamp(24px, 3.4vw, 42px) clamp(18px, 4vw, 48px) clamp(20px, 2.4vw, 30px);
+	overflow: hidden;
+}
+
+.hero::before,
+.hero::after {
+	content: "";
+	position: absolute;
+	z-index: -1;
+	border: 1px solid rgba(24, 32, 24, 0.08);
+	border-radius: 8px;
+	background: rgba(255, 255, 255, 0.52);
+}
+
+.hero::before {
+	right: 3%;
+	top: 12%;
+	width: 230px;
+	height: 142px;
+	transform: rotate(7deg);
+}
+
+.hero::after {
+	left: 7%;
+	bottom: 4%;
+	width: 180px;
+	height: 110px;
+	transform: rotate(-5deg);
+}
+
+.eyebrow {
+	margin: 0 0 12px;
+	color: var(--green);
+	font-size: 13px;
+	font-weight: 780;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+}
+
+.hero h1,
+.section-copy h2,
+.install-copy h2 {
+	margin: 0;
+	letter-spacing: 0;
+}
+
+.hero h1 {
+	max-width: 700px;
+	font-size: clamp(40px, 4.6vw, 58px);
+	line-height: 1;
+}
+
+.hero-subhead {
+	max-width: 680px;
+	margin: 24px 0 0;
+	color: var(--muted);
+	font-size: 19px;
+	line-height: 1.55;
+}
+
+.hero-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 12px;
+	margin: 28px 0 0;
+}
+
+.hero-visual {
+	position: relative;
+	min-width: 0;
+}
+
+.terminal-window {
+	position: relative;
+	overflow: hidden;
+	border: 1px solid rgba(16, 21, 16, 0.86);
+	border-radius: 8px;
+	background: var(--terminal);
+	box-shadow: var(--shadow);
+}
+
+.terminal-window::before {
+	content: "";
+	position: absolute;
+	inset: 42px 0 auto;
+	height: 1px;
+	background: var(--terminal-line);
+}
+
+.terminal-bar {
+	display: grid;
+	grid-template-columns: 82px minmax(0, 1fr) auto;
+	align-items: center;
+	gap: 14px;
+	height: 42px;
+	padding: 0 14px;
+	background: #192019;
+	color: #aebaae;
+	font-family: var(--mono);
+	font-size: 12px;
+}
+
+.window-dots {
+	display: flex;
+	gap: 7px;
+}
+
+.window-dots span {
+	width: 11px;
+	height: 11px;
+	border-radius: 50%;
+	background: var(--coral);
+}
+
+.window-dots span:nth-child(2) {
+	background: var(--yellow);
+}
+
+.window-dots span:nth-child(3) {
+	background: #3fb56b;
+}
+
+.terminal-transcript {
+	height: 370px;
+	margin: 0;
+	padding: 20px 20px 24px;
+	overflow: auto;
+	color: var(--terminal-text);
+	font-size: 13px;
+	line-height: 1.58;
+	white-space: pre-wrap;
+}
+
+.terminal-transcript .line {
+	display: block;
+	min-height: 21px;
+}
+
+.terminal-transcript .command {
+	color: #8bd6ff;
+}
+
+.terminal-transcript .success {
+	color: #8fe3a3;
+}
+
+.terminal-transcript .diff {
+	color: #ffd37b;
+}
+
+.terminal-transcript .output {
+	color: #c7d1c7;
+}
+
+.terminal-transcript.is-enhanced .line {
+	opacity: 0;
+	transform: translateY(4px);
+	transition: opacity 0.26s ease, transform 0.26s ease;
+}
+
+.terminal-transcript.is-enhanced .line.is-visible {
+	opacity: 1;
+	transform: translateY(0);
+}
+
+.source-badge {
+	position: absolute;
+	right: 20px;
+	top: -26px;
+	display: grid;
+	gap: 3px;
+	max-width: 310px;
+	padding: 15px 16px;
+	border: 1px solid rgba(47, 111, 78, 0.22);
+	border-radius: 8px;
+	background: #fafff8;
+	box-shadow: 0 18px 45px rgba(24, 32, 24, 0.16);
+}
+
+.source-badge-label {
+	color: var(--green);
+	font-size: 12px;
+	font-weight: 800;
+	letter-spacing: 0.07em;
+	text-transform: uppercase;
+}
+
+.source-badge strong {
+	font-size: 24px;
+	line-height: 1.1;
+}
+
+.source-badge span:last-child {
+	color: var(--muted);
+	font-size: 13px;
+}
+
+.authority-strip,
+.workflow-section,
+.skills-section,
+.markdown-section,
+.install-section,
+.site-footer {
+	max-width: 1240px;
+	margin: 0 auto;
+	padding-inline: clamp(18px, 4vw, 48px);
+}
+
+.authority-strip {
+	display: grid;
+	grid-template-columns: repeat(4, minmax(0, 1fr));
+	gap: 12px;
+	padding-top: 20px;
+	padding-bottom: 62px;
+}
+
+.authority-strip article,
+.skill-card,
+.install-panel,
+.file-matrix div,
+.flow-node {
+	border: 1px solid var(--line);
+	border-radius: 8px;
+	background: rgba(255, 255, 255, 0.78);
+}
+
+.authority-strip article {
+	padding: 18px;
+}
+
+.proof-kicker,
+.skill-label {
+	display: inline-flex;
+	align-items: center;
+	min-height: 24px;
+	padding: 3px 8px;
+	border-radius: 999px;
+	background: var(--green-soft);
+	color: var(--green);
+	font-size: 12px;
+	font-weight: 760;
+}
+
+.authority-strip h2 {
+	margin: 14px 0 8px;
+	font-size: 19px;
+	line-height: 1.2;
+	letter-spacing: 0;
+}
+
+.authority-strip p,
+.section-copy p,
+.skill-card p,
+.install-copy p,
+.install-note,
+.file-matrix span {
+	color: var(--muted);
+}
+
+.authority-strip p,
+.skill-card p {
+	margin: 0;
+	font-size: 14px;
+	line-height: 1.5;
+}
+
+.authority-strip p code,
+.section-copy p code,
+.install-copy p code,
+.install-steps code {
+	padding: 1px 4px;
+	border-radius: 4px;
+	background: rgba(39, 107, 143, 0.1);
+	color: var(--blue);
+	font-size: 0.94em;
+	overflow-wrap: anywhere;
+}
+
+.workflow-section,
+.skills-section,
+.markdown-section,
+.install-section {
+	display: grid;
+	grid-template-columns: minmax(0, 0.78fr) minmax(0, 1.22fr);
+	gap: clamp(24px, 5vw, 72px);
+	align-items: center;
+	padding-top: 72px;
+	padding-bottom: 72px;
+}
+
+.section-copy h2,
+.install-copy h2 {
+	max-width: 620px;
+	font-size: clamp(34px, 4vw, 54px);
+	line-height: 1.02;
+}
+
+.section-copy p,
+.install-copy p {
+	max-width: 580px;
+	margin: 18px 0 0;
+	font-size: 17px;
+}
+
+.flow-map {
+	position: relative;
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	grid-template-rows: repeat(3, 116px);
+	gap: 14px;
+	min-height: 372px;
+}
+
+.flow-map::before {
+	content: "";
+	position: absolute;
+	inset: 58px 17% 58px;
+	border: 2px dashed rgba(39, 107, 143, 0.3);
+	border-radius: 8px;
+}
+
+.flow-node {
+	position: relative;
+	z-index: 1;
+	display: grid;
+	align-content: center;
+	gap: 8px;
+	padding: 16px;
+	box-shadow: 0 14px 34px rgba(24, 32, 24, 0.08);
+}
+
+.flow-node span {
+	font-weight: 800;
+}
+
+.flow-node code {
+	width: max-content;
+	max-width: 100%;
+	padding: 3px 7px;
+	border-radius: 6px;
+	background: #eef4ea;
+	color: #3b493f;
+	font-size: 12px;
+	overflow-wrap: anywhere;
+}
+
+.flow-node.core {
+	grid-column: 2;
+	grid-row: 2;
+	border-color: rgba(47, 111, 78, 0.35);
+	background: var(--ink);
+	color: #ffffff;
+}
+
+.flow-node.core strong {
+	color: #d6ead9;
+	font-size: 13px;
+	line-height: 1.4;
+}
+
+.flow-node.agent-a {
+	grid-column: 1;
+	grid-row: 1;
+}
+
+.flow-node.agent-b {
+	grid-column: 3;
+	grid-row: 1;
+}
+
+.flow-node.editor {
+	grid-column: 1;
+	grid-row: 3;
+}
+
+.flow-node.admin {
+	grid-column: 3;
+	grid-row: 3;
+}
+
+.skills-grid {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 16px;
+}
+
+.skill-card {
+	padding: 22px;
+	min-height: 250px;
+}
+
+.skill-card.highlight {
+	border-color: rgba(39, 107, 143, 0.32);
+	background: var(--blue-soft);
+}
+
+.skill-card h3 {
+	margin: 18px 0 10px;
+	font-size: 25px;
+	line-height: 1.12;
+	letter-spacing: 0;
+}
+
+.skill-card h3 code {
+	font-size: 0.86em;
+}
+
+.file-matrix {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 12px;
+}
+
+.file-matrix div {
+	display: grid;
+	gap: 8px;
+	padding: 18px;
+}
+
+.file-matrix code {
+	color: var(--blue);
+	font-size: 14px;
+	overflow-wrap: anywhere;
+}
+
+.install-section {
+	align-items: stretch;
+	padding-bottom: 90px;
+}
+
+.install-panel {
+	display: grid;
+	gap: 22px;
+	padding: clamp(22px, 4vw, 34px);
+	background: #fffdf6;
+}
+
+.install-steps {
+	display: grid;
+	gap: 12px;
+	margin: 0;
+	padding-left: 22px;
+}
+
+.install-steps li {
+	padding-left: 6px;
+	font-weight: 700;
+}
+
+.command-copy {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	gap: 10px;
+	align-items: center;
+	padding: 10px;
+	border: 1px solid rgba(24, 32, 24, 0.16);
+	border-radius: 8px;
+	background: #ffffff;
+}
+
+.command-copy code {
+	display: block;
+	color: #213023;
+	overflow-wrap: anywhere;
+}
+
+.copy-button {
+	min-height: 38px;
+	padding: 8px 13px;
+	border: 1px solid rgba(24, 32, 24, 0.2);
+	border-radius: 7px;
+	background: var(--green);
+	color: #ffffff;
+	font: inherit;
+	font-weight: 760;
+	cursor: pointer;
+}
+
+.copy-button.is-copied {
+	background: var(--blue);
+}
+
+.install-note {
+	margin: 0;
+	font-size: 14px;
+}
+
+.site-footer {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 20px;
+	padding-top: 26px;
+	padding-bottom: 32px;
+	border-top: 1px solid var(--line);
+	color: var(--muted);
+	font-size: 14px;
+}
+
+.site-footer p {
+	margin: 0;
+}
+
+.site-footer div {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 16px;
+}
+
+@media (max-width: 1080px) {
+	.site-header {
+		flex-wrap: wrap;
+	}
+
+	.site-nav {
+		order: 3;
+		width: 100%;
+		justify-content: flex-start;
+		overflow-x: auto;
+		padding-bottom: 2px;
+	}
+
+	.hero,
+	.workflow-section,
+	.skills-section,
+	.markdown-section,
+	.install-section {
+		grid-template-columns: 1fr;
+	}
+
+	.hero {
+		min-height: auto;
+		padding-top: 38px;
+	}
+
+	.hero h1 {
+		font-size: 52px;
+	}
+
+	.hero-subhead {
+		font-size: 18px;
+	}
+
+	.authority-strip {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	.terminal-transcript {
+		height: 430px;
+	}
+
+	.source-badge {
+		position: relative;
+		right: auto;
+		bottom: auto;
+		margin: 14px 0 0;
+		max-width: none;
+	}
+}
+
+@media (max-width: 720px) {
+	body {
+		background-size: 20px 20px;
+	}
+
+	.site-header {
+		position: static;
+		min-height: 0;
+		gap: 12px;
+		padding: 12px 16px;
+	}
+
+	.site-header > .button {
+		width: 100%;
+	}
+
+	.site-nav {
+		gap: 14px;
+		font-size: 13px;
+	}
+
+	.hero {
+		padding: 24px 16px 20px;
+	}
+
+	.hero h1 {
+		font-size: 40px;
+		line-height: 1;
+	}
+
+	.hero-subhead,
+	.section-copy p,
+	.install-copy p {
+		font-size: 16px;
+	}
+
+	.hero-actions .button {
+		flex: 1 1 180px;
+	}
+
+	.terminal-bar {
+		grid-template-columns: 64px minmax(0, 1fr);
+	}
+
+	.terminal-bar span:last-child {
+		display: none;
+	}
+
+	.terminal-transcript {
+		height: 290px;
+		padding: 16px;
+		font-size: 12px;
+		line-height: 1.52;
+	}
+
+	.authority-strip,
+	.workflow-section,
+	.skills-section,
+	.markdown-section,
+	.install-section,
+	.site-footer {
+		padding-inline: 16px;
+	}
+
+	.authority-strip,
+	.skills-grid,
+	.file-matrix {
+		grid-template-columns: 1fr;
+	}
+
+	.authority-strip {
+		padding-top: 8px;
+		padding-bottom: 38px;
+	}
+
+	.workflow-section,
+	.skills-section,
+	.markdown-section,
+	.install-section {
+		padding-top: 46px;
+		padding-bottom: 46px;
+	}
+
+	.section-copy h2,
+	.install-copy h2 {
+		font-size: 34px;
+	}
+
+	.flow-map {
+		grid-template-columns: 1fr;
+		grid-template-rows: none;
+		min-height: 0;
+	}
+
+	.flow-map::before {
+		inset: 30px 50% 30px auto;
+		width: 2px;
+		border-width: 0 0 0 2px;
+	}
+
+	.flow-node,
+	.flow-node.core,
+	.flow-node.agent-a,
+	.flow-node.agent-b,
+	.flow-node.editor,
+	.flow-node.admin {
+		grid-column: auto;
+		grid-row: auto;
+	}
+
+	.command-copy {
+		grid-template-columns: 1fr;
+	}
+
+	.site-footer {
+		display: grid;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	*,
+	*::before,
+	*::after {
+		scroll-behavior: auto !important;
+		transition-duration: 0.01ms !important;
+		animation-duration: 0.01ms !important;
+		animation-iteration-count: 1 !important;
+	}
+}

--- a/plugins/push-md/docs/landing/landing.css
+++ b/plugins/push-md/docs/landing/landing.css
@@ -237,9 +237,7 @@ pre {
 
 .terminal-card,
 .authority-strip article,
-.flow-note,
-.markdown-callout,
-.markdown-table,
+.use-case-card,
 .install-panel {
 	border: 1px solid var(--line);
 	border-radius: 8px;
@@ -370,23 +368,28 @@ pre {
 
 .authority-strip p:last-child,
 .section-copy p,
-.markdown-callout p,
-.install-note,
-.table-row span {
+.use-case-card p:not(.callout-label),
+.task-list,
+.file-map span,
+.install-note {
 	color: var(--muted);
 }
 
 .authority-strip p:last-child,
-.markdown-callout p {
+.use-case-card p:not(.callout-label) {
 	margin: 12px 0 0;
-	font-size: 14px;
 	line-height: 1.5;
+}
+
+.authority-strip p:last-child {
+	font-size: 14px;
 }
 
 .authority-strip code,
 .section-copy code,
 .install-steps code,
-.markdown-callout code {
+.use-case-card code,
+.file-map code {
 	padding: 1px 4px;
 	border-radius: 4px;
 	background: rgba(30, 107, 131, 0.1);
@@ -426,42 +429,12 @@ pre {
 	font-size: 17px;
 }
 
-.flow-note {
-	position: relative;
-	overflow: hidden;
-	padding: 0;
-	box-shadow: none;
-}
-
-.flow-note pre {
-	margin: 0;
-	padding: 24px;
-	overflow: auto;
-	color: #efe8d8;
-	background: #1f1d19;
-	font-size: 14px;
-	line-height: 1.85;
-}
-
-.flow-core {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
+.use-case-list {
+	display: grid;
 	gap: 18px;
-	padding: 18px 20px;
-	background: var(--paper);
 }
 
-.flow-core strong {
-	font-size: 22px;
-}
-
-.flow-core span {
-	color: var(--muted);
-	font-size: 14px;
-}
-
-.markdown-callout {
+.use-case-card {
 	padding: clamp(22px, 4vw, 36px);
 	background:
 		linear-gradient(90deg, rgba(176, 93, 51, 0.12) 0 5px, transparent 5px),
@@ -469,42 +442,64 @@ pre {
 	box-shadow: none;
 }
 
-.markdown-callout h3 {
+.use-case-card .callout-label {
+	margin: 0 0 12px;
+	color: var(--hash);
+}
+
+.use-case-card h3 {
 	margin: 0;
-	font-size: clamp(26px, 3vw, 38px);
-	line-height: 1.1;
+	font-family: var(--serif);
+	font-size: clamp(28px, 3.1vw, 42px);
+	line-height: 1.08;
 	letter-spacing: 0;
 }
 
-.markdown-callout p:last-child {
-	font-size: 16px;
-}
-
-.markdown-table {
+.task-list {
 	display: grid;
-	overflow: hidden;
-	box-shadow: none;
+	gap: 10px;
+	margin: 20px 0 0;
+	padding: 0;
+	list-style: none;
 }
 
-.table-row {
+.task-list li {
 	display: grid;
-	grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
-	gap: 16px;
-	padding: 15px 18px;
-	border-top: 1px solid var(--line);
+	grid-template-columns: auto minmax(0, 1fr);
+	gap: 10px;
+	align-items: start;
 }
 
-.table-row:first-child {
-	border-top: 0;
-}
-
-.table-head {
-	background: var(--paper-deep);
-	color: var(--ink);
+.task-list li > code:first-child {
+	padding: 0;
+	background: transparent;
+	color: var(--green);
 	font-weight: 800;
 }
 
-.table-row code {
+.file-map {
+	display: grid;
+	margin-top: 24px;
+	overflow: hidden;
+	border: 1px solid var(--line);
+	border-radius: 8px;
+	background: rgba(255, 253, 247, 0.72);
+}
+
+.file-map div {
+	display: grid;
+	grid-template-columns: minmax(220px, 0.8fr) minmax(0, 1.2fr);
+	gap: 16px;
+	padding: 14px 16px;
+	border-top: 1px solid var(--line);
+}
+
+.file-map div:first-child {
+	border-top: 0;
+}
+
+.file-map code {
+	background: transparent;
 	color: var(--link);
 	overflow-wrap: anywhere;
 }
@@ -693,9 +688,8 @@ pre {
 		font-size: 34px;
 	}
 
-	.table-row,
-	.code-block,
-	.flow-core {
+	.file-map div,
+	.code-block {
 		grid-template-columns: 1fr;
 	}
 

--- a/plugins/push-md/docs/landing/landing.css
+++ b/plugins/push-md/docs/landing/landing.css
@@ -159,16 +159,14 @@ pre {
 
 .hero {
 	display: grid;
-	grid-template-columns: minmax(0, 0.72fr) minmax(520px, 1.28fr);
+	grid-template-columns: minmax(420px, 0.82fr) minmax(520px, 1.18fr);
 	gap: clamp(30px, 5vw, 76px);
 	align-items: center;
 	min-height: 0;
 	padding: clamp(34px, 5vw, 58px) 0 46px;
 }
 
-.file-label,
-.section-path,
-.preview-kicker {
+.callout-label {
 	margin: 0 0 12px;
 	color: var(--hash);
 	font-family: var(--mono);
@@ -187,7 +185,7 @@ pre {
 .hero h1 {
 	max-width: 680px;
 	font-family: var(--serif);
-	font-size: clamp(44px, 5.4vw, 74px);
+	font-size: clamp(44px, 4.9vw, 68px);
 	font-weight: 700;
 	line-height: 0.96;
 }
@@ -198,6 +196,12 @@ pre {
 	font-size: 0.72em;
 	font-weight: 760;
 	vertical-align: 0.08em;
+}
+
+.section-copy .md-token,
+.authority-strip .md-token {
+	margin-right: 6px;
+	font-size: 0.72em;
 }
 
 .hero-subhead {
@@ -223,17 +227,7 @@ pre {
 	margin: 28px 0 0;
 }
 
-.markdown-workbench {
-	position: relative;
-	display: grid;
-	grid-template-columns: minmax(0, 1.02fr) 92px minmax(290px, 0.9fr);
-	gap: 14px;
-	align-items: stretch;
-	min-width: 0;
-}
-
-.editor-card,
-.preview-card,
+.terminal-card,
 .authority-strip article,
 .flow-note,
 .markdown-callout,
@@ -245,13 +239,13 @@ pre {
 	box-shadow: var(--shadow);
 }
 
-.editor-card {
+.terminal-card {
 	overflow: hidden;
 	background: #1f1d19;
 	color: #efe8d8;
 }
 
-.editor-topline {
+.terminal-topline {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
@@ -265,119 +259,88 @@ pre {
 	font-size: 12px;
 }
 
-.markdown-source {
-	height: 458px;
+.terminal-dots {
+	display: inline-flex;
+	gap: 6px;
+}
+
+.terminal-dots span {
+	width: 10px;
+	height: 10px;
+	border-radius: 50%;
+	background: #f4d06f;
+}
+
+.terminal-dots span:first-child {
+	background: #d66a4b;
+}
+
+.terminal-dots span:last-child {
+	background: #68a77d;
+}
+
+.terminal-source {
+	min-height: 410px;
 	margin: 0;
-	padding: 18px 18px 22px;
+	padding: 20px 22px 24px;
 	overflow: auto;
-	font-size: 13px;
-	line-height: 1.68;
+	font-size: 14px;
+	line-height: 1.72;
 	white-space: pre-wrap;
 }
 
-.md-line {
+.terminal-line {
 	display: block;
 	min-height: 22px;
 }
 
-.md-heading {
+.terminal-prompt {
 	color: #f4d06f;
-	font-weight: 760;
+	font-weight: 800;
 }
 
-.md-code {
+.terminal-comment {
 	color: #91d6ee;
 }
 
-.md-key {
+.terminal-success,
+.terminal-diff-add {
 	color: #aee0b5;
 }
 
-.md-muted {
+.terminal-muted {
 	color: #9b917f;
 }
 
-.markdown-source.is-enhanced .md-line {
-	opacity: 0;
-	transform: translateY(4px);
-	transition: opacity 0.24s ease, transform 0.24s ease;
+.terminal-diff-remove {
+	color: #e7a191;
 }
 
-.markdown-source.is-enhanced .md-line.is-visible {
-	opacity: 1;
-	transform: translateY(0);
-}
-
-.format-bridge {
+.terminal-summary {
 	display: grid;
-	align-content: center;
-	justify-items: center;
-	gap: 8px;
-	min-width: 0;
-	padding: 16px 8px;
-	border: 1px dashed rgba(176, 93, 51, 0.48);
-	border-radius: 8px;
-	background: rgba(255, 253, 247, 0.68);
-	color: var(--hash);
-	font-family: var(--mono);
-	font-size: 12px;
-	font-weight: 780;
-	text-align: center;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	border-top: 1px solid rgba(255, 253, 247, 0.12);
+	background: #2a251e;
 }
 
-.format-bridge strong {
+.terminal-summary span {
 	display: grid;
-	place-items: center;
-	width: 36px;
-	height: 36px;
-	border-radius: 50%;
-	background: var(--hash);
+	gap: 2px;
+	padding: 15px 18px;
+	border-left: 1px solid rgba(255, 253, 247, 0.1);
+	color: #cfc4ae;
+	font-size: 13px;
+	line-height: 1.35;
+}
+
+.terminal-summary span:first-child {
+	border-left: 0;
+}
+
+.terminal-summary strong {
 	color: #ffffff;
-	font-size: 14px;
-}
-
-.preview-card {
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
-	padding: clamp(20px, 3vw, 30px);
-}
-
-.preview-card h2 {
-	margin: 0;
-	font-family: var(--serif);
-	font-size: clamp(30px, 3.2vw, 44px);
-	line-height: 1.04;
-	letter-spacing: 0;
-}
-
-.preview-card h3 {
-	margin: 22px 0 8px;
-	font-size: 18px;
-	line-height: 1.2;
-}
-
-.preview-card p,
-.preview-card li {
-	color: var(--muted);
-}
-
-.preview-card ul {
-	margin: 10px 0 0;
-	padding-left: 20px;
-}
-
-.remote-output {
-	display: grid;
-	gap: 5px;
-	margin-top: 22px;
-	padding: 12px;
-	border-radius: 8px;
-	background: #f1f7ef;
-	color: var(--green);
 	font-family: var(--mono);
-	font-size: 12px;
-	line-height: 1.5;
+	font-size: 13px;
 }
 
 .authority-strip {
@@ -393,7 +356,7 @@ pre {
 }
 
 .authority-strip h2 {
-	font-size: 20px;
+	font-size: 19px;
 	line-height: 1.2;
 }
 
@@ -407,7 +370,7 @@ pre {
 
 .authority-strip p:last-child,
 .markdown-callout p {
-	margin: 10px 0 0;
+	margin: 12px 0 0;
 	font-size: 14px;
 	line-height: 1.5;
 }
@@ -440,7 +403,7 @@ pre {
 	line-height: 1.02;
 }
 
-.section-copy p:not(.section-path) {
+.section-copy p {
 	max-width: 590px;
 	margin: 18px 0 0;
 	font-size: 17px;
@@ -629,23 +592,12 @@ pre {
 		min-height: 0;
 	}
 
-	.markdown-workbench {
-		grid-template-columns: minmax(0, 1fr);
-	}
-
-	.format-bridge {
-		grid-template-columns: 1fr auto 1fr;
-		align-items: center;
-		padding: 12px;
-		text-transform: none;
-	}
-
 	.authority-strip {
 		grid-template-columns: repeat(2, minmax(0, 1fr));
 	}
 
-	.markdown-source {
-		height: 360px;
+	.terminal-source {
+		min-height: 360px;
 	}
 }
 
@@ -684,7 +636,7 @@ pre {
 	}
 
 	.hero-subhead,
-	.section-copy p:not(.section-path) {
+	.section-copy p {
 		font-size: 16px;
 	}
 
@@ -692,14 +644,23 @@ pre {
 		flex: 1 1 180px;
 	}
 
-	.markdown-source {
-		height: 300px;
+	.terminal-source {
+		min-height: 300px;
 		padding: 16px;
 		font-size: 12px;
 	}
 
-	.preview-card {
-		padding: 20px;
+	.terminal-summary {
+		grid-template-columns: 1fr;
+	}
+
+	.terminal-summary span {
+		border-top: 1px solid rgba(255, 253, 247, 0.1);
+		border-left: 0;
+	}
+
+	.terminal-summary span:first-child {
+		border-top: 0;
 	}
 
 	.authority-strip {

--- a/plugins/push-md/docs/landing/landing.css
+++ b/plugins/push-md/docs/landing/landing.css
@@ -253,8 +253,10 @@ pre {
 
 .terminal-card {
 	overflow: hidden;
-	background: #1f1d19;
+	background: #151515;
 	color: #efe8d8;
+	font-family: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+	font-variant-ligatures: none;
 }
 
 .terminal-topline {
@@ -262,13 +264,18 @@ pre {
 	align-items: center;
 	justify-content: space-between;
 	gap: 12px;
-	height: 42px;
-	padding: 0 14px;
-	border-bottom: 1px solid rgba(255, 253, 247, 0.12);
-	background: #2a251e;
+	height: 34px;
+	padding: 0 12px;
+	border-bottom: 1px solid rgba(255, 253, 247, 0.08);
+	background: linear-gradient(180deg, #34302b, #23211e);
 	color: #cfc4ae;
-	font-family: var(--mono);
-	font-size: 12px;
+	font-size: 11px;
+}
+
+.terminal-topline > span:nth-child(2) {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .terminal-dots {
@@ -277,8 +284,8 @@ pre {
 }
 
 .terminal-dots span {
-	width: 10px;
-	height: 10px;
+	width: 11px;
+	height: 11px;
 	border-radius: 50%;
 	background: #f4d06f;
 }
@@ -291,19 +298,92 @@ pre {
 	background: #68a77d;
 }
 
-.terminal-source {
-	min-height: 410px;
-	margin: 0;
-	padding: 20px 22px 24px;
+.terminal-status {
+	color: #b7ad9e;
+	text-align: right;
+}
+
+.terminal-summary {
+	display: flex;
+	gap: 4px;
+	align-items: end;
+	padding: 6px 10px 0;
+	border-bottom: 1px solid rgba(255, 253, 247, 0.08);
+	background: #191817;
+}
+
+.terminal-summary span {
+	display: inline-flex;
+	align-items: baseline;
+	gap: 8px;
+	min-width: 0;
+	max-width: 150px;
+	padding: 7px 10px 8px;
+	overflow: hidden;
+	border: 1px solid rgba(255, 253, 247, 0.1);
+	border-bottom: 0;
+	border-radius: 7px 7px 0 0;
+	background: #24211e;
+	color: #bcb2a3;
+	font-size: 12px;
+	line-height: 1.2;
+	white-space: nowrap;
+}
+
+.terminal-summary span.is-active {
+	background: #151515;
+	color: #efe8d8;
+	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.terminal-summary strong {
+	color: #ffffff;
+	font-size: 12px;
+	flex: 0 0 auto;
+}
+
+.terminal-body {
+	display: flex;
+	flex-direction: column;
+	height: 494px;
+	padding: 16px 18px 15px;
+	color: #d7dee6;
+	font-size: 13px;
+	line-height: 1.54;
+}
+
+.terminal-output {
+	scrollbar-color: #6b655c #1d1b18;
+	scrollbar-width: thin;
+	flex: 1;
 	overflow: auto;
-	font-size: 14px;
-	line-height: 1.72;
+	padding-right: 6px;
 	white-space: pre-wrap;
+}
+
+.terminal-output::-webkit-scrollbar {
+	width: 10px;
+}
+
+.terminal-output::-webkit-scrollbar-track {
+	border-radius: 999px;
+	background: #1d1b18;
+}
+
+.terminal-output::-webkit-scrollbar-thumb {
+	border: 2px solid #1d1b18;
+	border-radius: 999px;
+	background: #6b655c;
+}
+
+.terminal-output::-webkit-scrollbar-thumb:hover {
+	background: #8b8275;
 }
 
 .terminal-line {
 	display: block;
-	min-height: 22px;
+	min-height: 20px;
+	overflow-wrap: anywhere;
 }
 
 .terminal-prompt {
@@ -311,13 +391,24 @@ pre {
 	font-weight: 800;
 }
 
+.terminal-accent,
+.terminal-prompt-path {
+	color: #91d6ee;
+}
+
 .terminal-comment {
 	color: #91d6ee;
 }
 
 .terminal-success,
+.terminal-prompt-user,
 .terminal-diff-add {
 	color: #aee0b5;
+}
+
+.terminal-warning,
+.terminal-prompt-mark {
+	color: #f4d06f;
 }
 
 .terminal-muted {
@@ -328,31 +419,118 @@ pre {
 	color: #e7a191;
 }
 
-.terminal-summary {
-	display: grid;
-	grid-template-columns: repeat(3, minmax(0, 1fr));
-	border-top: 1px solid rgba(255, 253, 247, 0.12);
-	background: #2a251e;
+.terminal-error {
+	color: #e7a191;
 }
 
-.terminal-summary span {
-	display: grid;
-	gap: 2px;
-	padding: 15px 18px;
-	border-left: 1px solid rgba(255, 253, 247, 0.1);
-	color: #cfc4ae;
-	font-size: 13px;
-	line-height: 1.35;
+.terminal-input-row {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	min-height: 38px;
+	margin-top: 10px;
+	padding: 6px 8px;
+	border: 1px solid rgba(145, 214, 238, 0.16);
+	border-radius: 6px;
+	background: #111111;
+	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
 
-.terminal-summary span:first-child {
-	border-left: 0;
+.terminal-input-row:focus-within {
+	border-color: rgba(145, 214, 238, 0.34);
+	box-shadow: 0 0 0 1px rgba(145, 214, 238, 0.08);
 }
 
-.terminal-summary strong {
+.terminal-prompt-chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	max-width: 50%;
+	min-height: 26px;
+	padding: 3px 8px;
+	overflow: hidden;
+	border: 0;
+	background: transparent;
+	white-space: nowrap;
+}
+
+.terminal-entry {
+	position: relative;
+	display: flex;
+	align-items: center;
+	flex: 1;
+	min-width: 0;
+	min-height: 26px;
+}
+
+.terminal-input {
+	position: absolute;
+	inset: 0;
+	z-index: 2;
+	appearance: none;
+	width: 100%;
+	min-width: 0;
+	min-height: 26px;
+	margin: 0;
+	padding: 0;
+	border: 0;
+	outline: 0;
+	background: transparent;
+	color: transparent;
+	caret-color: transparent;
+	font: inherit;
+	box-shadow: none;
+}
+
+.terminal-input::placeholder {
+	color: transparent;
+}
+
+.terminal-input:focus {
+	outline: 0;
+}
+
+.terminal-input-ghost {
+	position: relative;
+	z-index: 1;
+	display: inline-flex;
+	align-items: center;
+	min-width: 0;
+	max-width: 100%;
+	overflow: hidden;
 	color: #ffffff;
-	font-family: var(--mono);
-	font-size: 13px;
+	white-space: pre;
+}
+
+.terminal-placeholder {
+	color: #80786d;
+	margin-left: 8px;
+}
+
+.terminal-cursor {
+	display: inline-block;
+	width: 8px;
+	height: 1.2em;
+	margin-left: 1px;
+	background: rgba(239, 232, 216, 0.28);
+	animation: terminal-cursor-blink 1s steps(1, end) infinite;
+	vertical-align: -0.18em;
+}
+
+.terminal-input-row.is-focused .terminal-cursor,
+.terminal-input-row:focus-within .terminal-cursor {
+	background: #efe8d8;
+}
+
+.terminal-input-row.is-focused .terminal-placeholder,
+.terminal-input-row:focus-within .terminal-placeholder {
+	display: none;
+}
+
+@keyframes terminal-cursor-blink {
+	50% {
+		opacity: 0.16;
+	}
 }
 
 .authority-strip {
@@ -660,8 +838,8 @@ pre {
 		grid-template-columns: repeat(2, minmax(0, 1fr));
 	}
 
-	.terminal-source {
-		min-height: 360px;
+	.terminal-body {
+		height: 454px;
 	}
 }
 
@@ -686,7 +864,7 @@ pre {
 	}
 
 	.site-header > .button {
-		width: 100%;
+		display: none;
 	}
 
 	.site-nav {
@@ -716,23 +894,8 @@ pre {
 		flex: 1 1 180px;
 	}
 
-	.terminal-source {
-		min-height: 300px;
-		padding: 16px;
-		font-size: 12px;
-	}
-
-	.terminal-summary {
-		grid-template-columns: 1fr;
-	}
-
-	.terminal-summary span {
-		border-top: 1px solid rgba(255, 253, 247, 0.1);
-		border-left: 0;
-	}
-
-	.terminal-summary span:first-child {
-		border-top: 0;
+	.terminal-card {
+		display: none;
 	}
 
 	.authority-strip {

--- a/plugins/push-md/docs/landing/landing.css
+++ b/plugins/push-md/docs/landing/landing.css
@@ -22,6 +22,11 @@
 
 html {
 	scroll-behavior: smooth;
+	scroll-padding-top: 94px;
+}
+
+section[id] {
+	scroll-margin-top: 94px;
 }
 
 body {
@@ -523,16 +528,16 @@ pre {
 
 .faq-item h3 {
 	margin: 0;
-	font-family: var(--serif);
-	font-size: clamp(24px, 2.7vw, 36px);
-	line-height: 1.16;
+	font-size: clamp(19px, 2vw, 25px);
+	line-height: 1.28;
+	font-weight: 780;
 	letter-spacing: 0;
 }
 
 .faq-item h3 .md-token {
 	margin-right: 8px;
-	font-size: 0.76em;
-	vertical-align: 0.04em;
+	font-size: 0.82em;
+	vertical-align: 0.02em;
 }
 
 .faq-item p {
@@ -625,6 +630,14 @@ pre {
 }
 
 @media (max-width: 1120px) {
+	html {
+		scroll-padding-top: 138px;
+	}
+
+	section[id] {
+		scroll-margin-top: 138px;
+	}
+
 	.site-header {
 		flex-wrap: wrap;
 	}
@@ -662,6 +675,14 @@ pre {
 		min-height: 0;
 		gap: 12px;
 		padding: 12px 16px;
+	}
+
+	section[id] {
+		scroll-margin-top: 18px;
+	}
+
+	html {
+		scroll-padding-top: 18px;
 	}
 
 	.site-header > .button {
@@ -733,7 +754,7 @@ pre {
 	}
 
 	.faq-item h3 {
-		font-size: 25px;
+		font-size: 21px;
 	}
 
 	.site-footer {

--- a/plugins/push-md/docs/landing/landing.css
+++ b/plugins/push-md/docs/landing/landing.css
@@ -187,7 +187,7 @@ pre {
 	font-family: var(--serif);
 	font-size: clamp(44px, 4.9vw, 68px);
 	font-weight: 700;
-	line-height: 1.08;
+	line-height: 1.16;
 	text-wrap: balance;
 }
 
@@ -649,7 +649,7 @@ pre {
 
 	.hero h1 {
 		font-size: 40px;
-		line-height: 1.1;
+		line-height: 1.18;
 	}
 
 	.hero-subhead,

--- a/plugins/push-md/docs/landing/landing.css
+++ b/plugins/push-md/docs/landing/landing.css
@@ -194,22 +194,22 @@ pre {
 .md-token {
 	color: var(--hash);
 	font-family: var(--mono);
-	font-size: 0.72em;
+	font-size: 0.84em;
 	font-weight: 760;
 	vertical-align: 0.08em;
 }
 
 .hero h1 .md-token {
 	display: inline-block;
-	margin-right: 0.08em;
-	font-size: 0.86em;
-	vertical-align: 0.02em;
+	margin-right: 0.1em;
+	font-size: 0.98em;
+	vertical-align: 0;
 }
 
 .section-copy .md-token,
 .authority-strip .md-token {
-	margin-right: 6px;
-	font-size: 0.72em;
+	margin-right: 8px;
+	font-size: 0.88em;
 }
 
 .hero-subhead {

--- a/plugins/push-md/docs/landing/landing.css
+++ b/plugins/push-md/docs/landing/landing.css
@@ -1,21 +1,19 @@
 :root {
-	--bg: #f7f9f4;
-	--paper: #ffffff;
-	--ink: #182018;
-	--muted: #5e6b63;
-	--line: #dce3d6;
-	--green: #2f6f4e;
-	--green-soft: #e6f3ea;
-	--blue: #276b8f;
-	--blue-soft: #e4f2f8;
-	--coral: #d95c44;
-	--yellow: #e4b53b;
-	--terminal: #101510;
-	--terminal-line: #263029;
-	--terminal-text: #dce8dc;
-	--shadow: 0 24px 80px rgba(24, 32, 24, 0.18);
+	--page: #faf8f1;
+	--paper: #fffdf7;
+	--paper-deep: #f4efe2;
+	--ink: #1f1d19;
+	--muted: #706a5f;
+	--line: #ded6c7;
+	--hash: #b05d33;
+	--link: #1e6b83;
+	--green: #2f704d;
+	--green-soft: #e7f2e6;
+	--yellow: #f4d06f;
+	--shadow: 0 24px 70px rgba(58, 47, 31, 0.16);
 	--mono: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
 	--sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+	--serif: Georgia, "Times New Roman", serif;
 }
 
 * {
@@ -29,13 +27,13 @@ html {
 body {
 	margin: 0;
 	background:
-		radial-gradient(circle at 12px 12px, rgba(47, 111, 78, 0.08) 1px, transparent 1px),
-		var(--bg);
-	background-size: 24px 24px;
+		linear-gradient(rgba(112, 106, 95, 0.06) 1px, transparent 1px),
+		var(--page);
+	background-size: 100% 34px;
 	color: var(--ink);
 	font-family: var(--sans);
 	font-size: 16px;
-	line-height: 1.55;
+	line-height: 1.62;
 }
 
 a {
@@ -71,11 +69,11 @@ pre {
 	align-items: center;
 	justify-content: space-between;
 	gap: 20px;
-	min-height: 72px;
-	padding: 14px clamp(18px, 4vw, 48px);
-	border-bottom: 1px solid rgba(220, 227, 214, 0.78);
-	background: rgba(247, 249, 244, 0.88);
-	backdrop-filter: blur(16px);
+	min-height: 70px;
+	padding: 13px clamp(18px, 4vw, 48px);
+	border-bottom: 1px solid rgba(222, 214, 199, 0.84);
+	background: rgba(250, 248, 241, 0.92);
+	backdrop-filter: blur(14px);
 }
 
 .brand {
@@ -83,7 +81,7 @@ pre {
 	align-items: center;
 	gap: 10px;
 	color: var(--ink);
-	font-weight: 760;
+	font-weight: 780;
 	text-decoration: none;
 	white-space: nowrap;
 }
@@ -93,7 +91,7 @@ pre {
 	place-items: center;
 	width: 38px;
 	height: 38px;
-	border: 1px solid rgba(24, 32, 24, 0.22);
+	border: 1px solid rgba(31, 29, 25, 0.18);
 	border-radius: 8px;
 	background: var(--ink);
 	color: #ffffff;
@@ -119,7 +117,7 @@ pre {
 .site-nav a:focus,
 .site-footer a:hover,
 .site-footer a:focus {
-	color: var(--green);
+	color: var(--hash);
 }
 
 .button {
@@ -130,7 +128,7 @@ pre {
 	padding: 10px 16px;
 	border: 1px solid transparent;
 	border-radius: 8px;
-	font-weight: 700;
+	font-weight: 760;
 	text-decoration: none;
 	white-space: nowrap;
 	transition: transform 0.16s ease, box-shadow 0.16s ease, background 0.16s ease;
@@ -144,82 +142,70 @@ pre {
 .button-primary {
 	background: var(--ink);
 	color: #ffffff;
-	box-shadow: 0 12px 30px rgba(24, 32, 24, 0.2);
+	box-shadow: 0 12px 30px rgba(31, 29, 25, 0.18);
 }
 
 .button-secondary {
-	border-color: rgba(24, 32, 24, 0.18);
-	background: rgba(255, 255, 255, 0.72);
+	border-color: rgba(31, 29, 25, 0.18);
+	background: rgba(255, 253, 247, 0.8);
 	color: var(--ink);
 }
 
-.hero {
-	position: relative;
-	display: grid;
-	grid-template-columns: minmax(0, 0.82fr) minmax(520px, 1.18fr);
-	gap: clamp(26px, 4vw, 64px);
-	align-items: center;
-	max-width: 1340px;
-	min-height: 0;
+.markdown-document {
+	max-width: 1320px;
 	margin: 0 auto;
-	padding: clamp(24px, 3.4vw, 42px) clamp(18px, 4vw, 48px) clamp(20px, 2.4vw, 30px);
-	overflow: hidden;
+	padding: 0 clamp(18px, 4vw, 48px);
 }
 
-.hero::before,
-.hero::after {
-	content: "";
-	position: absolute;
-	z-index: -1;
-	border: 1px solid rgba(24, 32, 24, 0.08);
-	border-radius: 8px;
-	background: rgba(255, 255, 255, 0.52);
+.hero {
+	display: grid;
+	grid-template-columns: minmax(0, 0.72fr) minmax(520px, 1.28fr);
+	gap: clamp(30px, 5vw, 76px);
+	align-items: center;
+	min-height: 0;
+	padding: clamp(34px, 5vw, 58px) 0 46px;
 }
 
-.hero::before {
-	right: 3%;
-	top: 12%;
-	width: 230px;
-	height: 142px;
-	transform: rotate(7deg);
-}
-
-.hero::after {
-	left: 7%;
-	bottom: 4%;
-	width: 180px;
-	height: 110px;
-	transform: rotate(-5deg);
-}
-
-.eyebrow {
+.file-label,
+.section-path,
+.preview-kicker {
 	margin: 0 0 12px;
-	color: var(--green);
+	color: var(--hash);
+	font-family: var(--mono);
 	font-size: 13px;
-	font-weight: 780;
-	letter-spacing: 0.08em;
-	text-transform: uppercase;
+	font-weight: 760;
+	letter-spacing: 0.02em;
 }
 
 .hero h1,
 .section-copy h2,
-.install-copy h2 {
+.authority-strip h2 {
 	margin: 0;
 	letter-spacing: 0;
 }
 
 .hero h1 {
-	max-width: 700px;
-	font-size: clamp(40px, 4.6vw, 58px);
-	line-height: 1;
+	max-width: 680px;
+	font-family: var(--serif);
+	font-size: clamp(44px, 5.4vw, 74px);
+	font-weight: 700;
+	line-height: 0.96;
+}
+
+.md-token {
+	color: var(--hash);
+	font-family: var(--mono);
+	font-size: 0.72em;
+	font-weight: 760;
+	vertical-align: 0.08em;
 }
 
 .hero-subhead {
-	max-width: 680px;
-	margin: 24px 0 0;
+	max-width: 670px;
+	margin: 22px 0 0;
 	color: var(--muted);
-	font-size: 19px;
-	line-height: 1.55;
+	font-size: 18px;
+	line-height: 1.62;
 }
 
 .hero-actions {
@@ -229,374 +215,282 @@ pre {
 	margin: 28px 0 0;
 }
 
-.hero-visual {
+.markdown-workbench {
 	position: relative;
+	display: grid;
+	grid-template-columns: minmax(0, 1.1fr) minmax(300px, 0.9fr);
+	gap: 14px;
+	align-items: stretch;
 	min-width: 0;
 }
 
-.terminal-window {
-	position: relative;
-	overflow: hidden;
-	border: 1px solid rgba(16, 21, 16, 0.86);
+.editor-card,
+.preview-card,
+.authority-strip article,
+.flow-note,
+.markdown-callout,
+.markdown-table,
+.install-panel {
+	border: 1px solid var(--line);
 	border-radius: 8px;
-	background: var(--terminal);
+	background: rgba(255, 253, 247, 0.9);
 	box-shadow: var(--shadow);
 }
 
-.terminal-window::before {
-	content: "";
-	position: absolute;
-	inset: 42px 0 auto;
-	height: 1px;
-	background: var(--terminal-line);
+.editor-card {
+	overflow: hidden;
+	background: #1f1d19;
+	color: #efe8d8;
 }
 
-.terminal-bar {
-	display: grid;
-	grid-template-columns: 82px minmax(0, 1fr) auto;
+.editor-topline {
+	display: flex;
 	align-items: center;
-	gap: 14px;
+	justify-content: space-between;
+	gap: 12px;
 	height: 42px;
 	padding: 0 14px;
-	background: #192019;
-	color: #aebaae;
+	border-bottom: 1px solid rgba(255, 253, 247, 0.12);
+	background: #2a251e;
+	color: #cfc4ae;
 	font-family: var(--mono);
 	font-size: 12px;
 }
 
-.window-dots {
-	display: flex;
-	gap: 7px;
-}
-
-.window-dots span {
-	width: 11px;
-	height: 11px;
-	border-radius: 50%;
-	background: var(--coral);
-}
-
-.window-dots span:nth-child(2) {
-	background: var(--yellow);
-}
-
-.window-dots span:nth-child(3) {
-	background: #3fb56b;
-}
-
-.terminal-transcript {
-	height: 370px;
+.markdown-source {
+	height: 458px;
 	margin: 0;
-	padding: 20px 20px 24px;
+	padding: 18px 18px 22px;
 	overflow: auto;
-	color: var(--terminal-text);
 	font-size: 13px;
-	line-height: 1.58;
+	line-height: 1.68;
 	white-space: pre-wrap;
 }
 
-.terminal-transcript .line {
+.md-line {
 	display: block;
-	min-height: 21px;
+	min-height: 22px;
 }
 
-.terminal-transcript .command {
-	color: #8bd6ff;
+.md-heading {
+	color: #f4d06f;
+	font-weight: 760;
 }
 
-.terminal-transcript .success {
-	color: #8fe3a3;
+.md-code {
+	color: #91d6ee;
 }
 
-.terminal-transcript .diff {
-	color: #ffd37b;
-}
-
-.terminal-transcript .output {
-	color: #c7d1c7;
-}
-
-.terminal-transcript.is-enhanced .line {
+.markdown-source.is-enhanced .md-line {
 	opacity: 0;
 	transform: translateY(4px);
-	transition: opacity 0.26s ease, transform 0.26s ease;
+	transition: opacity 0.24s ease, transform 0.24s ease;
 }
 
-.terminal-transcript.is-enhanced .line.is-visible {
+.markdown-source.is-enhanced .md-line.is-visible {
 	opacity: 1;
 	transform: translateY(0);
 }
 
-.source-badge {
-	position: absolute;
-	right: 20px;
-	top: -26px;
-	display: grid;
-	gap: 3px;
-	max-width: 310px;
-	padding: 15px 16px;
-	border: 1px solid rgba(47, 111, 78, 0.22);
-	border-radius: 8px;
-	background: #fafff8;
-	box-shadow: 0 18px 45px rgba(24, 32, 24, 0.16);
+.preview-card {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	padding: clamp(20px, 3vw, 30px);
 }
 
-.source-badge-label {
-	color: var(--green);
-	font-size: 12px;
-	font-weight: 800;
-	letter-spacing: 0.07em;
-	text-transform: uppercase;
+.preview-card h2 {
+	margin: 0;
+	font-family: var(--serif);
+	font-size: clamp(30px, 3.2vw, 44px);
+	line-height: 1.04;
+	letter-spacing: 0;
 }
 
-.source-badge strong {
-	font-size: 24px;
-	line-height: 1.1;
+.preview-card h3 {
+	margin: 22px 0 8px;
+	font-size: 18px;
+	line-height: 1.2;
 }
 
-.source-badge span:last-child {
+.preview-card p,
+.preview-card li {
 	color: var(--muted);
-	font-size: 13px;
 }
 
-.authority-strip,
-.workflow-section,
-.skills-section,
-.markdown-section,
-.install-section,
-.site-footer {
-	max-width: 1240px;
-	margin: 0 auto;
-	padding-inline: clamp(18px, 4vw, 48px);
+.preview-card ul {
+	margin: 10px 0 0;
+	padding-left: 20px;
+}
+
+.remote-output {
+	display: grid;
+	gap: 5px;
+	margin-top: 22px;
+	padding: 12px;
+	border-radius: 8px;
+	background: #f1f7ef;
+	color: var(--green);
+	font-family: var(--mono);
+	font-size: 12px;
+	line-height: 1.5;
 }
 
 .authority-strip {
 	display: grid;
 	grid-template-columns: repeat(4, minmax(0, 1fr));
 	gap: 12px;
-	padding-top: 20px;
-	padding-bottom: 62px;
-}
-
-.authority-strip article,
-.skill-card,
-.install-panel,
-.file-matrix div,
-.flow-node {
-	border: 1px solid var(--line);
-	border-radius: 8px;
-	background: rgba(255, 255, 255, 0.78);
+	padding: 16px 0 70px;
 }
 
 .authority-strip article {
+	box-shadow: none;
 	padding: 18px;
 }
 
-.proof-kicker,
-.skill-label {
-	display: inline-flex;
-	align-items: center;
-	min-height: 24px;
-	padding: 3px 8px;
-	border-radius: 999px;
-	background: var(--green-soft);
-	color: var(--green);
-	font-size: 12px;
-	font-weight: 760;
-}
-
 .authority-strip h2 {
-	margin: 14px 0 8px;
-	font-size: 19px;
+	font-size: 20px;
 	line-height: 1.2;
-	letter-spacing: 0;
 }
 
-.authority-strip p,
+.authority-strip p:last-child,
 .section-copy p,
-.skill-card p,
-.install-copy p,
+.markdown-callout p,
 .install-note,
-.file-matrix span {
+.table-row span {
 	color: var(--muted);
 }
 
-.authority-strip p,
-.skill-card p {
-	margin: 0;
+.authority-strip p:last-child,
+.markdown-callout p {
+	margin: 10px 0 0;
 	font-size: 14px;
 	line-height: 1.5;
 }
 
-.authority-strip p code,
-.section-copy p code,
-.install-copy p code,
-.install-steps code {
+.authority-strip code,
+.section-copy code,
+.install-steps code,
+.markdown-callout code {
 	padding: 1px 4px;
 	border-radius: 4px;
-	background: rgba(39, 107, 143, 0.1);
-	color: var(--blue);
+	background: rgba(30, 107, 131, 0.1);
+	color: var(--link);
 	font-size: 0.94em;
 	overflow-wrap: anywhere;
 }
 
-.workflow-section,
-.skills-section,
-.markdown-section,
-.install-section {
+.doc-section {
 	display: grid;
-	grid-template-columns: minmax(0, 0.78fr) minmax(0, 1.22fr);
-	gap: clamp(24px, 5vw, 72px);
+	grid-template-columns: minmax(0, 0.82fr) minmax(0, 1.18fr);
+	gap: clamp(28px, 5vw, 76px);
 	align-items: center;
-	padding-top: 72px;
-	padding-bottom: 72px;
+	padding: 78px 0;
+	border-top: 1px solid rgba(222, 214, 199, 0.7);
 }
 
-.section-copy h2,
-.install-copy h2 {
-	max-width: 620px;
-	font-size: clamp(34px, 4vw, 54px);
+.section-copy h2 {
+	max-width: 660px;
+	font-family: var(--serif);
+	font-size: clamp(34px, 4.2vw, 58px);
 	line-height: 1.02;
 }
 
-.section-copy p,
-.install-copy p {
-	max-width: 580px;
+.section-copy p:not(.section-path) {
+	max-width: 590px;
 	margin: 18px 0 0;
 	font-size: 17px;
 }
 
-.flow-map {
+.flow-note {
 	position: relative;
-	display: grid;
-	grid-template-columns: repeat(3, minmax(0, 1fr));
-	grid-template-rows: repeat(3, 116px);
-	gap: 14px;
-	min-height: 372px;
+	overflow: hidden;
+	padding: 0;
+	box-shadow: none;
 }
 
-.flow-map::before {
-	content: "";
-	position: absolute;
-	inset: 58px 17% 58px;
-	border: 2px dashed rgba(39, 107, 143, 0.3);
-	border-radius: 8px;
+.flow-note pre {
+	margin: 0;
+	padding: 24px;
+	overflow: auto;
+	color: #efe8d8;
+	background: #1f1d19;
+	font-size: 14px;
+	line-height: 1.85;
 }
 
-.flow-node {
-	position: relative;
-	z-index: 1;
-	display: grid;
-	align-content: center;
-	gap: 8px;
-	padding: 16px;
-	box-shadow: 0 14px 34px rgba(24, 32, 24, 0.08);
+.flow-core {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 18px;
+	padding: 18px 20px;
+	background: var(--paper);
 }
 
-.flow-node span {
-	font-weight: 800;
+.flow-core strong {
+	font-size: 22px;
 }
 
-.flow-node code {
-	width: max-content;
-	max-width: 100%;
-	padding: 3px 7px;
-	border-radius: 6px;
-	background: #eef4ea;
-	color: #3b493f;
-	font-size: 12px;
-	overflow-wrap: anywhere;
+.flow-core span {
+	color: var(--muted);
+	font-size: 14px;
 }
 
-.flow-node.core {
-	grid-column: 2;
-	grid-row: 2;
-	border-color: rgba(47, 111, 78, 0.35);
-	background: var(--ink);
-	color: #ffffff;
+.markdown-callout {
+	padding: clamp(22px, 4vw, 36px);
+	background:
+		linear-gradient(90deg, rgba(176, 93, 51, 0.12) 0 5px, transparent 5px),
+		var(--paper);
+	box-shadow: none;
 }
 
-.flow-node.core strong {
-	color: #d6ead9;
-	font-size: 13px;
-	line-height: 1.4;
-}
-
-.flow-node.agent-a {
-	grid-column: 1;
-	grid-row: 1;
-}
-
-.flow-node.agent-b {
-	grid-column: 3;
-	grid-row: 1;
-}
-
-.flow-node.editor {
-	grid-column: 1;
-	grid-row: 3;
-}
-
-.flow-node.admin {
-	grid-column: 3;
-	grid-row: 3;
-}
-
-.skills-grid {
-	display: grid;
-	grid-template-columns: repeat(2, minmax(0, 1fr));
-	gap: 16px;
-}
-
-.skill-card {
-	padding: 22px;
-	min-height: 250px;
-}
-
-.skill-card.highlight {
-	border-color: rgba(39, 107, 143, 0.32);
-	background: var(--blue-soft);
-}
-
-.skill-card h3 {
-	margin: 18px 0 10px;
-	font-size: 25px;
-	line-height: 1.12;
+.markdown-callout h3 {
+	margin: 0;
+	font-size: clamp(26px, 3vw, 38px);
+	line-height: 1.1;
 	letter-spacing: 0;
 }
 
-.skill-card h3 code {
-	font-size: 0.86em;
+.markdown-callout p:last-child {
+	font-size: 16px;
 }
 
-.file-matrix {
+.markdown-table {
 	display: grid;
-	grid-template-columns: repeat(2, minmax(0, 1fr));
-	gap: 12px;
+	overflow: hidden;
+	box-shadow: none;
 }
 
-.file-matrix div {
+.table-row {
 	display: grid;
-	gap: 8px;
-	padding: 18px;
+	grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+	gap: 16px;
+	padding: 15px 18px;
+	border-top: 1px solid var(--line);
 }
 
-.file-matrix code {
-	color: var(--blue);
-	font-size: 14px;
+.table-row:first-child {
+	border-top: 0;
+}
+
+.table-head {
+	background: var(--paper-deep);
+	color: var(--ink);
+	font-weight: 800;
+}
+
+.table-row code {
+	color: var(--link);
 	overflow-wrap: anywhere;
-}
-
-.install-section {
-	align-items: stretch;
-	padding-bottom: 90px;
 }
 
 .install-panel {
 	display: grid;
 	gap: 22px;
 	padding: clamp(22px, 4vw, 34px);
-	background: #fffdf6;
+	background: var(--paper);
+	box-shadow: none;
 }
 
 .install-steps {
@@ -608,30 +502,30 @@ pre {
 
 .install-steps li {
 	padding-left: 6px;
-	font-weight: 700;
+	font-weight: 720;
 }
 
-.command-copy {
+.code-block {
 	display: grid;
 	grid-template-columns: minmax(0, 1fr) auto;
 	gap: 10px;
 	align-items: center;
-	padding: 10px;
-	border: 1px solid rgba(24, 32, 24, 0.16);
+	padding: 12px;
+	border: 1px solid rgba(31, 29, 25, 0.16);
 	border-radius: 8px;
 	background: #ffffff;
 }
 
-.command-copy code {
+.code-block code {
 	display: block;
-	color: #213023;
+	color: var(--ink);
 	overflow-wrap: anywhere;
 }
 
 .copy-button {
 	min-height: 38px;
 	padding: 8px 13px;
-	border: 1px solid rgba(24, 32, 24, 0.2);
+	border: 1px solid rgba(31, 29, 25, 0.2);
 	border-radius: 7px;
 	background: var(--green);
 	color: #ffffff;
@@ -641,7 +535,7 @@ pre {
 }
 
 .copy-button.is-copied {
-	background: var(--blue);
+	background: var(--link);
 }
 
 .install-note {
@@ -654,8 +548,9 @@ pre {
 	align-items: center;
 	justify-content: space-between;
 	gap: 20px;
-	padding-top: 26px;
-	padding-bottom: 32px;
+	max-width: 1320px;
+	margin: 0 auto;
+	padding: 26px clamp(18px, 4vw, 48px) 32px;
 	border-top: 1px solid var(--line);
 	color: var(--muted);
 	font-size: 14px;
@@ -671,7 +566,7 @@ pre {
 	gap: 16px;
 }
 
-@media (max-width: 1080px) {
+@media (max-width: 1120px) {
 	.site-header {
 		flex-wrap: wrap;
 	}
@@ -685,46 +580,27 @@ pre {
 	}
 
 	.hero,
-	.workflow-section,
-	.skills-section,
-	.markdown-section,
-	.install-section {
+	.doc-section {
 		grid-template-columns: 1fr;
+		min-height: 0;
 	}
 
-	.hero {
-		min-height: auto;
-		padding-top: 38px;
-	}
-
-	.hero h1 {
-		font-size: 52px;
-	}
-
-	.hero-subhead {
-		font-size: 18px;
+	.markdown-workbench {
+		grid-template-columns: minmax(0, 1fr);
 	}
 
 	.authority-strip {
 		grid-template-columns: repeat(2, minmax(0, 1fr));
 	}
 
-	.terminal-transcript {
-		height: 430px;
-	}
-
-	.source-badge {
-		position: relative;
-		right: auto;
-		bottom: auto;
-		margin: 14px 0 0;
-		max-width: none;
+	.markdown-source {
+		height: 360px;
 	}
 }
 
 @media (max-width: 720px) {
 	body {
-		background-size: 20px 20px;
+		background-size: 100% 30px;
 	}
 
 	.site-header {
@@ -743,18 +619,21 @@ pre {
 		font-size: 13px;
 	}
 
+	.markdown-document {
+		padding-inline: 16px;
+	}
+
 	.hero {
-		padding: 24px 16px 20px;
+		padding: 30px 0 34px;
 	}
 
 	.hero h1 {
 		font-size: 40px;
-		line-height: 1;
+		line-height: 1.02;
 	}
 
 	.hero-subhead,
-	.section-copy p,
-	.install-copy p {
+	.section-copy p:not(.section-path) {
 		font-size: 16px;
 	}
 
@@ -762,82 +641,38 @@ pre {
 		flex: 1 1 180px;
 	}
 
-	.terminal-bar {
-		grid-template-columns: 64px minmax(0, 1fr);
-	}
-
-	.terminal-bar span:last-child {
-		display: none;
-	}
-
-	.terminal-transcript {
-		height: 290px;
+	.markdown-source {
+		height: 300px;
 		padding: 16px;
 		font-size: 12px;
-		line-height: 1.52;
 	}
 
-	.authority-strip,
-	.workflow-section,
-	.skills-section,
-	.markdown-section,
-	.install-section,
-	.site-footer {
-		padding-inline: 16px;
-	}
-
-	.authority-strip,
-	.skills-grid,
-	.file-matrix {
-		grid-template-columns: 1fr;
+	.preview-card {
+		padding: 20px;
 	}
 
 	.authority-strip {
-		padding-top: 8px;
-		padding-bottom: 38px;
+		grid-template-columns: 1fr;
+		padding-bottom: 42px;
 	}
 
-	.workflow-section,
-	.skills-section,
-	.markdown-section,
-	.install-section {
-		padding-top: 46px;
-		padding-bottom: 46px;
+	.doc-section {
+		padding: 48px 0;
 	}
 
-	.section-copy h2,
-	.install-copy h2 {
+	.section-copy h2 {
 		font-size: 34px;
 	}
 
-	.flow-map {
-		grid-template-columns: 1fr;
-		grid-template-rows: none;
-		min-height: 0;
-	}
-
-	.flow-map::before {
-		inset: 30px 50% 30px auto;
-		width: 2px;
-		border-width: 0 0 0 2px;
-	}
-
-	.flow-node,
-	.flow-node.core,
-	.flow-node.agent-a,
-	.flow-node.agent-b,
-	.flow-node.editor,
-	.flow-node.admin {
-		grid-column: auto;
-		grid-row: auto;
-	}
-
-	.command-copy {
+	.table-row,
+	.code-block,
+	.flow-core {
 		grid-template-columns: 1fr;
 	}
 
 	.site-footer {
 		display: grid;
+		padding-inline: 16px;
 	}
 }
 

--- a/plugins/push-md/docs/landing/landing.css
+++ b/plugins/push-md/docs/landing/landing.css
@@ -238,6 +238,7 @@ pre {
 .terminal-card,
 .authority-strip article,
 .use-case-card,
+.faq-list,
 .install-panel {
 	border: 1px solid var(--line);
 	border-radius: 8px;
@@ -504,6 +505,44 @@ pre {
 	overflow-wrap: anywhere;
 }
 
+.faq-list {
+	display: grid;
+	overflow: hidden;
+	background: rgba(255, 253, 247, 0.76);
+	box-shadow: none;
+}
+
+.faq-item {
+	padding: clamp(20px, 3vw, 28px);
+	border-top: 1px solid var(--line);
+}
+
+.faq-item:first-child {
+	border-top: 0;
+}
+
+.faq-item h3 {
+	margin: 0;
+	font-family: var(--serif);
+	font-size: clamp(24px, 2.7vw, 36px);
+	line-height: 1.16;
+	letter-spacing: 0;
+}
+
+.faq-item h3 .md-token {
+	margin-right: 8px;
+	font-size: 0.76em;
+	vertical-align: 0.04em;
+}
+
+.faq-item p {
+	max-width: 980px;
+	margin: 10px 0 0;
+	color: var(--muted);
+	font-size: 16px;
+	line-height: 1.58;
+}
+
 .install-panel {
 	display: grid;
 	gap: 22px;
@@ -691,6 +730,10 @@ pre {
 	.file-map div,
 	.code-block {
 		grid-template-columns: 1fr;
+	}
+
+	.faq-item h3 {
+		font-size: 25px;
 	}
 
 	.site-footer {

--- a/plugins/push-md/docs/landing/landing.css
+++ b/plugins/push-md/docs/landing/landing.css
@@ -406,7 +406,7 @@ pre {
 }
 
 .doc-section > :not(.section-copy) {
-	width: min(100%, 980px);
+	width: 100%;
 }
 
 .section-copy h2 {

--- a/plugins/push-md/docs/landing/landing.css
+++ b/plugins/push-md/docs/landing/landing.css
@@ -183,11 +183,12 @@ pre {
 }
 
 .hero h1 {
-	max-width: 680px;
+	max-width: 720px;
 	font-family: var(--serif);
 	font-size: clamp(44px, 4.9vw, 68px);
 	font-weight: 700;
-	line-height: 0.96;
+	line-height: 1.08;
+	text-wrap: balance;
 }
 
 .md-token {
@@ -196,6 +197,13 @@ pre {
 	font-size: 0.72em;
 	font-weight: 760;
 	vertical-align: 0.08em;
+}
+
+.hero h1 .md-token {
+	display: inline-block;
+	margin-right: 0.08em;
+	font-size: 0.86em;
+	vertical-align: 0.02em;
 }
 
 .section-copy .md-token,
@@ -357,7 +365,7 @@ pre {
 
 .authority-strip h2 {
 	font-size: 19px;
-	line-height: 1.2;
+	line-height: 1.28;
 }
 
 .authority-strip p:last-child,
@@ -400,7 +408,8 @@ pre {
 	max-width: 660px;
 	font-family: var(--serif);
 	font-size: clamp(34px, 4.2vw, 58px);
-	line-height: 1.02;
+	line-height: 1.08;
+	text-wrap: balance;
 }
 
 .section-copy p {
@@ -632,7 +641,7 @@ pre {
 
 	.hero h1 {
 		font-size: 40px;
-		line-height: 1.02;
+		line-height: 1.1;
 	}
 
 	.hero-subhead,

--- a/plugins/push-md/docs/landing/landing.css
+++ b/plugins/push-md/docs/landing/landing.css
@@ -409,16 +409,19 @@ pre {
 	width: 100%;
 }
 
+.section-copy {
+	width: 100%;
+}
+
 .section-copy h2 {
-	max-width: 920px;
+	max-width: none;
 	font-family: var(--serif);
 	font-size: clamp(34px, 4.2vw, 58px);
 	line-height: 1.08;
-	text-wrap: balance;
 }
 
 .section-copy p {
-	max-width: 720px;
+	max-width: none;
 	margin: 18px 0 0;
 	font-size: 17px;
 }

--- a/plugins/push-md/docs/landing/landing.css
+++ b/plugins/push-md/docs/landing/landing.css
@@ -96,7 +96,7 @@ pre {
 	background: var(--ink);
 	color: #ffffff;
 	font-size: 11px;
-	letter-spacing: 0.06em;
+	letter-spacing: 0;
 }
 
 .site-nav {
@@ -174,7 +174,7 @@ pre {
 	font-family: var(--mono);
 	font-size: 13px;
 	font-weight: 760;
-	letter-spacing: 0.02em;
+	letter-spacing: 0;
 }
 
 .hero h1,
@@ -208,6 +208,14 @@ pre {
 	line-height: 1.62;
 }
 
+.hero-subhead code {
+	padding: 1px 5px;
+	border-radius: 4px;
+	background: rgba(30, 107, 131, 0.1);
+	color: var(--link);
+	font-size: 0.94em;
+}
+
 .hero-actions {
 	display: flex;
 	flex-wrap: wrap;
@@ -218,7 +226,7 @@ pre {
 .markdown-workbench {
 	position: relative;
 	display: grid;
-	grid-template-columns: minmax(0, 1.1fr) minmax(300px, 0.9fr);
+	grid-template-columns: minmax(0, 1.02fr) 92px minmax(290px, 0.9fr);
 	gap: 14px;
 	align-items: stretch;
 	min-width: 0;
@@ -281,6 +289,14 @@ pre {
 	color: #91d6ee;
 }
 
+.md-key {
+	color: #aee0b5;
+}
+
+.md-muted {
+	color: #9b917f;
+}
+
 .markdown-source.is-enhanced .md-line {
 	opacity: 0;
 	transform: translateY(4px);
@@ -290,6 +306,34 @@ pre {
 .markdown-source.is-enhanced .md-line.is-visible {
 	opacity: 1;
 	transform: translateY(0);
+}
+
+.format-bridge {
+	display: grid;
+	align-content: center;
+	justify-items: center;
+	gap: 8px;
+	min-width: 0;
+	padding: 16px 8px;
+	border: 1px dashed rgba(176, 93, 51, 0.48);
+	border-radius: 8px;
+	background: rgba(255, 253, 247, 0.68);
+	color: var(--hash);
+	font-family: var(--mono);
+	font-size: 12px;
+	font-weight: 780;
+	text-align: center;
+}
+
+.format-bridge strong {
+	display: grid;
+	place-items: center;
+	width: 36px;
+	height: 36px;
+	border-radius: 50%;
+	background: var(--hash);
+	color: #ffffff;
+	font-size: 14px;
 }
 
 .preview-card {
@@ -587,6 +631,13 @@ pre {
 
 	.markdown-workbench {
 		grid-template-columns: minmax(0, 1fr);
+	}
+
+	.format-bridge {
+		grid-template-columns: 1fr auto 1fr;
+		align-items: center;
+		padding: 12px;
+		text-transform: none;
 	}
 
 	.authority-strip {

--- a/plugins/push-md/docs/landing/landing.js
+++ b/plugins/push-md/docs/landing/landing.js
@@ -1,20 +1,19 @@
 (function () {
-	var transcript = document.querySelector( '.terminal-transcript' );
-	if ( transcript ) {
+	var source = document.querySelector( '.markdown-source' );
+	if ( source ) {
 		var prefersReducedMotion = window.matchMedia &&
 			window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
-		var lines                = transcript.querySelectorAll( '.line' );
+		var lines                = source.querySelectorAll( '.md-line' );
 
 		if ( ! prefersReducedMotion && lines.length ) {
-			transcript.classList.add( 'is-enhanced' );
+			source.classList.add( 'is-enhanced' );
 			lines.forEach(
 				function ( line, index ) {
 					window.setTimeout(
 						function () {
 							line.classList.add( 'is-visible' );
-							transcript.scrollTop = transcript.scrollHeight;
 						},
-						Math.min( index * 95, 1800 )
+						Math.min( index * 80, 1200 )
 					);
 				}
 			);
@@ -32,11 +31,11 @@
 						return;
 					}
 
-						copyText( target.textContent ).then( onCopied );
-
-					function onCopied() {
-						markCopied( button );
-					}
+					copyText( target.textContent ).then(
+						function () {
+							markCopied( button );
+						}
+					);
 				}
 			);
 		}

--- a/plugins/push-md/docs/landing/landing.js
+++ b/plugins/push-md/docs/landing/landing.js
@@ -1,0 +1,78 @@
+(function () {
+	var transcript = document.querySelector( '.terminal-transcript' );
+	if ( transcript ) {
+		var prefersReducedMotion = window.matchMedia &&
+			window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
+		var lines                = transcript.querySelectorAll( '.line' );
+
+		if ( ! prefersReducedMotion && lines.length ) {
+			transcript.classList.add( 'is-enhanced' );
+			lines.forEach(
+				function ( line, index ) {
+					window.setTimeout(
+						function () {
+							line.classList.add( 'is-visible' );
+							transcript.scrollTop = transcript.scrollHeight;
+						},
+						Math.min( index * 95, 1800 )
+					);
+				}
+			);
+		}
+	}
+
+	var copyButtons = document.querySelectorAll( '[data-copy-target]' );
+	copyButtons.forEach(
+		function ( button ) {
+			button.addEventListener(
+				'click',
+				function () {
+					var target = document.getElementById( button.getAttribute( 'data-copy-target' ) );
+					if ( ! target ) {
+						return;
+					}
+
+						copyText( target.textContent ).then( onCopied );
+
+					function onCopied() {
+						markCopied( button );
+					}
+				}
+			);
+		}
+	);
+
+	function markCopied( button ) {
+		var original       = button.textContent;
+		button.textContent = 'Copied';
+		button.classList.add( 'is-copied' );
+		window.setTimeout(
+			function () {
+				button.textContent = original;
+				button.classList.remove( 'is-copied' );
+			},
+			1400
+		);
+	}
+
+	function copyText( text ) {
+		if ( navigator.clipboard && navigator.clipboard.writeText ) {
+			return navigator.clipboard.writeText( text );
+		}
+
+		return new Promise(
+			function ( resolve ) {
+				var input   = document.createElement( 'textarea' );
+				input.value = text;
+				input.setAttribute( 'readonly', 'readonly' );
+				input.style.position = 'fixed';
+				input.style.opacity  = '0';
+				document.body.appendChild( input );
+				input.select();
+				document.execCommand( 'copy' );
+				document.body.removeChild( input );
+				resolve();
+			}
+		);
+	}
+}());

--- a/plugins/push-md/docs/landing/landing.js
+++ b/plugins/push-md/docs/landing/landing.js
@@ -1,24 +1,501 @@
 (function () {
-	var copyButtons = document.querySelectorAll( '[data-copy-target]' );
-	copyButtons.forEach(
-		function ( button ) {
-			button.addEventListener(
-				'click',
-				function () {
-					var target = document.getElementById( button.getAttribute( 'data-copy-target' ) );
-					if ( ! target ) {
-						return;
-					}
+	setupCopyButtons();
+	setupTerminal();
 
-					copyText( target.textContent ).then(
-						function () {
-							markCopied( button );
+	function setupCopyButtons() {
+		var copyButtons = document.querySelectorAll( '[data-copy-target]' );
+		copyButtons.forEach(
+			function ( button ) {
+				button.addEventListener(
+					'click',
+					function () {
+						var target = document.getElementById( button.getAttribute( 'data-copy-target' ) );
+						if ( ! target ) {
+							return;
 						}
-					);
+
+						copyText( target.textContent ).then(
+							function () {
+								markCopied( button );
+							}
+						);
+					}
+				);
+			}
+		);
+	}
+
+	function setupTerminal() {
+		var outputEl       = document.getElementById( 'landing-terminal-output' );
+		var inputEl        = document.getElementById( 'landing-terminal-input' );
+		var inputGhostEl   = document.getElementById( 'landing-terminal-input-ghost' );
+		var inputRowEl     = inputEl ? inputEl.closest( '.terminal-input-row' ) : null;
+		var cwdEl          = document.getElementById( 'landing-terminal-cwd' );
+		var titleEl        = document.getElementById( 'landing-terminal-title' );
+		var checkoutDir    = 'site';
+		var remoteUrl      = 'https://example.com/wp-json/git/v1/md.git';
+		var cwd            = '~';
+		var history        = [];
+		var historyIndex   = 0;
+		var dirtyPath      = '';
+		var aheadMessage   = '';
+		var revisionNumber = 184;
+		var diffRemoveLine = 'Old CTA copy';
+		var diffAddLine    = 'Keep WordPress in charge';
+		var files          = {
+			'AGENTS.md': '# WordPress content guidelines\n\n- Keep block markup valid.\n- Pull before editing stale content.\n- Let WordPress roles decide who can publish.\n',
+			'page/home.md': '# Home\n\nOld CTA copy\n',
+			'post/hello-world.md': '# Hello World\n\nHello from WordPress.\n',
+			'wp_template_part/header.html': '<!-- wp:site-title /-->\n<!-- wp:navigation /-->\n',
+			'wp_global_styles/theme.json': '{\n  "version": 3,\n  "styles": {\n    "color": {\n      "background": "#faf8f1"\n    }\n  }\n}\n'
+		};
+		var pendingFiles   = {};
+
+		if ( ! outputEl || ! inputEl || ! inputGhostEl || ! inputRowEl || ! cwdEl || ! titleEl ) {
+			return;
+		}
+
+		function appendLine( text, className ) {
+			var line       = document.createElement( 'div' );
+			line.className = 'terminal-line';
+			if ( className ) {
+				line.className += ' ' + className;
+			}
+			line.textContent = text === undefined ? '' : String( text );
+			outputEl.appendChild( line );
+			outputEl.scrollTop = outputEl.scrollHeight;
+		}
+
+		function appendPrompt( command ) {
+			appendLine( 'emulator:' + displayCwd() + '$ ' + command, 'terminal-accent' );
+		}
+
+		function displayCwd() {
+			if ( cwd === '~' ) {
+				return '~';
+			}
+			return cwd === '/' ? '~/' + checkoutDir : '~/' + checkoutDir + cwd;
+		}
+
+		function updatePrompt() {
+			cwdEl.textContent   = displayCwd();
+			titleEl.textContent = 'emulator:' + displayCwd();
+		}
+
+		function updateInputGhost() {
+			var textEl   = document.createElement( 'span' );
+			var cursorEl = document.createElement( 'span' );
+			var value    = inputEl.value;
+			var focused  = inputRowEl.classList.contains( 'is-focused' );
+
+			inputGhostEl.textContent = '';
+			cursorEl.className       = 'terminal-cursor';
+
+			if ( value ) {
+				textEl.textContent = value;
+				inputGhostEl.appendChild( textEl );
+				inputGhostEl.appendChild( cursorEl );
+			} else if ( focused ) {
+				inputGhostEl.appendChild( cursorEl );
+			} else {
+				textEl.className   = 'terminal-placeholder';
+				textEl.textContent = inputEl.getAttribute( 'placeholder' ) || '';
+				inputGhostEl.appendChild( cursorEl );
+				inputGhostEl.appendChild( textEl );
+			}
+		}
+
+		function bootTranscript() {
+			outputEl.textContent = '';
+			appendLine( 'Push MD command emulator', 'terminal-success' );
+			appendLine( 'This public demo mirrors commands you can run with any Git client.', 'terminal-muted' );
+			appendLine( '' );
+			runCommand( 'git clone ' + remoteUrl + ' ' + checkoutDir, { silentHistory: true } );
+			runCommand( 'cd ' + checkoutDir, { silentHistory: true } );
+			runCommand( 'codex "Update page/home.md"', { silentHistory: true } );
+			runCommand( 'git diff -- page/home.md', { silentHistory: true } );
+			runCommand( 'git commit -am "Update home page"', { silentHistory: true } );
+			runCommand( 'git push origin trunk', { silentHistory: true } );
+			appendLine( '' );
+			appendLine( 'Try: git status, git pull, ls, cat AGENTS.md, codex "Update page/home.md", help', 'terminal-muted' );
+		}
+
+		function runCommand( command, options ) {
+			var parts;
+			var base;
+
+			options = options || {};
+			command = String( command || '' ).replace( /^\s+|\s+$/g, '' );
+			if ( ! command ) {
+				return;
+			}
+
+			appendPrompt( command );
+			if ( ! options.silentHistory ) {
+				history.push( command );
+				historyIndex = history.length;
+			}
+
+			parts = command.split( /\s+/ );
+			base  = parts[0];
+
+			if ( base === 'help' ) {
+				printHelp();
+			} else if ( base === 'clear' ) {
+				outputEl.textContent = '';
+			} else if ( base === 'pwd' ) {
+				appendLine( '/' + checkoutDir + ( cwd === '/' || cwd === '~' ? '' : cwd ) );
+			} else if ( base === 'ls' ) {
+				printLs( parts.slice( 1 ).join( ' ' ) || '.' );
+			} else if ( base === 'tree' ) {
+				printTree();
+			} else if ( base === 'cat' ) {
+				printCat( parts.slice( 1 ).join( ' ' ) );
+			} else if ( base === 'cd' ) {
+				changeDirectory( parts[1] || checkoutDir );
+			} else if ( base === 'status' ) {
+				printGit( [ 'status' ] );
+			} else if ( base === 'git' ) {
+				printGit( parts.slice( 1 ), command );
+			} else if ( base === 'codex' || base === 'agent' ) {
+				runAgentEdit();
+			} else {
+				appendLine( base + ': command not found. Try `help`.', 'terminal-error' );
+			}
+		}
+
+		function printHelp() {
+			appendLine( 'Emulated commands:', 'terminal-success' );
+			appendLine( '  ls, tree, cat <file>       inspect the WordPress checkout' );
+			appendLine( '  git status, diff, pull     see Git state through WordPress' );
+			appendLine( '  git commit -m "..."        record a local Markdown edit' );
+			appendLine( '  git push origin trunk      ask WordPress to accept the change' );
+			appendLine( '  codex "Update page/home.md" create a demo edit' );
+			appendLine( '  clear                      clear the terminal' );
+		}
+
+		function runAgentEdit() {
+			dirtyPath = 'page/home.md';
+			if ( files[dirtyPath].indexOf( 'Keep WordPress in charge' ) !== -1 ) {
+				diffRemoveLine          = 'Keep WordPress in charge';
+				diffAddLine             = 'Your WordPress database remains the source of truth';
+				pendingFiles[dirtyPath] = '# Home\n\nYour WordPress database remains the source of truth\n';
+			} else {
+				diffRemoveLine          = 'Old CTA copy';
+				diffAddLine             = 'Keep WordPress in charge';
+				pendingFiles[dirtyPath] = '# Home\n\nKeep WordPress in charge\n';
+			}
+			appendLine( 'edit: page/home.md', 'terminal-comment' );
+			appendLine( 'Agent updated Markdown locally. Commit, then push to WordPress.', 'terminal-muted' );
+		}
+
+		function printGit( args, command ) {
+			var subcommand = args[0] || '';
+
+			if ( subcommand === 'clone' ) {
+				appendLine( "Cloning into '" + ( args[2] || checkoutDir ) + "'..." );
+				appendLine( 'remote: exported posts and pages as Markdown', 'terminal-muted' );
+				appendLine( 'remote: exported templates as block HTML', 'terminal-muted' );
+				appendLine( 'remote: exported Global Styles as JSON', 'terminal-muted' );
+				appendLine( 'Receiving objects: 5, done.' );
+			} else if ( subcommand === 'status' ) {
+				appendLine( 'On branch trunk' );
+				if ( dirtyPath ) {
+					appendLine( 'Changes not staged for commit:', 'terminal-warning' );
+					appendLine( '  modified:   ' + dirtyPath );
+				} else if ( aheadMessage ) {
+					appendLine( 'Your branch is ahead of origin/trunk by 1 commit.', 'terminal-warning' );
+				} else {
+					appendLine( 'Your branch is up to date with origin/trunk.', 'terminal-success' );
+					appendLine( 'nothing to commit, working tree clean' );
+				}
+			} else if ( subcommand === 'diff' ) {
+				printDiff();
+			} else if ( subcommand === 'commit' ) {
+				printCommit( command || args.join( ' ' ) );
+			} else if ( subcommand === 'push' ) {
+				printPush();
+			} else if ( subcommand === 'pull' ) {
+				printPull();
+			} else if ( subcommand === 'remote' ) {
+				appendLine( 'origin  ' + remoteUrl + ' (fetch)' );
+				appendLine( 'origin  ' + remoteUrl + ' (push)' );
+			} else if ( subcommand === 'branch' ) {
+				appendLine( '* trunk' );
+			} else if ( subcommand === 'log' ) {
+				appendLine( 'a17f184 Update home page' );
+				appendLine( '5d6c013 Import WordPress content' );
+			} else {
+				appendLine( 'git: supported here: clone, status, diff, commit, push, pull, remote, branch, log', 'terminal-muted' );
+			}
+		}
+
+		function printDiff() {
+			if ( ! dirtyPath ) {
+				appendLine( '(no local changes)', 'terminal-muted' );
+				return;
+			}
+
+			appendLine( 'diff --git a/' + dirtyPath + ' b/' + dirtyPath );
+			appendLine( '@@', 'terminal-muted' );
+			appendLine( '- ' + diffRemoveLine, 'terminal-diff-remove' );
+			appendLine( '+ ' + diffAddLine, 'terminal-diff-add' );
+		}
+
+		function printCommit( command ) {
+			var messageMatch = String( command || '' ).match( /-[A-Za-z]*m\s+["']([^"']+)["']/ );
+			var message      = messageMatch ? messageMatch[1] : 'Update content';
+
+			if ( ! dirtyPath ) {
+				appendLine( 'nothing to commit, working tree clean', 'terminal-muted' );
+				return;
+			}
+
+			files[dirtyPath] = pendingFiles[dirtyPath];
+			pendingFiles     = {};
+			dirtyPath        = '';
+			aheadMessage     = message;
+			appendLine( '[trunk a17f184] ' + message );
+			appendLine( ' 1 file changed, 1 insertion(+), 1 deletion(-)' );
+		}
+
+		function printPush() {
+			if ( dirtyPath ) {
+				appendLine( 'error: failed to push some refs to origin', 'terminal-error' );
+				appendLine( 'Commit local Markdown edits before pushing.', 'terminal-muted' );
+				return;
+			}
+			if ( ! aheadMessage ) {
+				appendLine( 'Everything up-to-date', 'terminal-muted' );
+				return;
+			}
+
+			revisionNumber++;
+			appendLine( 'Enumerating objects: 5, done.' );
+			appendLine( 'Writing objects: 100% (3/3), 412 bytes | 412.00 KiB/s, done.' );
+			appendLine( 'remote: checked WordPress permissions', 'terminal-success' );
+			appendLine( 'remote: stale state check passed', 'terminal-success' );
+			appendLine( 'remote: created WordPress revision #' + revisionNumber, 'terminal-success' );
+			appendLine( 'remote: applied 1 Markdown change', 'terminal-success' );
+			appendLine( 'To ' + remoteUrl );
+			aheadMessage = '';
+		}
+
+		function printPull() {
+			if ( dirtyPath ) {
+				appendLine( 'error: Your local changes would be overwritten by merge.', 'terminal-error' );
+				appendLine( 'Commit or discard local edits before pulling from WordPress.', 'terminal-muted' );
+				return;
+			}
+
+			appendLine( 'From ' + remoteUrl );
+			appendLine( ' * branch            trunk      -> FETCH_HEAD' );
+			appendLine( 'remote: exported latest WordPress revisions', 'terminal-success' );
+			appendLine( 'WP-Admin edits are Git-visible on pull.', 'terminal-muted' );
+			appendLine( 'Already up to date.' );
+		}
+
+		function changeDirectory( path ) {
+			var nextPath = normalizePath( path );
+
+			if ( path === checkoutDir || path === '~/' + checkoutDir ) {
+				cwd = '/';
+				updatePrompt();
+				return;
+			}
+
+			if ( ! isDirectory( nextPath ) ) {
+				appendLine( 'cd: ' + path + ': No such directory', 'terminal-error' );
+				return;
+			}
+
+			cwd = nextPath;
+			updatePrompt();
+		}
+
+		function printLs( path ) {
+			var entries = directoryEntries( normalizePath( path ) );
+
+			if ( ! entries.length ) {
+				appendLine( '(empty)', 'terminal-muted' );
+				return;
+			}
+
+			appendLine( entries.join( '  ' ) );
+		}
+
+		function printTree() {
+			appendLine( '.' );
+			appendLine( '|-- AGENTS.md' );
+			appendLine( '|-- page/' );
+			appendLine( '|   `-- home.md' );
+			appendLine( '|-- post/' );
+			appendLine( '|   `-- hello-world.md' );
+			appendLine( '|-- wp_global_styles/' );
+			appendLine( '|   `-- theme.json' );
+			appendLine( '`-- wp_template_part/' );
+			appendLine( '    `-- header.html' );
+		}
+
+		function printCat( path ) {
+			var key;
+
+			if ( ! path ) {
+				appendLine( 'cat: missing file operand', 'terminal-error' );
+				return;
+			}
+
+			key = pathKey( normalizePath( path ) );
+			if ( ! files[key] ) {
+				appendLine( 'cat: ' + path + ': No such file', 'terminal-error' );
+				return;
+			}
+
+			files[key].split( /\r\n|\n|\r/ ).forEach(
+				function ( line ) {
+					appendLine( line );
 				}
 			);
 		}
-	);
+
+		function normalizePath( path ) {
+			var base;
+			var segments;
+
+			path = path || '.';
+			if ( path === checkoutDir || path === '~/' + checkoutDir || path === '/' + checkoutDir ) {
+				return '/';
+			}
+			if ( path.indexOf( '~/' + checkoutDir + '/' ) === 0 ) {
+				path = path.substring( checkoutDir.length + 3 );
+			}
+			if ( path.indexOf( '/' + checkoutDir + '/' ) === 0 ) {
+				path = path.substring( checkoutDir.length + 1 );
+			}
+			base     = cwd === '~' || cwd === '/' ? [] : pathKey( cwd ).split( '/' ).filter( Boolean );
+			segments = path.charAt( 0 ) === '/' ? [] : base;
+
+			path.split( '/' ).forEach(
+				function ( segment ) {
+					if ( ! segment || segment === '.' ) {
+						return;
+					}
+					if ( segment === '..' ) {
+						segments.pop();
+					} else {
+						segments.push( segment );
+					}
+				}
+			);
+
+			return '/' + segments.join( '/' );
+		}
+
+		function pathKey( path ) {
+			return String( path || '' ).replace( /^\/+/, '' ).replace( /\/+$/, '' );
+		}
+
+		function isDirectory( path ) {
+			var key = pathKey( path );
+			var prefix;
+			var filePath;
+
+			if ( ! key ) {
+				return true;
+			}
+
+			prefix = key + '/';
+			for ( filePath in files ) {
+				if ( Object.prototype.hasOwnProperty.call( files, filePath ) && filePath.indexOf( prefix ) === 0 ) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		function directoryEntries( path ) {
+			var key     = pathKey( path );
+			var prefix  = key ? key + '/' : '';
+			var entries = {};
+			var filePath;
+			var rest;
+			var slashAt;
+			var name;
+
+			for ( filePath in files ) {
+				if ( ! Object.prototype.hasOwnProperty.call( files, filePath ) ) {
+					continue;
+				}
+				if ( prefix && filePath.indexOf( prefix ) !== 0 ) {
+					continue;
+				}
+
+				rest = prefix ? filePath.substring( prefix.length ) : filePath;
+				if ( ! rest ) {
+					continue;
+				}
+
+				slashAt       = rest.indexOf( '/' );
+				name          = slashAt === -1 ? rest : rest.substring( 0, slashAt ) + '/';
+				entries[name] = true;
+			}
+
+			return Object.keys( entries ).sort();
+		}
+
+		inputEl.addEventListener(
+			'keydown',
+			function ( event ) {
+				if ( event.key === 'Enter' ) {
+					runCommand( inputEl.value );
+					inputEl.value = '';
+					updateInputGhost();
+				} else if ( event.key === 'ArrowUp' ) {
+					if ( history.length ) {
+						historyIndex  = Math.max( 0, historyIndex - 1 );
+						inputEl.value = history[historyIndex] || '';
+						updateInputGhost();
+						event.preventDefault();
+					}
+				} else if ( event.key === 'ArrowDown' ) {
+					if ( history.length ) {
+						historyIndex  = Math.min( history.length, historyIndex + 1 );
+						inputEl.value = history[historyIndex] || '';
+						updateInputGhost();
+						event.preventDefault();
+					}
+				}
+			}
+		);
+
+		inputEl.addEventListener( 'input', updateInputGhost );
+		inputEl.addEventListener(
+			'focus',
+			function () {
+				inputRowEl.classList.add( 'is-focused' );
+				updateInputGhost();
+			}
+		);
+		inputEl.addEventListener(
+			'blur',
+			function () {
+				inputRowEl.classList.remove( 'is-focused' );
+				updateInputGhost();
+			}
+		);
+		inputRowEl.addEventListener(
+			'click',
+			function () {
+				inputEl.focus();
+				inputRowEl.classList.add( 'is-focused' );
+				updateInputGhost();
+			}
+		);
+
+		updatePrompt();
+		updateInputGhost();
+		bootTranscript();
+	}
 
 	function markCopied( button ) {
 		var original       = button.textContent;

--- a/plugins/push-md/docs/landing/landing.js
+++ b/plugins/push-md/docs/landing/landing.js
@@ -1,25 +1,4 @@
 (function () {
-	var source = document.querySelector( '.markdown-source' );
-	if ( source ) {
-		var prefersReducedMotion = window.matchMedia &&
-			window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
-		var lines                = source.querySelectorAll( '.md-line' );
-
-		if ( ! prefersReducedMotion && lines.length ) {
-			source.classList.add( 'is-enhanced' );
-			lines.forEach(
-				function ( line, index ) {
-					window.setTimeout(
-						function () {
-							line.classList.add( 'is-visible' );
-						},
-						Math.min( index * 80, 1200 )
-					);
-				}
-			);
-		}
-	}
-
 	var copyButtons = document.querySelectorAll( '[data-copy-target]' );
 	copyButtons.forEach(
 		function ( button ) {


### PR DESCRIPTION
## Summary
- add a static public landing page draft for Push MD under `plugins/push-md/docs/landing/`
- position Push MD around WordPress-as-source-of-truth for Git, agents, permissions, and revisions
- document the landing page location in the Push MD developer README

## Validation
- `node --check plugins/push-md/docs/landing/landing.js`
- `vendor/bin/phpcs -d memory_limit=1G plugins/push-md/docs/landing/landing.js`
- browser preview via localhost with no console errors

## Notes
- Full `composer lint` still reports existing repo-wide PHPCS warnings outside this change.