### PR TITLE
[codex] Configure Push MD release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,223 +1,166 @@
-name: Publish new composer packages and phar files
+name: Publish Push MD release asset
 
 on:
-  workflow_dispatch:
-    inputs:
-      bump:
-        description: 'Version bump type (patch, minor, major)'
-        required: true
-        default: 'patch'
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
+  release:
+    types: [published]
+
+permissions:
+  contents: write
 
 jobs:
-  release-composer-packages:
+  build-push-md-release:
+    name: Build Push MD release asset
     runs-on: ubuntu-latest
-    environment: composer_deploy
-    permissions:
-      contents: write
+
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - name: Validate release tag
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+(\.[0-9]+){1,3}(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            echo "Release tag must look like v1.2.3 or v1.2.3-alpha. Got: $RELEASE_TAG" >&2
+            exit 1
+          fi
+
+          echo "version=${RELEASE_TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout trunk
+        uses: actions/checkout@v4
         with:
+          ref: trunk
           fetch-depth: 0
+
+      - name: Fetch release tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --force origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+
+      - name: Verify release tag is on trunk
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git fetch --force origin "refs/heads/trunk:refs/remotes/origin/trunk"
+          tag_sha="$(git rev-list -n 1 "$RELEASE_TAG")"
+          if ! git merge-base --is-ancestor "$tag_sha" origin/trunk; then
+            echo "Release tag $RELEASE_TAG is not reachable from origin/trunk." >&2
+            exit 1
+          fi
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.1'
+          coverage: none
 
       - name: Install Composer dependencies
-        run: composer install --no-interaction --prefer-dist
-
-      - name: Install Monorepo Builder
-        run: composer global require symplify/monorepo-builder:^12.2
+        run: composer install --no-interaction --prefer-dist --no-progress --optimize-autoloader
 
       - name: Configure Git user
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
+      - name: Update Push MD release version
+        run: php bin/update-push-md-version.php "${{ steps.release.outputs.version }}"
 
-      - name: Determine next version
-        id: semver
+      - name: Commit release version
+        shell: bash
         run: |
-          last="$(git tag --list 'v[0-9]*' --sort=-version:refname | head -n 1 || echo 'v0.1.0')"
-          bump="${{ github.event.inputs.bump }}"
-          case "$bump" in
-            patch|minor|major) inc="$bump" ;;
-            *) echo "Invalid bump: $bump" ; exit 1 ;;
-          esac
-          new="$(npx -y semver -i "$inc" "$last")"
-          new="${new#v}"
-          echo "new_version=$new" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
 
-      - name: Prepare VERSION file
-        run: |
-          echo "${{ steps.semver.outputs.new_version }}" > VERSION
-          git add VERSION
-          git commit -m "chore(release): record version v${{ steps.semver.outputs.new_version }}"
-
-      - name: Run MonorepoBuilder release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          $(composer global config bin-dir --absolute)/monorepo-builder release v${{ steps.semver.outputs.new_version }} 
-
-      - name: Ensure GitHub CLI and jq are installed
-        run: |
-          if ! command -v gh >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y gh jq
-          else
-            gh --version
-            jq --version || (sudo apt-get update && sudo apt-get install -y jq)
+          git status --short
+          if git diff --quiet -- plugins/push-md/push-md.php plugins/push-md/readme.txt plugins/push-md/class-pmd-admin.php; then
+            echo "Push MD release metadata already matches $RELEASE_TAG."
+            exit 0
           fi
 
-      - name: Install git-filter-repo
-        run: |
-          python3 -m pip install --user git-filter-repo
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          git add plugins/push-md/push-md.php plugins/push-md/readme.txt plugins/push-md/class-pmd-admin.php
+          git commit -m "chore(push-md): release $RELEASE_TAG"
+          git push origin HEAD:trunk
 
-      - name: Split code into component repositories
+      - name: Build Push MD plugin zip
+        run: bash bin/build-plugins.sh
+
+      - name: Inspect Push MD plugin zip
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          test -f dist/plugins/push-md.zip
+          zipinfo -1 dist/plugins/push-md.zip | tee /tmp/push-md-zip-contents.txt
+
+          grep -Fxq 'push-md/push-md.php' /tmp/push-md-zip-contents.txt
+          grep -Fxq 'push-md/readme.txt' /tmp/push-md-zip-contents.txt
+          grep -Fxq 'push-md/php-toolkit/vendor/composer/ClassLoader.php' /tmp/push-md-zip-contents.txt
+
+          ! grep -Eq '^push-md/(Tests|docker-demo|docs)/' /tmp/push-md-zip-contents.txt
+          ! grep -Fxq 'push-md/blueprint-e2e.json' /tmp/push-md-zip-contents.txt
+          ! grep -Fxq 'push-md/push-md-dev-bootstrap.php' /tmp/push-md-zip-contents.txt
+          ! grep -Fxq 'push-md/push-md-phar-bootstrap.php' /tmp/push-md-zip-contents.txt
+
+      - name: Upload Push MD release asset
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PACKAGIST_USERNAME: ${{ secrets.PACKAGIST_USERNAME }}
-          PACKAGIST_TOKEN: ${{ secrets.PACKAGIST_TOKEN }}
-          GH_CODESPLIT_EMAIL: ${{ secrets.GH_CODESPLIT_EMAIL }}
-          GH_ORG: ${{ secrets.GH_ORG }}
-          DEFAULT_BRANCH: trunk
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config --global user.email ${{ secrets.GH_CODESPLIT_EMAIL }}
-          git config --global user.name "github-actions[bot]"
-          bash bin/split-code.sh
+          gh --version
+          gh release upload "$RELEASE_TAG" dist/plugins/push-md.zip --clobber
 
-  build-phar-files:
-    needs: release-composer-packages
-    runs-on: ubuntu-latest
-    permissions:
-        contents: write
-        packages: write
-
-    steps:
-        - name: Checkout code
-          uses: actions/checkout@v2
-          with:
-              fetch-depth: 0
-
-        - name: Set up PHP
-          uses: shivammathur/setup-php@v2
-          with:
-              php-version: '8.0' # Specify the PHP version you need
-
-        - name: Install Composer dependencies
-          run: composer install --no-dev --prefer-dist
-
-        - name: Install Box
-          run: composer global require humbug/box
-
-        - name: Set up Node.js
-          uses: actions/setup-node@v2
-          with:
-              node-version: '22'
-
-        - name: Install npm dependencies for static-files-editor
-          run: |
-            cd plugins/static-files-editor
-            npm install
-
-        - name: Build all components
-          run: bash bin/build-all.sh
-
-        - name: Fetch tags
-          run: |
-            git fetch --tags --prune --quiet || true
-
-        - name: Determine latest tag
-          id: tag
-          run: |
-            latest="$(git tag --list 'v[0-9]*' --sort=-version:refname | head -n 1)"
-            if [ -z "$latest" ]; then echo "No version tags found"; exit 1; fi
-            echo "tag=$latest" >> "$GITHUB_OUTPUT"
-
-        - name: Create GitHub Release
-          id: create_release
-          uses: actions/create-release@v1
-          env:
-              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          with:
-              tag_name: ${{ steps.tag.outputs.tag }}
-              release_name: Release ${{ steps.tag.outputs.tag }}
-              draft: false
-              prerelease: false
-
-        - name: Upload Data Liberation Asset
-          uses: actions/upload-release-asset@v1
-          env:
-              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          with:
-              upload_url: ${{ steps.create_release.outputs.upload_url }}
-              asset_path: ./dist/plugins/data-liberation.zip
-              asset_name: data-liberation.zip
-              asset_content_type: application/zip
-
-        - name: Upload URL Updater Asset
-          uses: actions/upload-release-asset@v1
-          env:
-              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          with:
-              upload_url: ${{ steps.create_release.outputs.upload_url }}
-              asset_path: ./dist/plugins/url-updater.zip
-              asset_name: url-updater.zip
-              asset_content_type: application/zip
-
-        - name: Upload Static Files Editor Asset
-          uses: actions/upload-release-asset@v1
-          env:
-              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          with:
-              upload_url: ${{ steps.create_release.outputs.upload_url }}
-              asset_path: ./dist/plugins/static-files-editor.zip
-              asset_name: static-files-editor.zip
-              asset_content_type: application/zip
-
-        - name: Upload Import Static Files Example Asset
-          uses: actions/upload-release-asset@v1
-          env:
-              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          with:
-              upload_url: ${{ steps.create_release.outputs.upload_url }}
-              asset_path: ./dist/examples/create-wp-site.tar.gz
-              asset_name: create-wp-site.tar.gz
-              asset_content_type: application/gzip
-
-
-        - name: Upload Blueprints Asset
-          uses: actions/upload-release-asset@v1
-          env:
-              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          with:
-              upload_url: ${{ steps.create_release.outputs.upload_url }}
-              asset_path: ./dist/blueprints.phar
-              asset_name: blueprints.phar
-              asset_content_type: application/phar
-
-        - name: Upload PHP toolkit .phar Asset
-          uses: actions/upload-release-asset@v1
-          env:
-              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          with:
-              upload_url: ${{ steps.create_release.outputs.upload_url }}
-              asset_path: ./dist/php-toolkit.phar
-              asset_name: php-toolkit.phar
-              asset_content_type: application/phar
-    
+# Temporarily disabled legacy release flow. Restore these sections when the
+# repository release process should publish Composer packages, PHARs, examples,
+# and the older plugin zips again.
+#
+# on:
+#   workflow_dispatch:
+#     inputs:
+#       bump:
+#         description: 'Version bump type (patch, minor, major)'
+#         required: true
+#         default: 'patch'
+#         type: choice
+#         options:
+#           - patch
+#           - minor
+#           - major
+#
+# jobs:
+#   release-composer-packages:
+#     runs-on: ubuntu-latest
+#     environment: composer_deploy
+#     permissions:
+#       contents: write
+#     steps:
+#       - Checkout code
+#       - Set up PHP 8.2
+#       - Install Composer dependencies
+#       - Install Monorepo Builder
+#       - Determine next version from the bump input
+#       - Commit the root VERSION file
+#       - Run MonorepoBuilder release
+#       - Install git-filter-repo
+#       - Run bin/split-code.sh
+#
+#   build-phar-files:
+#     needs: release-composer-packages
+#     runs-on: ubuntu-latest
+#     permissions:
+#       contents: write
+#       packages: write
+#     steps:
+#       - Checkout code
+#       - Set up PHP and Node.js
+#       - Install Composer, Box, and static-files-editor npm dependencies
+#       - Run bash bin/build-all.sh
+#       - Create a new GitHub Release from the latest v* tag
+#       - Upload dist/plugins/data-liberation.zip
+#       - Upload dist/plugins/url-updater.zip
+#       - Upload dist/plugins/static-files-editor.zip
+#       - Upload dist/examples/create-wp-site.tar.gz
+#       - Upload dist/blueprints.phar
+#       - Upload dist/php-toolkit.phar

--- a/bin/build-plugins.sh
+++ b/bin/build-plugins.sh
@@ -226,32 +226,43 @@ copy_pmd_php_toolkit_bundle() {
 	generate_pmd_toolkit_autoload "$target_dir"
 }
 
-cp -r $PROJECT_DIR/plugins/data-liberation $DIST_DIR
-cp $PROJECT_DIR/dist/php-toolkit.phar $DIST_DIR/data-liberation/php-toolkit.phar
-cd $DIST_DIR
-zip -r data-liberation.zip data-liberation/
-cd $PROJECT_DIR
-rm -rf $DIST_DIR/data-liberation
-
-cd $PROJECT_DIR/plugins/static-files-editor/
-npm run build
-cd $PROJECT_DIR
-mkdir -p $DIST_DIR/static-files-editor
-cp -r $PROJECT_DIR/plugins/static-files-editor/!(node_modules|src|webpack.config.js|package.json|package-lock.json) $DIST_DIR/static-files-editor
-cd $DIST_DIR
-zip -r static-files-editor.zip static-files-editor/
-cd $PROJECT_DIR
-rm -rf $DIST_DIR/static-files-editor
-
-mkdir -p $DIST_DIR/url-updater
-cp -r $PROJECT_DIR/plugins/url-updater/!(node_modules|src|webpack.config.js|package.json|package-lock.json) $DIST_DIR/url-updater
-cd $DIST_DIR
-zip -r url-updater.zip url-updater/
-cd $PROJECT_DIR
-rm -rf $DIST_DIR/url-updater
+# Temporarily disabled while the release workflow only publishes Push MD.
+# Restore these blocks when the older plugin zips should be built again.
+#
+# cp -r $PROJECT_DIR/plugins/data-liberation $DIST_DIR
+# cp $PROJECT_DIR/dist/php-toolkit.phar $DIST_DIR/data-liberation/php-toolkit.phar
+# cd $DIST_DIR
+# zip -r data-liberation.zip data-liberation/
+# cd $PROJECT_DIR
+# rm -rf $DIST_DIR/data-liberation
+#
+# cd $PROJECT_DIR/plugins/static-files-editor/
+# npm run build
+# cd $PROJECT_DIR
+# mkdir -p $DIST_DIR/static-files-editor
+# cp -r $PROJECT_DIR/plugins/static-files-editor/!(node_modules|src|webpack.config.js|package.json|package-lock.json) $DIST_DIR/static-files-editor
+# cd $DIST_DIR
+# zip -r static-files-editor.zip static-files-editor/
+# cd $PROJECT_DIR
+# rm -rf $DIST_DIR/static-files-editor
+#
+# mkdir -p $DIST_DIR/url-updater
+# cp -r $PROJECT_DIR/plugins/url-updater/!(node_modules|src|webpack.config.js|package.json|package-lock.json) $DIST_DIR/url-updater
+# cd $DIST_DIR
+# zip -r url-updater.zip url-updater/
+# cd $PROJECT_DIR
+# rm -rf $DIST_DIR/url-updater
 
 mkdir -p $DIST_DIR/push-md
-cp -r $PROJECT_DIR/plugins/push-md/!(Tests|docker-demo|docs|blueprint-e2e.json|push-md-dev-bootstrap.php|push-md-phar-bootstrap.php) $DIST_DIR/push-md
+rsync -a \
+	--exclude='Tests/' \
+	--exclude='docker-demo/' \
+	--exclude='docs/' \
+	--exclude='blueprint-e2e.json' \
+	--exclude='push-md-dev-bootstrap.php' \
+	--exclude='push-md-phar-bootstrap.php' \
+	"$PROJECT_DIR/plugins/push-md/" \
+	"$DIST_DIR/push-md/"
 copy_pmd_php_toolkit_bundle "$DIST_DIR/push-md/php-toolkit"
 cd $DIST_DIR
 zip -r push-md.zip push-md/

--- a/bin/update-push-md-version.php
+++ b/bin/update-push-md-version.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Updates Push MD release metadata from a version string.
+ */
+
+if ( 'cli' !== PHP_SAPI ) {
+	fwrite( STDERR, "This script must be run from the command line.\n" );
+	exit( 1 );
+}
+
+if ( 2 !== $argc ) {
+	fwrite( STDERR, "Usage: php bin/update-push-md-version.php <version>\n" );
+	exit( 1 );
+}
+
+$version = $argv[1];
+if ( 1 !== preg_match( '/\A[0-9]+(?:\.[0-9]+){1,3}(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?\z/', $version ) ) {
+	fwrite( STDERR, "Invalid Push MD release version: $version\n" );
+	exit( 1 );
+}
+
+$root_dir = dirname( __DIR__ );
+
+function pmd_update_version_field( $root_dir, $relative_path, $pattern, $version ) {
+	$path     = $root_dir . '/' . $relative_path;
+	$contents = file_get_contents( $path );
+
+	if ( false === $contents ) {
+		fwrite( STDERR, "Unable to read $relative_path\n" );
+		exit( 1 );
+	}
+
+	$count   = 0;
+	$updated = preg_replace_callback(
+		$pattern,
+		function ( $matches ) use ( $version, &$count ) {
+			$count++;
+			$suffix = isset( $matches[2] ) ? $matches[2] : '';
+			return $matches[1] . $version . $suffix;
+		},
+		$contents
+	);
+
+	if ( 1 !== $count || null === $updated ) {
+		fwrite( STDERR, "Expected one release metadata match in $relative_path; found $count\n" );
+		exit( 1 );
+	}
+
+	if ( $updated === $contents ) {
+		echo "$relative_path already uses $version\n";
+		return;
+	}
+
+	if ( false === file_put_contents( $path, $updated ) ) {
+		fwrite( STDERR, "Unable to write $relative_path\n" );
+		exit( 1 );
+	}
+
+	echo "Updated $relative_path to $version\n";
+}
+
+pmd_update_version_field(
+	$root_dir,
+	'plugins/push-md/push-md.php',
+	'/(\* Version:\s*)[^\r\n]+/',
+	$version
+);
+pmd_update_version_field(
+	$root_dir,
+	'plugins/push-md/readme.txt',
+	'/(Stable tag:\s*)[^\r\n]+/',
+	$version
+);
+pmd_update_version_field(
+	$root_dir,
+	'plugins/push-md/class-pmd-admin.php',
+	"/(const ASSET_VERSION\s*=\s*')[^']+(';)/",
+	$version
+);


### PR DESCRIPTION
## Summary
- Convert the publish workflow into a Push MD-only release asset workflow triggered by published GitHub Releases.
- Add a release-version helper that updates the Push MD plugin header, readme stable tag, and admin asset version from the release tag.
- Temporarily disable legacy Composer/PHAR/example/other-plugin release work while keeping it visible for later restoration.

## Impact
Publishing a GitHub Release for a tag such as `v0.6.0` now builds and uploads `push-md.zip` to that existing release. The workflow commits Push MD version metadata back to `trunk` without moving or recreating the tag.

## Validation
- `bash -n bin/build-plugins.sh`
- `php -l bin/update-push-md-version.php`
- Version helper tested against a temporary Push MD copy
- `bash bin/build-plugins.sh`
- `zipinfo -1 dist/plugins/push-md.zip` confirmed expected runtime/toolkit files and excluded dev/test/docs files
- `vendor/bin/phpcs -d memory_limit=1G bin/update-push-md-version.php plugins/push-md/push-md.php plugins/push-md/class-pmd-admin.php`
- `vendor/bin/phpunit --testsuite "Push MD E2E"` passed locally as skipped because `PUSH_MD_E2E_*` env vars were not set

## Notes
`composer lint` still exits nonzero from existing repository warnings outside this change; the touched PHP files pass targeted PHPCS.
