### PR TITLE
[codex] Update Push MD landing links

### DIFF
--- a/plugins/push-md/docs/landing/index.html
+++ b/plugins/push-md/docs/landing/index.html
@@ -22,7 +22,7 @@
 			<a href="#faq">FAQ</a>
 			<a href="https://github.com/Automattic/php-toolkit/tree/trunk/plugins/push-md/docs">Docs</a>
 		</nav>
-		<a class="button button-primary" href="#install">Download plugin</a>
+		<a class="button button-primary" href="https://github.com/Automattic/php-toolkit/releases/latest/download/push-md.zip">Download plugin</a>
 	</header>
 
 	<main id="main" class="markdown-document">
@@ -35,7 +35,7 @@
 					revisions, rejects stale pushes, and lets WordPress render the site.
 				</p>
 				<div class="hero-actions" aria-label="Primary actions">
-					<a class="button button-primary" href="#install">Download plugin</a>
+					<a class="button button-primary" href="https://github.com/Automattic/php-toolkit/releases/latest/download/push-md.zip">Download plugin</a>
 					<a class="button button-secondary" href="https://github.com/Automattic/php-toolkit/tree/trunk/plugins/push-md/docs">Read docs</a>
 				</div>
 			</div>
@@ -246,10 +246,8 @@
 	</main>
 
 	<footer class="site-footer">
-		<p>Push MD is part of the WordPress PHP Toolkit.</p>
+		<p>An Automattic experiment by <a href="https://adamadam.blog/">zieladam</a> and <a href="https://piszek.com">artpi</a></p>
 		<div>
-			<a href="https://github.com/Automattic/php-toolkit/tree/trunk/plugins/push-md/docs">Developer docs</a>
-			<a href="../prd.md">PRD</a>
 			<a href="https://github.com/WordPress/php-toolkit/tree/trunk/plugins/push-md">GitHub</a>
 		</div>
 	</footer>


### PR DESCRIPTION
## Summary
- Point Push MD landing page download CTAs to the latest release ZIP.
- Replace the footer copy with Automattic experiment attribution links.
- Remove Developer docs and PRD links from the footer.

## Validation
- Ran `git diff --check -- plugins/push-md/docs/landing/index.html`.
- Ran `composer lint`; it exits non-zero because of pre-existing PHPCS warnings in unrelated PHP files.
- No focused component tests apply to this static HTML change.
