### PR TITLE
[codex] Add Push MD landing beta and plugin links

### DIFF
--- a/plugins/push-md/docs/landing/index.html
+++ b/plugins/push-md/docs/landing/index.html
@@ -19,6 +19,8 @@
 	<meta name="twitter:description" content="Clone posts as Markdown, pull WP-Admin edits, and push your changes with any git client.">
 	<meta name="twitter:image" content="https://pushmd.blog/assets/push-md-social-card.png">
 	<meta name="twitter:image:alt" content="Push MD social card showing a terminal workflow for WordPress content in Git.">
+	<link rel="icon" type="image/png" sizes="512x512" href="assets/push-md-logo.png">
+	<link rel="apple-touch-icon" href="assets/push-md-logo.png">
 	<link rel="stylesheet" href="landing.css">
 </head>
 <body>
@@ -28,6 +30,7 @@
 		<a class="brand" href="#top" aria-label="Push MD home">
 			<img class="brand-logo" src="assets/push-md-logo.png" alt="" width="512" height="512" aria-hidden="true">
 			<span>Push MD</span>
+			<span class="beta-badge">Beta</span>
 		</a>
 		<nav class="site-nav" aria-label="Main navigation">
 			<a href="#how-it-works">Use cases</a>
@@ -65,6 +68,9 @@
 					</a>
 					<a class="button button-secondary" href="https://github.com/Automattic/php-toolkit/tree/trunk/plugins/push-md/docs">Read docs</a>
 				</div>
+				<p class="beta-note">
+					<strong>Beta:</strong> Push MD is an early release for experimentation. Try it on a staging site first and keep your usual WordPress backups in place.
+				</p>
 			</div>
 
 			<div class="terminal-card" role="application" aria-label="Push MD command emulator">

--- a/plugins/push-md/docs/landing/landing.css
+++ b/plugins/push-md/docs/landing/landing.css
@@ -100,6 +100,21 @@ pre {
 	filter: drop-shadow(0 5px 12px rgba(31, 29, 25, 0.18));
 }
 
+.beta-badge {
+	display: inline-flex;
+	align-items: center;
+	min-height: 22px;
+	padding: 2px 8px;
+	border: 1px solid rgba(176, 93, 51, 0.26);
+	border-radius: 999px;
+	background: rgba(244, 208, 111, 0.28);
+	color: var(--hash);
+	font-size: 12px;
+	font-weight: 780;
+	line-height: 1;
+	text-transform: uppercase;
+}
+
 .site-nav {
 	display: flex;
 	align-items: center;
@@ -251,6 +266,20 @@ pre {
 	flex-wrap: wrap;
 	gap: 12px;
 	margin: 28px 0 0;
+}
+
+.beta-note {
+	max-width: 660px;
+	margin: 18px 0 0;
+	padding: 10px 0 10px 14px;
+	border-left: 3px solid var(--hash);
+	color: var(--muted);
+	font-size: 14px;
+	line-height: 1.5;
+}
+
+.beta-note strong {
+	color: var(--ink);
 }
 
 .terminal-card,

--- a/plugins/push-md/push-md.php
+++ b/plugins/push-md/push-md.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Plugin Name: Push MD
+ * Plugin URI: https://pushmd.blog/
  * Description: Edit WordPress content with Git, Markdown and block files, reviewable diffs, and safe pushes.
  * Version: 0.6.0
  * Requires at least: 6.9
@@ -57,6 +58,19 @@ add_action(
 		}
 		wp_safe_redirect( admin_url( 'tools.php?page=' . PMD_Admin::PAGE_SLUG ) );
 		exit;
+	}
+);
+
+add_filter(
+	'plugin_action_links_' . plugin_basename( PMD_PLUGIN_FILE ),
+	function ( $actions ) {
+		$actions['push_md_landing_page'] = sprintf(
+			'<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>',
+			esc_url( 'https://pushmd.blog/' ),
+			esc_html__( 'Landing page', 'push-md' )
+		);
+
+		return $actions;
 	}
 );
 


### PR DESCRIPTION
## Summary
- add favicon and Apple touch icon links to the Push MD landing page using the existing logo asset
- add beta messaging to the landing page header and hero
- add the Push MD Plugin URI plus a plugin-list Landing page action link

## Validation
- vendor/bin/phpcs -d memory_limit=1G plugins/push-md/push-md.php
- php -l plugins/push-md/push-md.php
- git diff --check
- local browser preview at http://127.0.0.1:8876/ confirmed beta copy, favicon links, terminal content, and no console errors
- vendor/bin/phpunit plugins/push-md/Tests/ ran, but all 5 E2E tests skipped because PUSH_MD_E2E_* env vars were not set

## Notes
Full composer lint still reports existing unrelated warnings elsewhere in the repository; the touched PHP file passes targeted PHPCS.