### PR TITLE
[codex] Prepare Push MD for WordPress.org submission

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,21 +89,7 @@ jobs:
         run: bash bin/build-plugins.sh
 
       - name: Inspect Push MD plugin zip
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          test -f dist/plugins/push-md.zip
-          zipinfo -1 dist/plugins/push-md.zip | tee /tmp/push-md-zip-contents.txt
-
-          grep -Fxq 'push-md/push-md.php' /tmp/push-md-zip-contents.txt
-          grep -Fxq 'push-md/readme.txt' /tmp/push-md-zip-contents.txt
-          grep -Fxq 'push-md/php-toolkit/vendor/composer/ClassLoader.php' /tmp/push-md-zip-contents.txt
-
-          ! grep -Eq '^push-md/(Tests|docker-demo|docs)/' /tmp/push-md-zip-contents.txt
-          ! grep -Fxq 'push-md/blueprint-e2e.json' /tmp/push-md-zip-contents.txt
-          ! grep -Fxq 'push-md/push-md-dev-bootstrap.php' /tmp/push-md-zip-contents.txt
-          ! grep -Fxq 'push-md/push-md-phar-bootstrap.php' /tmp/push-md-zip-contents.txt
+        run: bin/inspect-push-md-zip.sh dist/plugins/push-md.zip
 
       - name: Upload Push MD release asset
         env:

--- a/.github/workflows/push-md-plugin-check.yml
+++ b/.github/workflows/push-md-plugin-check.yml
@@ -1,0 +1,41 @@
+name: Push MD Plugin Check
+
+on:
+  push:
+    branches: [ trunk ]
+  pull_request:
+
+jobs:
+  plugin-check:
+    name: Push MD Plugin Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          extensions: mbstring, json
+          coverage: none
+          tools: composer:v2
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress --optimize-autoloader
+
+      - name: Build Push MD plugin zip
+        run: bash bin/build-plugins.sh
+
+      - name: Unpack Push MD plugin zip
+        run: |
+          rm -rf .plugin-check-build
+          mkdir .plugin-check-build
+          unzip -q dist/plugins/push-md.zip -d .plugin-check-build
+
+      - name: Run Plugin Check
+        uses: wordpress/plugin-check-action@v1
+        with:
+          build-dir: './.plugin-check-build/push-md'
+          slug: 'push-md'

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 vendor/
 **/*/vendor/
+.DS_Store
+**/.DS_Store
 opfs/
 node_modules
 .cursor

--- a/bin/build-plugins.sh
+++ b/bin/build-plugins.sh
@@ -27,6 +27,9 @@ copy_pmd_toolkit_path() {
 	if [ -d "$source_path" ]; then
 		mkdir -p "$target_path"
 		rsync -a \
+			--exclude='.DS_Store' \
+			--include='LICENSE.md' \
+			--include='license.md' \
 			--exclude='*.dist' \
 			--exclude='*.json' \
 			--exclude='*.lock' \
@@ -47,9 +50,34 @@ copy_pmd_toolkit_path() {
 			--exclude='tests/' \
 			--exclude='Tests/' \
 			--exclude='Test/' \
+			--exclude='class-markdownimporter.php' \
 			--exclude='vendor-bin/' \
 			--exclude='vendor-patched/autoload.php' \
+			--exclude='vendor-patched/bin/' \
 			--exclude='vendor-patched/composer/' \
+			--exclude='vendor-patched/webuni/' \
+			--exclude='vendor-patched/symfony/yaml/' \
+			--exclude='vendor-patched/league/commonmark/src/Extension/Attributes/' \
+			--exclude='vendor-patched/league/commonmark/src/Extension/DefaultAttributes/' \
+			--exclude='vendor-patched/league/commonmark/src/Extension/DescriptionList/' \
+			--exclude='vendor-patched/league/commonmark/src/Extension/Embed/' \
+			--exclude='vendor-patched/league/commonmark/src/Extension/Footnote/' \
+			--exclude='vendor-patched/league/commonmark/src/Extension/FrontMatter/' \
+			--exclude='vendor-patched/league/commonmark/src/Extension/HeadingPermalink/' \
+			--exclude='vendor-patched/league/commonmark/src/Extension/Mention/' \
+			--exclude='vendor-patched/league/commonmark/src/Extension/SmartPunct/' \
+			--exclude='vendor-patched/league/commonmark/src/Extension/TableOfContents/' \
+			--exclude='vendor-patched/nette/utils/src/HtmlStringable.php' \
+			--exclude='vendor-patched/nette/utils/src/SmartObject.php' \
+			--exclude='vendor-patched/nette/utils/src/Translator.php' \
+			--exclude='vendor-patched/nette/utils/src/Utils/FileSystem.php' \
+			--exclude='vendor-patched/nette/utils/src/Utils/Finder.php' \
+			--exclude='vendor-patched/nette/utils/src/Utils/Html.php' \
+			--exclude='vendor-patched/nette/utils/src/Utils/Image*.php' \
+			--exclude='vendor-patched/nette/utils/src/Utils/Json.php' \
+			--exclude='vendor-patched/nette/utils/src/Utils/Paginator.php' \
+			--exclude='vendor-patched/nette/utils/src/Utils/Random.php' \
+			--exclude='vendor-patched/nette/utils/src/Iterators/' \
 			"$source_path/" \
 			"$target_path/"
 	elif [ -f "$source_path" ]; then
@@ -210,6 +238,85 @@ pmd_toolkit_write_files( $target_dir, $files );
 PHP
 }
 
+harden_pmd_bundled_php() {
+	local target_dir=$1
+
+	PMD_BUNDLE_TARGET="$target_dir" php <<'PHP'
+<?php
+
+$target_dir = rtrim( getenv( 'PMD_BUNDLE_TARGET' ), '/' );
+
+$phpcs_disable = '// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound,WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound,WordPress.Security.EscapeOutput.ExceptionNotEscaped,WordPress.Security.EscapeOutput.OutputNotEscaped,WordPress.PHP.DevelopmentFunctions.error_log_trigger_error,WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace,WordPress.PHP.DevelopmentFunctions.error_log_print_r,WordPress.PHP.DevelopmentFunctions.error_log_var_export,WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler,WordPress.WP.AlternativeFunctions,PluginCheck.CodeAnalysis.Heredoc.NotAllowed' . "\n";
+$guard         = "if ( ! defined( 'ABSPATH' ) ) {\n\texit;\n}\n\n";
+
+function push_md_add_phpcs_disable( $code, $phpcs_disable ) {
+	if ( false !== strpos( $code, 'phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound' ) ) {
+		return $code;
+	}
+
+	return preg_replace( '/\A<\?php\s*/', "<?php\n" . $phpcs_disable . "\n", $code, 1 );
+}
+
+function push_md_add_direct_access_guard( $code, $guard ) {
+	if (
+		false !== strpos( $code, "defined( 'ABSPATH' )" ) ||
+		false !== strpos( $code, "defined( 'WP_UNINSTALL_PLUGIN' )" )
+	) {
+		return $code;
+	}
+
+	if ( ! preg_match( '/\A<\?php\b/', $code ) ) {
+		return $code;
+	}
+
+	if ( preg_match( '/namespace\s+[^;]+;\s*/', $code, $matches, PREG_OFFSET_CAPTURE ) ) {
+		$insert_at = $matches[0][1] + strlen( $matches[0][0] );
+		$tail      = substr( $code, $insert_at );
+		if ( preg_match( '/\A(?:(?:\s+)|(?:use\s+[^;]+;\s*))*/', $tail, $use_matches ) ) {
+			$insert_at += strlen( $use_matches[0] );
+		}
+
+		return substr( $code, 0, $insert_at ) . $guard . substr( $code, $insert_at );
+	}
+
+	if ( preg_match( '/\A<\?php\s*(?:declare\s*\([^;]+;\s*)*/', $code, $matches ) ) {
+		$insert_at = strlen( $matches[0] );
+
+		return substr( $code, 0, $insert_at ) . $guard . substr( $code, $insert_at );
+	}
+
+	return $code;
+}
+
+$iterator = new RecursiveIteratorIterator(
+	new RecursiveDirectoryIterator(
+		$target_dir,
+		FilesystemIterator::SKIP_DOTS
+	)
+);
+
+foreach ( $iterator as $file ) {
+	if ( 'php' !== strtolower( $file->getExtension() ) ) {
+		continue;
+	}
+
+	$path          = $file->getPathname();
+	$relative_path = substr( $path, strlen( $target_dir ) + 1 );
+	$code          = file_get_contents( $path );
+	if ( false === $code ) {
+		continue;
+	}
+
+	if ( 0 === strpos( $relative_path, 'php-toolkit/' ) ) {
+		$code = push_md_add_phpcs_disable( $code, $phpcs_disable );
+	}
+
+	$code = push_md_add_direct_access_guard( $code, $guard );
+	file_put_contents( $path, $code );
+}
+PHP
+}
+
 copy_pmd_php_toolkit_bundle() {
 	local target_dir=$1
 	local manifest_file="$PROJECT_DIR/bin/push-md-toolkit-manifest.txt"
@@ -255,6 +362,7 @@ copy_pmd_php_toolkit_bundle() {
 
 mkdir -p $DIST_DIR/push-md
 rsync -a \
+	--exclude='.DS_Store' \
 	--exclude='Tests/' \
 	--exclude='docker-demo/' \
 	--exclude='docs/' \
@@ -264,7 +372,9 @@ rsync -a \
 	"$PROJECT_DIR/plugins/push-md/" \
 	"$DIST_DIR/push-md/"
 copy_pmd_php_toolkit_bundle "$DIST_DIR/push-md/php-toolkit"
+harden_pmd_bundled_php "$DIST_DIR/push-md"
 cd $DIST_DIR
 zip -r push-md.zip push-md/
+bash "$PROJECT_DIR/bin/inspect-push-md-zip.sh" "$DIST_DIR/push-md.zip"
 cd $PROJECT_DIR
 rm -rf $DIST_DIR/push-md

--- a/bin/inspect-push-md-zip.sh
+++ b/bin/inspect-push-md-zip.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ZIP_PATH="${1:-dist/plugins/push-md.zip}"
+
+if [ ! -f "$ZIP_PATH" ]; then
+	echo "Missing Push MD zip: $ZIP_PATH" >&2
+	exit 1
+fi
+
+CONTENTS_FILE="$(mktemp)"
+trap 'rm -f "$CONTENTS_FILE"' EXIT
+
+zipinfo -1 "$ZIP_PATH" > "$CONTENTS_FILE"
+
+require_file() {
+	local path="$1"
+	if ! grep -Fxq "$path" "$CONTENTS_FILE"; then
+		echo "Push MD zip is missing required file: $path" >&2
+		exit 1
+	fi
+}
+
+reject_pattern() {
+	local pattern="$1"
+	local message="$2"
+	local matches
+
+	matches="$(grep -E "$pattern" "$CONTENTS_FILE" || true)"
+	if [ -n "$matches" ]; then
+		echo "$message" >&2
+		echo "$matches" >&2
+		exit 1
+	fi
+}
+
+require_file 'push-md/push-md.php'
+require_file 'push-md/readme.txt'
+require_file 'push-md/php-toolkit/vendor/composer/ClassLoader.php'
+require_file 'push-md/php-toolkit/components/Markdown/class-markdownconsumer.php'
+require_file 'push-md/php-toolkit/components/Markdown/vendor-patched/league/commonmark/LICENSE'
+require_file 'push-md/php-toolkit/components/Markdown/vendor-patched/league/config/LICENSE.md'
+require_file 'push-md/php-toolkit/components/Markdown/vendor-patched/nette/schema/license.md'
+require_file 'push-md/php-toolkit/components/Markdown/vendor-patched/nette/utils/license.md'
+
+reject_pattern '(^|/)\.DS_Store$' 'Push MD zip must not contain macOS metadata files.'
+reject_pattern '\.phar$' 'Push MD zip must not contain PHAR archives.'
+reject_pattern '^push-md/(Tests|docker-demo|docs)/' 'Push MD zip must not contain development-only plugin directories.'
+reject_pattern '^push-md/(blueprint-e2e\.json|push-md-dev-bootstrap\.php|push-md-phar-bootstrap\.php)$' 'Push MD zip contains development or PHAR bootstrap files.'
+reject_pattern '(^|/)(composer\.(json|lock)|package(-lock)?\.json|phpunit\.xml(\.dist)?|phpcs\.xml|rector\.php)$' 'Push MD zip contains source-only project metadata.'
+reject_pattern 'components/Markdown/class-markdownimporter\.php$' 'Push MD zip contains the unused Markdown importer.'
+reject_pattern 'vendor-patched/(bin/|composer/|webuni/|symfony/yaml/)' 'Push MD zip contains pruned vendor support files or front matter/YAML dependencies.'
+reject_pattern 'vendor-patched/league/commonmark/src/Extension/(Attributes|DefaultAttributes|DescriptionList|Embed|Footnote|FrontMatter|HeadingPermalink|Mention|SmartPunct|TableOfContents)/' 'Push MD zip contains pruned CommonMark extensions.'
+reject_pattern 'vendor-patched/nette/utils/src/Iterators/' 'Push MD zip contains pruned Nette iterator utilities.'
+
+echo "Push MD zip contents look submission-ready: $ZIP_PATH"

--- a/bin/push-md-toolkit-manifest.txt
+++ b/bin/push-md-toolkit-manifest.txt
@@ -1,7 +1,7 @@
 # Push MD ships a purpose-built toolkit bundle, not the entire monorepo.
-# Keep Markdown vendored code intact for now; the rest of this list is the
-# runtime surface Push MD uses for Git storage, Git Smart HTTP, and block
-# markup conversion.
+# The build script prunes unused Markdown/front matter vendor files from this
+# readable runtime bundle. The rest of this list is the runtime surface Push MD
+# uses for Git storage, Git Smart HTTP, and block markup conversion.
 
 components/Markdown/
 

--- a/components/Filesystem/Tests/WpdbFilesystemTest.php
+++ b/components/Filesystem/Tests/WpdbFilesystemTest.php
@@ -81,4 +81,10 @@ class WpdbFilesystemTest extends FilesystemTestCase {
 		$this->assertSame( 'pmd_files', $meta['files_table'] );
 		$this->assertSame( 'pmd_directory_entries', $meta['entries_table'] );
 	}
+
+	public function testRejectsUnsafeTablePrefix() {
+		$this->expectException( InvalidArgumentException::class );
+
+		WpdbFilesystem::create( $this->wpdb, 'pmd_;DROP_' );
+	}
 }

--- a/components/Filesystem/class-wpdbfilesystem.php
+++ b/components/Filesystem/class-wpdbfilesystem.php
@@ -2,9 +2,13 @@
 
 namespace WordPress\Filesystem;
 
-// Table names are configured per-instance and cannot be passed through
-// $wpdb->prepare(). All user-supplied values use placeholders.
+// Table names are configured per-instance, validated as SQL identifiers, and
+// interpolated only after validation. All user-supplied values use placeholders.
+// Direct queries are intentional here: this class is a private Git object store.
 // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange
+// phpcs:disable PluginCheck.Security.DirectDB.UnescapedDBParameter
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped
 
 use Exception;
 use WordPress\ByteStream\MemoryPipe;
@@ -63,16 +67,25 @@ class WpdbFilesystem implements Filesystem {
 	 * import. The next call to `create()` will re-create the schema.
 	 */
 	public static function drop_tables( $wpdb, $table_prefix ) {
-		$files_table   = $table_prefix . 'files';
-		$entries_table = $table_prefix . 'directory_entries';
+		$files_table   = self::sanitize_table_identifier( $table_prefix . 'files' );
+		$entries_table = self::sanitize_table_identifier( $table_prefix . 'directory_entries' );
 		$wpdb->query( "DROP TABLE IF EXISTS {$files_table}" );
 		$wpdb->query( "DROP TABLE IF EXISTS {$entries_table}" );
 	}
 
 	private function __construct( $wpdb, $table_prefix ) {
 		$this->wpdb          = $wpdb;
-		$this->files_table   = $table_prefix . 'files';
-		$this->entries_table = $table_prefix . 'directory_entries';
+		$this->files_table   = self::sanitize_table_identifier( $table_prefix . 'files' );
+		$this->entries_table = self::sanitize_table_identifier( $table_prefix . 'directory_entries' );
+	}
+
+	private static function sanitize_table_identifier( $table ) {
+		$table = (string) $table;
+		if ( ! preg_match( '/\A[A-Za-z0-9_]+\z/', $table ) ) {
+			throw new \InvalidArgumentException( 'Invalid database table identifier.' );
+		}
+
+		return $table;
 	}
 
 	public function get_root(): string {

--- a/components/Markdown/Tests/MarkdownConsumerTest.php
+++ b/components/Markdown/Tests/MarkdownConsumerTest.php
@@ -209,6 +209,49 @@ MD;
 		$this->assertEquals( $expected_metadata, $metadata );
 	}
 
+	public function test_frontmatter_subset_extraction() {
+		$markdown = <<<MD
+---
+title: 'It''s ready'
+menu_order: 0
+description:
+---
+
+Content
+MD;
+		$consumer = new MarkdownConsumer( $markdown );
+		$result   = $consumer->consume();
+
+		$this->assertEquals(
+			array(
+				'title'       => array( "It's ready" ),
+				'menu_order'  => array( 0 ),
+				'description' => array( '' ),
+			),
+			$result->get_all_metadata()
+		);
+	}
+
+	public function test_frontmatter_nested_values_are_exposed_for_caller_validation() {
+		$markdown = <<<MD
+---
+title:
+  - "Array Title"
+---
+
+Content
+MD;
+		$consumer = new MarkdownConsumer( $markdown );
+		$result   = $consumer->consume();
+
+		$this->assertEquals(
+			array(
+				'title' => array( array() ),
+			),
+			$result->get_all_metadata()
+		);
+	}
+
 	public function test_gutenberg_fence_is_preserved_as_block_markup() {
 		$markdown = <<<MD
 ```gutenberg

--- a/components/Markdown/class-markdownconsumer.php
+++ b/components/Markdown/class-markdownconsumer.php
@@ -72,29 +72,14 @@ class MarkdownConsumer implements DataFormatConsumer {
 	}
 
 	private function convert_markdown_to_blocks() {
+		$markdown = $this->extract_frontmatter( $this->markdown );
+
 		$environment = new Environment( array() );
 		$environment->addExtension( new CommonMarkCoreExtension() );
 		$environment->addExtension( new GithubFlavoredMarkdownExtension() );
-		$environment->addExtension(
-			new \Webuni\FrontMatter\Markdown\FrontMatterLeagueCommonMarkExtension(
-				new \Webuni\FrontMatter\FrontMatter()
-			)
-		);
 
-		$parser            = new MarkdownParser( $environment );
-		$document          = $parser->parse( $this->markdown );
-		$this->frontmatter = array();
-		foreach ( $document->data->export() as $key => $value ) {
-			if ( 'attributes' === $key && empty( $value ) ) {
-				// The Frontmatter extension adds an 'attributes' key to the document data
-				// even when there is no actual "attributes" key in the frontmatter.
-				//
-				// Let's skip it when the value is empty.
-				continue;
-			}
-			// Use an array as a value to comply with the WP_Block_Markup_Converter interface.
-			$this->frontmatter[ $key ] = array( $value );
-		}
+		$parser   = new MarkdownParser( $environment );
+		$document = $parser->parse( $markdown );
 
 		$walker = $document->walker();
 		while ( true ) {
@@ -375,6 +360,116 @@ BLOCK;
 				}
 			}
 		}
+	}
+
+	private function extract_frontmatter( $markdown ) {
+		$this->frontmatter = array();
+
+		if ( ! preg_match( '/\A---\r?\n/', $markdown, $opening ) ) {
+			return $markdown;
+		}
+
+		$body_start = strlen( $opening[0] );
+		$offset     = $body_start;
+		$length     = strlen( $markdown );
+
+		while ( $offset < $length ) {
+			$line_end = strpos( $markdown, "\n", $offset );
+			if ( false === $line_end ) {
+				$line      = substr( $markdown, $offset );
+				$next_line = $length;
+			} else {
+				$line      = substr( $markdown, $offset, $line_end - $offset );
+				$next_line = $line_end + 1;
+			}
+
+			if ( '---' === rtrim( $line, "\r" ) ) {
+				$frontmatter = substr( $markdown, $body_start, $offset - $body_start );
+				foreach ( $this->parse_frontmatter_block( $frontmatter ) as $key => $value ) {
+					// Use an array as a value to comply with the WP_Block_Markup_Converter interface.
+					$this->frontmatter[ $key ] = array( $value );
+				}
+
+				return substr( $markdown, $next_line );
+			}
+
+			$offset = $next_line;
+		}
+
+		return $markdown;
+	}
+
+	private function parse_frontmatter_block( $frontmatter ) {
+		$metadata = array();
+		$lines    = preg_split( "/\r\n|\n|\r/", $frontmatter );
+		$count    = count( $lines );
+
+		for ( $i = 0; $i < $count; $i++ ) {
+			$line = $lines[ $i ];
+			if ( '' === trim( $line ) || preg_match( '/^\s*#/', $line ) ) {
+				continue;
+			}
+			if ( preg_match( '/^\s+/', $line ) ) {
+				continue;
+			}
+			if ( ! preg_match( '/^([A-Za-z0-9_.-]+)\s*:(?:\s*(.*))?$/', $line, $matches ) ) {
+				continue;
+			}
+
+			$key = $matches[1];
+			$raw = isset( $matches[2] ) ? trim( $matches[2] ) : '';
+			if ( '' === $raw ) {
+				$nested = false;
+				$j      = $i + 1;
+				while ( $j < $count && preg_match( '/^\s+/', $lines[ $j ] ) ) {
+					if ( '' !== trim( $lines[ $j ] ) ) {
+						$nested = true;
+					}
+					++$j;
+				}
+
+				if ( $nested ) {
+					$metadata[ $key ] = array();
+					$i                = $j - 1;
+					continue;
+				}
+
+				$metadata[ $key ] = '';
+				continue;
+			}
+
+			$metadata[ $key ] = $this->parse_frontmatter_scalar( $raw );
+		}
+
+		return $metadata;
+	}
+
+	private function parse_frontmatter_scalar( $raw ) {
+		if ( preg_match( '/^\[|\{|- /', $raw ) ) {
+			return array();
+		}
+
+		$first = substr( $raw, 0, 1 );
+		$last  = substr( $raw, -1 );
+
+		if ( '"' === $first && '"' === $last ) {
+			$decoded = json_decode( $raw );
+			if ( JSON_ERROR_NONE === json_last_error() && is_string( $decoded ) ) {
+				return $decoded;
+			}
+
+			return stripcslashes( substr( $raw, 1, -1 ) );
+		}
+
+		if ( "'" === $first && "'" === $last ) {
+			return str_replace( "''", "'", substr( $raw, 1, -1 ) );
+		}
+
+		if ( preg_match( '/^-?(?:0|[1-9][0-9]*)$/', $raw ) ) {
+			return (int) $raw;
+		}
+
+		return $raw;
 	}
 
 	/**

--- a/plugins/push-md/Tests/ci-mu-test-helper.php
+++ b/plugins/push-md/Tests/ci-mu-test-helper.php
@@ -12,20 +12,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-add_filter( 'pmd_seed_batch_size', static function () {
+add_filter( 'push_md_seed_batch_size', static function () {
 	return 5;
 } );
 
 // Zero-second budget forces budget_exhausted() to fire after every
 // batch, so the seeder reschedules itself even if the host can run
 // the whole thing in one tick.
-add_filter( 'pmd_seed_time_budget_seconds', static function () {
+add_filter( 'push_md_seed_time_budget_seconds', static function () {
 	return 0.0;
 } );
 
 // Reschedule "in the future" with no delay so wp-cli's
 // `cron event run --due-now` picks up the next tick on the very next
 // invocation.
-add_filter( 'pmd_seed_tick_reschedule_seconds', static function () {
+add_filter( 'push_md_seed_tick_reschedule_seconds', static function () {
 	return 0;
 } );

--- a/plugins/push-md/class-pmd-plugin.php
+++ b/plugins/push-md/class-pmd-plugin.php
@@ -83,11 +83,11 @@ class PMD_Plugin {
 	}
 
 	public static function install_default_agent_skill() {
-		if ( ! self::guidelines_available() || ! function_exists( 'wp_install_skill' ) ) {
+		if ( ! self::guidelines_available() || ! function_exists( 'push_md_install_skill' ) ) {
 			return;
 		}
 
-		wp_install_skill(
+		push_md_install_skill(
 			self::AGENT_SKILL_SOURCE,
 			self::AGENT_SKILL_TITLE,
 			'Guide for coding agents working in a Push MD checkout of a WordPress site.',
@@ -97,7 +97,7 @@ class PMD_Plugin {
 			)
 		);
 
-		wp_install_skill(
+		push_md_install_skill(
 			self::TEMPLATE_EDITOR_SKILL_SOURCE,
 			self::TEMPLATE_EDITOR_SKILL_TITLE,
 			'Edit Push MD block theme templates and template parts as raw Gutenberg HTML while preserving Site Editor compatibility.',

--- a/plugins/push-md/class-pmd-seeder.php
+++ b/plugins/push-md/class-pmd-seeder.php
@@ -45,7 +45,7 @@ class PMD_Seeder {
 	const STATE_OPTION    = 'pmd_seed_state';
 	const PROGRESS_OPTION = 'pmd_seed_progress';
 	const SEED_BRANCH     = 'refs/heads/_pmd_seed';
-	const CRON_HOOK       = 'pmd_seed_tick';
+	const CRON_HOOK       = 'push_md_seed_tick';
 	const LOCK_TRANSIENT  = 'pmd_seed_lock';
 
 	const STATE_PENDING     = 'pending';
@@ -66,21 +66,21 @@ class PMD_Seeder {
 	/**
 	 * Resolve budget knobs through filters. The defaults are the
 	 * production values; tests and unusual hosts can shrink them via
-	 * `pmd_seed_batch_size`,
-	 * `pmd_seed_time_budget_seconds`, and
-	 * `pmd_seed_tick_reschedule_seconds` to force the seeder to
+	 * `push_md_seed_batch_size`,
+	 * `push_md_seed_time_budget_seconds`, and
+	 * `push_md_seed_tick_reschedule_seconds` to force the seeder to
 	 * span multiple cron ticks.
 	 */
 	private static function batch_size() {
-		return (int) apply_filters( 'pmd_seed_batch_size', self::BATCH_SIZE );
+		return (int) apply_filters( 'push_md_seed_batch_size', self::BATCH_SIZE );
 	}
 
 	private static function time_budget_seconds() {
-		return (float) apply_filters( 'pmd_seed_time_budget_seconds', self::TIME_BUDGET_SECONDS );
+		return (float) apply_filters( 'push_md_seed_time_budget_seconds', self::TIME_BUDGET_SECONDS );
 	}
 
 	private static function tick_reschedule_seconds() {
-		return (int) apply_filters( 'pmd_seed_tick_reschedule_seconds', self::TICK_RESCHEDULE_SECONDS );
+		return (int) apply_filters( 'push_md_seed_tick_reschedule_seconds', self::TICK_RESCHEDULE_SECONDS );
 	}
 
 	public static function on_activation() {

--- a/plugins/push-md/functions.php
+++ b/plugins/push-md/functions.php
@@ -4,8 +4,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-if ( ! function_exists( 'wp_install_skill' ) ) {
-	function wp_install_skill( string $source_identifier, string $title, string $excerpt, string $content, array $extras = array() ) {
+if ( ! function_exists( 'push_md_install_skill' ) ) {
+	function push_md_install_skill( string $source_identifier, string $title, string $excerpt, string $content, array $extras = array() ) {
 		if ( '' === $source_identifier ) {
 			return new WP_Error( 'missing_source_identifier', 'A non-empty $source_identifier is required.' );
 		}

--- a/plugins/push-md/push-md-dev-bootstrap.php
+++ b/plugins/push-md/push-md-dev-bootstrap.php
@@ -40,5 +40,5 @@ $pmd_files = array(
 );
 
 foreach ( $pmd_files as $pmd_file ) {
-	pmd_require_toolkit_file( md5( 'push-md:' . $pmd_file ), $pmd_file );
+	push_md_require_toolkit_file( md5( 'push-md:' . $pmd_file ), $pmd_file );
 }

--- a/plugins/push-md/push-md-phar-bootstrap.php
+++ b/plugins/push-md/push-md-phar-bootstrap.php
@@ -42,5 +42,5 @@ $pmd_files = array(
 );
 
 foreach ( $pmd_files as $pmd_file ) {
-	pmd_require_toolkit_file( md5( 'push-md:' . $pmd_file ), $pmd_file );
+	push_md_require_toolkit_file( md5( 'push-md:' . $pmd_file ), $pmd_file );
 }

--- a/plugins/push-md/push-md-toolkit-bootstrap.php
+++ b/plugins/push-md/push-md-toolkit-bootstrap.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 require_once __DIR__ . '/push-md-toolkit-loader.php';
 
-function pmd_load_core_html_api() {
+function push_md_load_core_html_api() {
 	if ( class_exists( 'WP_HTML_Tag_Processor' ) && class_exists( 'WP_HTML_Processor' ) ) {
 		return;
 	}
@@ -41,10 +41,10 @@ function pmd_load_core_html_api() {
 	}
 }
 
-function pmd_load_toolkit_bundle() {
+function push_md_load_toolkit_bundle() {
 	$pmd_toolkit = __DIR__ . '/php-toolkit';
 
-	pmd_load_core_html_api();
+	push_md_load_core_html_api();
 
 	if ( ! class_exists( 'Composer\\Autoload\\ClassLoader' ) ) {
 		require_once $pmd_toolkit . '/vendor/composer/ClassLoader.php';
@@ -68,8 +68,8 @@ function pmd_load_toolkit_bundle() {
 
 	$pmd_files = require $pmd_toolkit . '/vendor/composer/autoload_files.php';
 	foreach ( $pmd_files as $pmd_file_identifier => $pmd_file ) {
-		pmd_require_toolkit_file( $pmd_file_identifier, $pmd_file );
+		push_md_require_toolkit_file( $pmd_file_identifier, $pmd_file );
 	}
 }
 
-pmd_load_toolkit_bundle();
+push_md_load_toolkit_bundle();

--- a/plugins/push-md/push-md-toolkit-loader.php
+++ b/plugins/push-md/push-md-toolkit-loader.php
@@ -4,16 +4,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-function pmd_require_toolkit_file( $pmd_file_identifier, $pmd_file ) {
-	if ( ! isset( $GLOBALS['__composer_autoload_files'] ) ) {
-		$GLOBALS['__composer_autoload_files'] = array();
+function push_md_require_toolkit_file( $push_md_file_identifier, $push_md_file ) {
+	if ( ! isset( $GLOBALS['push_md_composer_autoload_files'] ) ) {
+		$GLOBALS['push_md_composer_autoload_files'] = array();
 	}
 
-	if ( ! empty( $GLOBALS['__composer_autoload_files'][ $pmd_file_identifier ] ) ) {
+	if ( ! empty( $GLOBALS['push_md_composer_autoload_files'][ $push_md_file_identifier ] ) ) {
 		return;
 	}
 
-	$GLOBALS['__composer_autoload_files'][ $pmd_file_identifier ] = true;
+	$GLOBALS['push_md_composer_autoload_files'][ $push_md_file_identifier ] = true;
 
-	require_once $pmd_file;
+	require_once $push_md_file;
 }

--- a/plugins/push-md/push-md.php
+++ b/plugins/push-md/push-md.php
@@ -39,31 +39,20 @@ if ( ! defined( 'PMD_PLUGIN_FILE' ) ) {
 
 register_activation_hook( __FILE__, array( 'PMD_Plugin', 'on_activation' ) );
 
-// After the user clicks Activate, send them straight to the seeder
-// progress page so they can watch the import without hunting for a
-// menu item. Skipped for bulk activations and CLI/AJAX flows so we
-// only intercept the one-click admin "Activate" link.
-add_action(
-	'activated_plugin',
-	function ( $plugin ) {
-		if ( plugin_basename( PMD_PLUGIN_FILE ) !== $plugin ) {
-			return;
-		}
-		if ( wp_doing_ajax() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
-			return;
-		}
-		$action = isset( $_REQUEST['action'] ) ? sanitize_key( wp_unslash( $_REQUEST['action'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( '' !== $action && 'activate' !== $action ) {
-			return;
-		}
-		wp_safe_redirect( admin_url( 'tools.php?page=' . PMD_Admin::PAGE_SLUG ) );
-		exit;
-	}
-);
-
 add_filter(
 	'plugin_action_links_' . plugin_basename( PMD_PLUGIN_FILE ),
 	function ( $actions ) {
+		$actions = array_merge(
+			array(
+				'push_md_open' => sprintf(
+					'<a href="%s">%s</a>',
+					esc_url( admin_url( 'tools.php?page=' . PMD_Admin::PAGE_SLUG ) ),
+					esc_html__( 'Open Push MD', 'push-md' )
+				),
+			),
+			$actions
+		);
+
 		$actions['push_md_landing_page'] = sprintf(
 			'<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>',
 			esc_url( 'https://pushmd.blog/' ),

--- a/plugins/push-md/readme.txt
+++ b/plugins/push-md/readme.txt
@@ -109,6 +109,10 @@ No. Push MD does not enable or force any authentication method. It works with Wo
 
 The built-in WordPress Application Passwords feature is the default way to use Git over HTTPS when it is available on the site. Other REST authentication plugins may also work if they authenticate the request as a WordPress user before Push MD's permission checks run.
 
+= Does Push MD require Composer or a PHAR archive? =
+
+No. Push MD includes the readable PHP Toolkit runtime files it needs under `php-toolkit/` in the plugin package. The plugin does not install Composer dependencies on the site and does not load an opaque PHAR archive.
+
 = Does this sync my site to GitHub or another Git host? =
 
 No. Push MD makes WordPress itself behave like a Git remote for supported content. You can add GitHub, GitLab, Bitbucket, or another host as a separate remote in your local clone if your workflow needs that.

--- a/plugins/push-md/uninstall.php
+++ b/plugins/push-md/uninstall.php
@@ -12,12 +12,12 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit;
 }
 
-pmd_uninstall_cleanup();
+push_md_uninstall_cleanup();
 
 /**
  * Clean up every site in multisite installs, or the current site otherwise.
  */
-function pmd_uninstall_cleanup() {
+function push_md_uninstall_cleanup() {
 	if ( is_multisite() && function_exists( 'get_sites' ) && function_exists( 'switch_to_blog' ) && function_exists( 'restore_current_blog' ) ) {
 		$offset = 0;
 		$number = 100;
@@ -33,7 +33,7 @@ function pmd_uninstall_cleanup() {
 
 			foreach ( $site_ids as $site_id ) {
 				switch_to_blog( (int) $site_id );
-				pmd_uninstall_cleanup_site();
+				push_md_uninstall_cleanup_site();
 				restore_current_blog();
 			}
 
@@ -43,24 +43,24 @@ function pmd_uninstall_cleanup() {
 		return;
 	}
 
-	pmd_uninstall_cleanup_site();
+	push_md_uninstall_cleanup_site();
 }
 
 /**
  * Clean up Push MD data for the current site.
  */
-function pmd_uninstall_cleanup_site() {
+function push_md_uninstall_cleanup_site() {
 	delete_option( 'pmd_seed_state' );
 	delete_option( 'pmd_seed_progress' );
 	delete_transient( 'pmd_seed_lock' );
-	wp_clear_scheduled_hook( 'pmd_seed_tick' );
-	pmd_uninstall_drop_repository_tables();
+	wp_clear_scheduled_hook( 'push_md_seed_tick' );
+	push_md_uninstall_drop_repository_tables();
 }
 
 /**
  * Drop the per-site Git object-store tables.
  */
-function pmd_uninstall_drop_repository_tables() {
+function push_md_uninstall_drop_repository_tables() {
 	global $wpdb;
 
 	$table_prefix = preg_replace( '/[^A-Za-z0-9_]/', '', $wpdb->prefix . 'pmd_' );


### PR DESCRIPTION
## Summary

- Build Push MD as a readable WordPress.org submission zip with a bundled `php-toolkit/` runtime instead of a PHAR.
- Prune development/test/docs/vendor noise from the built zip and add release checks for forbidden submission files.
- Rename Push MD-owned globals/hooks to `push_md_*`, replace the YAML/front matter dependency path with a small parser, and harden Plugin Check findings in the bundled toolkit path.
- Remove the activation redirect and expose Push MD through an explicit plugin-row action link instead.

## Why

This prepares Push MD for WordPress.org review, where the submitted zip must be complete, human-readable, GPL-compatible, and clean under Plugin Check across every bundled PHP file.

## Validation

- `vendor/bin/phpunit components/Markdown/Tests/ components/Filesystem/Tests/ components/Git/Tests/`
- `vendor/bin/phpunit plugins/push-md/Tests/`
- `bash bin/test-push-md-git-actions.sh`
- `bash bin/build-plugins.sh`
- `bash bin/inspect-push-md-zip.sh dist/plugins/push-md.zip`
- `php -l plugins/push-md/push-md.php`
- `vendor/bin/phpcs -d memory_limit=1G plugins/push-md/push-md.php`
- `composer lint` still exits with the existing repo-wide warning baseline outside the touched Push MD submission files.

## Reviewer Notes

- The WordPress.org artifact is generated with `bash bin/build-plugins.sh`; `dist/plugins/push-md.zip` contains `push-md/` plus readable `push-md/php-toolkit/` runtime files.
- The runtime bundle does not require Composer install on the target WordPress site and does not ship as a PHAR.
- CommonMark remains bundled for Markdown parsing; the YAML/front matter dependency path was removed for this submission pass.
