### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
       with:
         php-version: '8.1'
         extensions: mbstring, json

--- a/.github/workflows/phpunit-tests-run.yml
+++ b/.github/workflows/phpunit-tests-run.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       # Dev drive speeds up Windows CI tests from ~25 minutes to ~15 minutes
       - name: Setup RAM Disk (Windows only)
-        uses: samypr100/setup-dev-drive@v3
+        uses: samypr100/setup-dev-drive@cf663fdf88945e3faaa980ec525b5bc2350fbf9d # v3.4.3
         with:
           drive-size: 15GB
         if: ${{ inputs.os == 'windows-latest' }}
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: '${{ inputs.php }}'
           tools: phpunit-polyfills

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
           fi
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: '8.1'
           coverage: none

--- a/.github/workflows/push-md-e2e.yml
+++ b/.github/workflows/push-md-e2e.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: '8.1'
           extensions: zip, sqlite3, pdo, pdo_sqlite, mysqli, mbstring, curl

--- a/.github/workflows/push-md-plugin-check.yml
+++ b/.github/workflows/push-md-plugin-check.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: '8.1'
           extensions: mbstring, json
@@ -35,7 +35,7 @@ jobs:
           unzip -q dist/plugins/push-md.zip -d .plugin-check-build
 
       - name: Run Plugin Check
-        uses: wordpress/plugin-check-action@v1
+        uses: wordpress/plugin-check-action@18573eb38f13543484a1f095672dae3849a4fbb0 # v1.1.6
         with:
           build-dir: './.plugin-check-build/push-md'
           slug: 'push-md'


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to immutable commit SHAs.

This is a draft PR for review before merging. It was prepared with agent assistance and manually verified.

Tracking: DEVPROD-1072

Repo-level summary:
- Pinned distinct third-party action refs in this PR: 3
- Repo-level unpinned usage count from the trunk recheck: 7
- Dependabot GitHub Actions coverage: created (.github/dependabot.yml)


Verification commands:

```bash
# samypr100/setup-dev-drive # v3.4.3 -> cf663fdf88945e3faaa980ec525b5bc2350fbf9d
gh api repos/samypr100/setup-dev-drive/commits/v3.4.3 --jq '.sha'
# expected: cf663fdf88945e3faaa980ec525b5bc2350fbf9d

# shivammathur/setup-php # 2.37.1 -> 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
gh api repos/shivammathur/setup-php/commits/2.37.1 --jq '.sha'
# expected: 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc

# wordpress/plugin-check-action # v1.1.6 -> 18573eb38f13543484a1f095672dae3849a4fbb0
gh api repos/wordpress/plugin-check-action/commits/v1.1.6 --jq '.sha'
# expected: 18573eb38f13543484a1f095672dae3849a4fbb0
```
