### PR TITLE
[codex] Fix Push MD live round trips

### DIFF
--- a/bin/inspect-push-md-zip.sh
+++ b/bin/inspect-push-md-zip.sh
@@ -88,6 +88,7 @@ reject_content_pattern 'utf8_decode[[:space:]]*\(' 'Push MD zip must not call de
 reject_content_pattern "define[[:space:]]*\\([[:space:]]*['\"]FILTER_VALIDATE_BOOL['\"]" 'Push MD zip must not define the unprefixed FILTER_VALIDATE_BOOL constant.'
 reject_content_pattern 'namespace[[:space:]]+Artpi\\PushMD' 'Push MD zip should use reviewer-friendly prefixes rather than the temporary namespace-only approach.'
 reject_content_pattern 'namespace[[:space:]]+(WordPress|League|Nette|Symfony|Dflydev|Psr|Composer)(\\|[[:space:]]*[{;])' 'Push MD zip must scope bundled runtime namespaces.'
+reject_content_pattern 'use[[:space:]]+PushMDVendor\\Nette\\StaticClass;' 'Push MD zip must fully qualify scoped Nette trait references in class bodies.'
 reject_content_pattern "['\"](PhpToken|ValueError|Attribute|UnhandledMatchError|Stringable)['\"][[:space:]]*=>" 'Push MD autoload metadata must not register unprefixed PHP 8 polyfill stubs.'
 reject_content_pattern 'class[[:space:]]+PMD_|interface[[:space:]]+PMD_|trait[[:space:]]+PMD_|function[[:space:]]+PMD_|define[[:space:]]*\([[:space:]]*['\''"]PMD_' 'Push MD zip must not declare old three-letter PMD globals.'
 reject_content_pattern '['\''"]pmd_(seed|auth|required|forbidden|error|invalid|files|directory_entries)' 'Push MD zip must not use old three-letter pmd_ storage or error identifiers.'

--- a/bin/scope-push-md-bundle.php
+++ b/bin/scope-push-md-bundle.php
@@ -65,6 +65,25 @@ function push_md_scope_qualified_name( $name ) {
 	return $leading . $name;
 }
 
+function push_md_should_fully_qualify_scoped_name( $tokens, $index, $original_name, $scoped_name ) {
+	if ( $original_name === $scoped_name ) {
+		return false;
+	}
+
+	if ( isset( $scoped_name[0] ) && '\\' === $scoped_name[0] ) {
+		return false;
+	}
+
+	if (
+		push_md_token_is_namespace_declaration_root( $tokens, $index ) ||
+		push_md_token_is_use_context( $tokens, $index )
+	) {
+		return false;
+	}
+
+	return true;
+}
+
 function push_md_token_is_use_context( $tokens, $index ) {
 	for ( $i = $index - 1; $i >= 0; --$i ) {
 		$token = $tokens[ $i ];
@@ -78,7 +97,7 @@ function push_md_token_is_use_context( $tokens, $index ) {
 			continue;
 		}
 		if ( is_array( $token ) && T_USE === $token[0] ) {
-			return true;
+			return ! push_md_token_is_inside_class_like_scope( $tokens, $i );
 		}
 		if ( in_array( $token, array( ';', '{', '}' ), true ) ) {
 			return false;
@@ -89,6 +108,55 @@ function push_md_token_is_use_context( $tokens, $index ) {
 	}
 
 	return false;
+}
+
+function push_md_token_is_class_like_declaration( $tokens, $index ) {
+	$token = $tokens[ $index ];
+	if ( ! is_array( $token ) || ! in_array( $token[0], array( T_CLASS, T_INTERFACE, T_TRAIT ), true ) ) {
+		return false;
+	}
+
+	for ( $i = $index - 1; $i >= 0; --$i ) {
+		$previous = $tokens[ $i ];
+		if ( is_array( $previous ) && in_array( $previous[0], array( T_WHITESPACE, T_COMMENT, T_DOC_COMMENT ), true ) ) {
+			continue;
+		}
+
+		return ! ( is_array( $previous ) && T_DOUBLE_COLON === $previous[0] );
+	}
+
+	return true;
+}
+
+function push_md_token_is_inside_class_like_scope( $tokens, $index ) {
+	$scope_stack        = array();
+	$pending_class_like = false;
+
+	for ( $i = 0; $i < $index; ++$i ) {
+		$token = $tokens[ $i ];
+
+		if ( push_md_token_is_class_like_declaration( $tokens, $i ) ) {
+			$pending_class_like = true;
+			continue;
+		}
+
+		if ( '{' === $token ) {
+			$scope_stack[]      = $pending_class_like ? 'class' : 'block';
+			$pending_class_like = false;
+			continue;
+		}
+
+		if ( ';' === $token ) {
+			$pending_class_like = false;
+			continue;
+		}
+
+		if ( '}' === $token && ! empty( $scope_stack ) ) {
+			array_pop( $scope_stack );
+		}
+	}
+
+	return in_array( 'class', $scope_stack, true );
 }
 
 function push_md_token_is_namespace_declaration_root( $tokens, $index ) {
@@ -157,7 +225,11 @@ function push_md_scope_php_code( $code, $relative_path ) {
 		}
 
 		if ( in_array( $token[0], $name_token_ids, true ) ) {
-			$rewritten .= push_md_scope_qualified_name( $token[1] );
+			$scoped_name = push_md_scope_qualified_name( $token[1] );
+			if ( push_md_should_fully_qualify_scoped_name( $tokens, $index, $token[1], $scoped_name ) ) {
+				$scoped_name = '\\' . $scoped_name;
+			}
+			$rewritten .= $scoped_name;
 			continue;
 		}
 

--- a/components/Markdown/Tests/MarkdownProducerTest.php
+++ b/components/Markdown/Tests/MarkdownProducerTest.php
@@ -28,6 +28,14 @@ class MarkdownProducerTest extends TestCase {
 				'blocks' => '<!-- wp:paragraph --><p>A simple paragraph</p><!-- /wp:paragraph -->',
 				'expected' => "A simple paragraph\n\n",
 			),
+			'Classic content without block delimiters' => array(
+				'blocks' => 'Classic content created through REST',
+				'expected' => "Classic content created through REST\n\n",
+			),
+			'Classic paragraph HTML without block delimiters' => array(
+				'blocks' => '<p>A classic paragraph</p>',
+				'expected' => "A classic paragraph\n\n",
+			),
 			'A simple paragraph – no blank text nodes – single space at the end' => array(
 				'blocks' => '<!-- wp:paragraph --><p>A simple paragraph </p><!-- /wp:paragraph -->',
 				'expected' => "A simple paragraph \n\n",

--- a/components/Markdown/class-markdownproducer.php
+++ b/components/Markdown/class-markdownproducer.php
@@ -278,7 +278,11 @@ class MarkdownProducer implements DataFormatProducer {
 			default:
 				// Short-circuit empty entries produced by the block parser.
 				if ( ! $block_name ) {
-					return '';
+					if ( '' === trim( $inner_html ) ) {
+						return '';
+					}
+
+					return $this->html_to_markdown( $inner_html ) . "\n\n";
 				}
 				$markdown   = array();
 				$markdown[] = '';


### PR DESCRIPTION
## Summary

Fixes two live Push MD round-trip failures found on the Jurassic Ninja test site:

- scope bundled runtime references as fully-qualified names outside namespace declarations and top-level imports, preventing scoped trait references from resolving relative to the current namespace
- export non-empty classic/freeform post content from `MarkdownProducer` instead of dropping unnamed `parse_blocks()` entries

Also adds a zip inspection guard for the concrete Nette `StaticClass` regression and unit coverage for REST/classic content without Gutenberg block delimiters.

## Root cause

The scoper rewrote a bundled trait import to `use PushMDVendor\Nette\StaticClass;` inside a namespaced class body. PHP resolves trait imports inside class bodies relative to the current namespace unless they start with `\`, so the live plugin tried to load `PushMDVendor\Nette\Schema\PushMDVendor\Nette\StaticClass` and fataled during Git apply.

Separately, REST-created classic content can be parsed by `parse_blocks()` as a freeform block with no `blockName`. `MarkdownProducer` treated every unnamed block as empty parser noise, so plain REST content appeared in WordPress but exported an empty Markdown body.

## Validation

- `php -l components/Markdown/class-markdownproducer.php`
- `php -l bin/scope-push-md-bundle.php`
- `vendor/bin/phpcs -d memory_limit=1G components/Markdown/class-markdownproducer.php components/Markdown/Tests/MarkdownProducerTest.php bin/scope-push-md-bundle.php`
- `vendor/bin/phpunit components/Markdown/Tests/MarkdownProducerTest.php`
- `vendor/bin/phpunit components/Markdown/Tests`
- `vendor/bin/phpunit plugins/push-md/Tests`
- `bash -n bin/inspect-push-md-zip.sh`
- `git diff --check`
- `bash bin/build-plugins.sh`
- Live Jurassic Ninja verification: REST-published classic content exported to Git, Git push updated WordPress, and the follow-up WordPress sync exported the pushed marker back to Git for `https://precious-halibut-stone.jurassic.ninja/2026/06/18/rest-classic-content-push-md-check-141620/`.
