### PR TITLE
Push MD: reliable fresh-site seeding (resolve by slug) + export path-collision hardening

### DIFF
--- a/components/Markdown/class-markdownconsumer.php
+++ b/components/Markdown/class-markdownconsumer.php
@@ -443,7 +443,12 @@ class MarkdownConsumer implements DataFormatConsumer {
 	}
 
 	private function parse_frontmatter_scalar( $raw ) {
-		if ( preg_match( '/^\[|\{|- /', $raw ) ) {
+		// Detect YAML flow sequences ([...]), flow mappings ({...}), and block
+		// sequence items (- item) by their leading indicator. The `^` must bind all
+		// three alternatives: without the group, `\{` and `- ` matched anywhere in
+		// the value, so any quoted scalar containing "{" or "- " (e.g. a title like
+		// "Jetpack 13.0 - AI Assistant") was wrongly parsed as an empty array.
+		if ( preg_match( '/^(?:\[|\{|- )/', $raw ) ) {
 			return array();
 		}
 

--- a/plugins/push-md/Tests/EndToEndTest.php
+++ b/plugins/push-md/Tests/EndToEndTest.php
@@ -132,6 +132,183 @@ class PMD_End_To_End_Test extends TestCase {
 		}
 	}
 
+	/**
+	 * Seeding mode (push_md_allow_create_on_missing_id) must resolve by slug and
+	 * ignore the front matter id, even when that id points at a *different* post of
+	 * the same type. Without the fix this rejects with "conflicts with the WordPress
+	 * post already mapped to this file path".
+	 */
+	public function testSeedingResolvesBySlugWhenIdPointsAtAnotherPost() {
+		$this->set_allow_create_on_missing_id( true );
+		try {
+			$suffix = uniqid( 'pmd-stype-' );
+			$id_a   = $this->create_page_via_rest(
+				array(
+					'slug'    => $suffix . '-a',
+					'title'   => 'Stype A ' . $suffix,
+					'status'  => 'publish',
+					'content' => '<!-- wp:paragraph --><p>STYPE-A-ORIG</p><!-- /wp:paragraph -->',
+				)
+			);
+			$id_b = $this->create_page_via_rest(
+				array(
+					'slug'    => $suffix . '-b',
+					'title'   => 'Stype B ' . $suffix,
+					'status'  => 'publish',
+					'content' => '<!-- wp:paragraph --><p>STYPE-B-ORIG</p><!-- /wp:paragraph -->',
+				)
+			);
+
+			$clone   = $this->clone_repo( $suffix );
+			$this->configure_git( $clone );
+			$page_md = $clone . '/page/' . $suffix . '-a.md';
+			$this->assertFileExists( $page_md );
+			// Point page A's file at page B's id (same type, different post) and edit body.
+			$this->edit_file( $page_md, 'id: "' . $id_a . '"', 'id: "' . $id_b . '"' );
+			$this->edit_file( $page_md, 'STYPE-A-ORIG', 'STYPE-A-UPDATED' );
+			$this->commit_and_push( $clone, 'page/' . $suffix . '-a.md', 'Seed: id points at another post' );
+
+			// The update must land on page A (slug match), not page B (the id'd post).
+			$this->assertStringContainsString( 'STYPE-A-UPDATED', $this->fetch_content( $id_a, 'pages' ) );
+			$this->assertStringContainsString( 'STYPE-B-ORIG', $this->fetch_content( $id_b, 'pages' ) );
+		} finally {
+			$this->set_allow_create_on_missing_id( false );
+		}
+	}
+
+	/**
+	 * Seeding mode must resolve by slug even when the front matter id collides with a
+	 * post of a *different* type. Without the fix this rejects with "references a
+	 * different WordPress post type".
+	 */
+	public function testSeedingResolvesBySlugWhenIdCollidesWithOtherType() {
+		$this->set_allow_create_on_missing_id( true );
+		try {
+			$suffix  = uniqid( 'pmd-xtype-' );
+			$post_id = $this->create_post_via_rest(
+				array(
+					'slug'    => $suffix . '-post',
+					'title'   => 'Xtype Post ' . $suffix,
+					'status'  => 'publish',
+					'content' => '<!-- wp:paragraph --><p>XTYPE-POST-ORIG</p><!-- /wp:paragraph -->',
+				)
+			);
+			$page_id = $this->create_page_via_rest(
+				array(
+					'slug'    => $suffix . '-page',
+					'title'   => 'Xtype Page ' . $suffix,
+					'status'  => 'publish',
+					'content' => '<!-- wp:paragraph --><p>XTYPE-PAGE-ORIG</p><!-- /wp:paragraph -->',
+				)
+			);
+
+			$clone   = $this->clone_repo( $suffix );
+			$this->configure_git( $clone );
+			$page_md = $clone . '/page/' . $suffix . '-page.md';
+			$this->assertFileExists( $page_md );
+			// Point the page file at the *post's* id (cross-type collision) and edit body.
+			$this->edit_file( $page_md, 'id: "' . $page_id . '"', 'id: "' . $post_id . '"' );
+			$this->edit_file( $page_md, 'XTYPE-PAGE-ORIG', 'XTYPE-PAGE-UPDATED' );
+			$this->commit_and_push( $clone, 'page/' . $suffix . '-page.md', 'Seed: cross-type id collision' );
+
+			$this->assertStringContainsString( 'XTYPE-PAGE-UPDATED', $this->fetch_content( $page_id, 'pages' ) );
+			$this->assertStringContainsString( 'XTYPE-POST-ORIG', $this->fetch_content( $post_id, 'posts' ) );
+		} finally {
+			$this->set_allow_create_on_missing_id( false );
+		}
+	}
+
+	/**
+	 * Two files in one push whose front matter ids collide must both resolve by their
+	 * own slugs. Without the fix this rejects with "multiple Markdown files reference
+	 * the same WordPress post ID".
+	 */
+	public function testSeedingAllowsTwoFilesWithCollidingIds() {
+		$this->set_allow_create_on_missing_id( true );
+		try {
+			$suffix  = uniqid( 'pmd-dup-' );
+			$page_id = $this->create_page_via_rest(
+				array(
+					'slug'    => $suffix . '-page',
+					'title'   => 'Dup Page ' . $suffix,
+					'status'  => 'publish',
+					'content' => '<!-- wp:paragraph --><p>DUP-PAGE-ORIG</p><!-- /wp:paragraph -->',
+				)
+			);
+			$post_id = $this->create_post_via_rest(
+				array(
+					'slug'    => $suffix . '-post',
+					'title'   => 'Dup Post ' . $suffix,
+					'status'  => 'publish',
+					'content' => '<!-- wp:paragraph --><p>DUP-POST-ORIG</p><!-- /wp:paragraph -->',
+				)
+			);
+
+			$clone = $this->clone_repo( $suffix );
+			$this->configure_git( $clone );
+			$page_md = $clone . '/page/' . $suffix . '-page.md';
+			$post_md = $clone . '/post/' . $suffix . '-post.md';
+			$this->assertFileExists( $page_md );
+			$this->assertFileExists( $post_md );
+			// Make both files claim the same id (the post's), so id-based resolution
+			// would map both to one post; slug-based resolution keeps them distinct.
+			$this->edit_file( $page_md, 'id: "' . $page_id . '"', 'id: "' . $post_id . '"' );
+			$this->edit_file( $page_md, 'DUP-PAGE-ORIG', 'DUP-PAGE-UPDATED' );
+			$this->edit_file( $post_md, 'DUP-POST-ORIG', 'DUP-POST-UPDATED' );
+
+			$this->run_cmd( array( 'git', '-C', $clone, 'add', 'page/' . $suffix . '-page.md', 'post/' . $suffix . '-post.md' ) );
+			$this->run_cmd( array( 'git', '-C', $clone, 'commit', '-m', 'Seed: two files, colliding ids' ) );
+			$this->run_cmd( array( 'git', '-C', $clone, 'push', 'origin', 'trunk' ) );
+
+			$this->assertStringContainsString( 'DUP-PAGE-UPDATED', $this->fetch_content( $page_id, 'pages' ) );
+			$this->assertStringContainsString( 'DUP-POST-UPDATED', $this->fetch_content( $post_id, 'posts' ) );
+		} finally {
+			$this->set_allow_create_on_missing_id( false );
+		}
+	}
+
+	/**
+	 * Production mode (option off) must still reject a front matter id that references
+	 * a different post type -- the strict guard is preserved.
+	 */
+	public function testProductionStillRejectsCrossTypeIdMismatch() {
+		$this->set_allow_create_on_missing_id( false );
+		$suffix  = uniqid( 'pmd-strict-' );
+		$post_id = $this->create_post_via_rest(
+			array(
+				'slug'    => $suffix . '-post',
+				'title'   => 'Strict Post ' . $suffix,
+				'status'  => 'publish',
+				'content' => '<!-- wp:paragraph --><p>STRICT-POST-ORIG</p><!-- /wp:paragraph -->',
+			)
+		);
+		$page_id = $this->create_page_via_rest(
+			array(
+				'slug'    => $suffix . '-page',
+				'title'   => 'Strict Page ' . $suffix,
+				'status'  => 'publish',
+				'content' => '<!-- wp:paragraph --><p>STRICT-PAGE-ORIG</p><!-- /wp:paragraph -->',
+			)
+		);
+
+		$clone   = $this->clone_repo( $suffix );
+		$this->configure_git( $clone );
+		$page_md = $clone . '/page/' . $suffix . '-page.md';
+		$this->assertFileExists( $page_md );
+		$this->edit_file( $page_md, 'id: "' . $page_id . '"', 'id: "' . $post_id . '"' );
+		$this->edit_file( $page_md, 'STRICT-PAGE-ORIG', 'STRICT-PAGE-UPDATED' );
+
+		$this->run_cmd( array( 'git', '-C', $clone, 'add', 'page/' . $suffix . '-page.md' ) );
+		$this->run_cmd( array( 'git', '-C', $clone, 'commit', '-m', 'Strict: cross-type id mismatch' ) );
+		$push = $this->run_cmd( array( 'git', '-C', $clone, 'push', 'origin', 'trunk' ), true );
+
+		$this->assertNotSame( 0, $push['code'], 'Production push must reject a cross-type id mismatch.' );
+		$this->assertStringContainsString(
+			'Push rejected because Markdown front matter id references a different WordPress post type.',
+			$push['output']
+		);
+	}
+
 	public function testFullRoundTrip() {
 		$hierarchy_suffix = uniqid( 'hierarchy-' );
 		$parent_a_slug    = 'parent-a-' . $hierarchy_suffix;
@@ -1062,6 +1239,50 @@ class PMD_End_To_End_Test extends TestCase {
 		$status   = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
 		curl_close( $ch );
 		$this->assertSame( 200, $status, "REST update failed: $response" );
+	}
+
+	private function create_post_via_rest( array $payload ) {
+		$ch = curl_init( $this->base_url . '/wp-json/wp/v2/posts?context=edit' );
+		curl_setopt_array(
+			$ch,
+			array(
+				CURLOPT_RETURNTRANSFER => true,
+				CURLOPT_CUSTOMREQUEST  => 'POST',
+				CURLOPT_HTTPHEADER     => array( $this->auth_header, 'Content-Type: application/json' ),
+				CURLOPT_POSTFIELDS     => pmd_e2e_json_encode( $payload ),
+			)
+		);
+		$response = curl_exec( $ch );
+		$status   = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
+		curl_close( $ch );
+		$this->assertTrue( 200 === $status || 201 === $status, "REST post create failed: $response" );
+
+		$post = json_decode( $response, true );
+		$this->assertIsArray( $post, "Unexpected REST post create response: $response" );
+		$this->assertArrayHasKey( 'id', $post, "REST post create response had no ID: $response" );
+
+		return intval( $post['id'] );
+	}
+
+	private function set_allow_create_on_missing_id( $enabled ) {
+		$ch = curl_init( $this->base_url . '/wp-json/push-md-test/v1/allow-create-on-missing-id' );
+		curl_setopt_array(
+			$ch,
+			array(
+				CURLOPT_RETURNTRANSFER => true,
+				CURLOPT_CUSTOMREQUEST  => 'POST',
+				CURLOPT_HTTPHEADER     => array( $this->auth_header, 'Content-Type: application/json' ),
+				CURLOPT_POSTFIELDS     => pmd_e2e_json_encode( array( 'enabled' => (bool) $enabled ) ),
+			)
+		);
+		$response = curl_exec( $ch );
+		$status   = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
+		curl_close( $ch );
+		$this->assertSame(
+			200,
+			$status,
+			'Could not toggle push_md_allow_create_on_missing_id (is ci-mu-test-helper.php installed?): ' . $response
+		);
 	}
 
 	private function curl_get( $url ) {

--- a/plugins/push-md/Tests/ExportPathTest.php
+++ b/plugins/push-md/Tests/ExportPathTest.php
@@ -12,8 +12,17 @@ if ( ! class_exists( 'WP_Post' ) ) {
 		public $post_type   = 'post';
 		public $post_name   = '';
 		public $post_parent = 0;
+		public $post_status = 'publish';
+		public $post_title  = '';
+		public $post_date   = '2000-01-01 00:00:00';
+		public $post_date_gmt = '2000-01-01 00:00:00';
+		public $post_modified_gmt = '2000-01-01 00:00:00';
+		public $post_content = '<!-- wp:paragraph --><p>Test content</p><!-- /wp:paragraph -->';
+		public $post_excerpt = '';
 	}
 }
+
+$push_md_test_posts = array();
 
 if ( ! function_exists( 'sanitize_title' ) ) {
 	function sanitize_title( $title ) {
@@ -38,9 +47,124 @@ if ( ! function_exists( 'taxonomy_exists' ) ) {
 	}
 }
 
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( $capability ) {
+		unset( $capability );
+
+		return true;
+	}
+}
+
+if ( ! function_exists( 'get_posts' ) ) {
+	function get_posts( $args = array() ) {
+		global $push_md_test_posts;
+
+		$posts = $push_md_test_posts;
+
+		if ( isset( $args['post_type'] ) ) {
+			$post_types = (array) $args['post_type'];
+			$posts      = array_filter(
+				$posts,
+				function ( $post ) use ( $post_types ) {
+					return in_array( $post->post_type, $post_types, true );
+				}
+			);
+		}
+
+		if ( isset( $args['name'] ) ) {
+			$posts = array_filter(
+				$posts,
+				function ( $post ) use ( $args ) {
+					return $post->post_name === $args['name'];
+				}
+			);
+		}
+
+		if ( isset( $args['post_parent'] ) ) {
+			$posts = array_filter(
+				$posts,
+				function ( $post ) use ( $args ) {
+					return intval( $post->post_parent ) === intval( $args['post_parent'] );
+				}
+			);
+		}
+
+		if ( isset( $args['post_status'] ) ) {
+			$statuses = (array) $args['post_status'];
+			$posts    = array_filter(
+				$posts,
+				function ( $post ) use ( $statuses ) {
+					return in_array( $post->post_status, $statuses, true );
+				}
+			);
+		}
+
+		usort(
+			$posts,
+			function ( $a, $b ) {
+				return intval( $a->ID ) - intval( $b->ID );
+			}
+		);
+
+		if ( isset( $args['fields'] ) && 'ids' === $args['fields'] ) {
+			return array_map(
+				function ( $post ) {
+					return intval( $post->ID );
+				},
+				$posts
+			);
+		}
+
+		return $posts;
+	}
+}
+
+if ( ! function_exists( 'get_post' ) ) {
+	function get_post( $post_id ) {
+		global $push_md_test_posts;
+
+		foreach ( $push_md_test_posts as $post ) {
+			if ( intval( $post->ID ) === intval( $post_id ) ) {
+				return $post;
+			}
+		}
+
+		return null;
+	}
+}
+
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $name, $default = false ) {
+		unset( $name );
+
+		return $default;
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, $options = 0 ) {
+		return json_encode( $data, $options );
+	}
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $text ) {
+		return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
 require_once dirname( __DIR__ ) . '/class-push-md-plugin.php';
 
 class PMD_Export_Path_Test extends TestCase {
+
+	/**
+	 * @after
+	 */
+	public function reset_test_posts() {
+		global $push_md_test_posts;
+
+		$push_md_test_posts = array();
+	}
 
 	public function testPostWithEmptySlugUsesStableIdFallbackPath() {
 		$this->assertSame(
@@ -100,14 +224,100 @@ class PMD_Export_Path_Test extends TestCase {
 		);
 	}
 
-	private function post( $id, $post_type, $post_name ) {
+	public function testDuplicatePathThrowsActionableErrorNamingBothPosts() {
+		$this->set_test_posts(
+			array(
+				$this->post( 101, 'post', 'shared-slug' ),
+				$this->post( 202, 'post', 'shared-slug' ),
+			)
+		);
+
+		try {
+			$this->export_wordpress_content();
+			$this->fail( 'Expected duplicate export paths to be rejected.' );
+		} catch ( Exception $exception ) {
+			$message = $exception->getMessage();
+			$this->assertStringContainsString( 'post/shared-slug.md', $message );
+			$this->assertStringContainsString( '101', $message );
+			$this->assertStringContainsString( '202', $message );
+		}
+	}
+
+	public function testDetectExportPathCollisionsReturnsConflictingGroup() {
+		$this->set_test_posts(
+			array(
+				$this->post( 101, 'post', 'shared-slug' ),
+				$this->post( 202, 'post', 'shared-slug' ),
+				$this->post( 303, 'post', 'unique-slug' ),
+			)
+		);
+
+		$collisions = Push_MD_Plugin::detect_export_path_collisions();
+
+		$this->assertCount( 1, $collisions );
+		$this->assertSame( 'post/shared-slug.md', $collisions[0]['path'] );
+		$this->assertSame( array( 101, 202 ), $collisions[0]['post_ids'] );
+	}
+
+	public function testDetectExportPathCollisionsIgnoresUniquePaths() {
+		$this->set_test_posts(
+			array(
+				$this->post( 101, 'post', 'first-slug' ),
+				$this->post( 202, 'post', 'second-slug' ),
+			)
+		);
+
+		$this->assertSame( array(), Push_MD_Plugin::detect_export_path_collisions() );
+	}
+
+	public function testDetectExportPathCollisionsSkipsUnbuildablePaths() {
+		// A published page pointing at a missing parent makes build_markdown_path()
+		// throw for that page; detection must skip it instead of aborting, and
+		// still report the unrelated post collision.
+		$orphan              = $this->post( 70, 'page', 'orphan' );
+		$orphan->post_parent = 9999;
+
+		$this->set_test_posts(
+			array(
+				$orphan,
+				$this->post( 101, 'post', 'shared-slug' ),
+				$this->post( 202, 'post', 'shared-slug' ),
+			)
+		);
+
+		$collisions = Push_MD_Plugin::detect_export_path_collisions();
+
+		$this->assertCount( 1, $collisions );
+		$this->assertSame( 'post/shared-slug.md', $collisions[0]['path'] );
+		$this->assertSame( array( 101, 202 ), $collisions[0]['post_ids'] );
+	}
+
+	private function post( $id, $post_type, $post_name, $post_status = 'publish', $post_date_gmt = '2000-01-01 00:00:00' ) {
 		$post              = new WP_Post();
 		$post->ID          = $id;
 		$post->post_type   = $post_type;
 		$post->post_name   = $post_name;
 		$post->post_parent = 0;
+		$post->post_status = $post_status;
+		$post->post_title  = 'Post ' . $id;
+		$post->post_date   = $post_date_gmt;
+		$post->post_date_gmt = $post_date_gmt;
+		$post->post_modified_gmt = $post_date_gmt;
 
 		return $post;
+	}
+
+	private function set_test_posts( $posts ) {
+		global $push_md_test_posts;
+
+		$push_md_test_posts = $posts;
+	}
+
+	private function export_wordpress_content() {
+		$method = new ReflectionMethod( Push_MD_Plugin::class, 'export_wordpress_content' );
+		$method->setAccessible( true );
+
+		return $method->invoke( null );
 	}
 
 	private function assert_id_fallback_path_is_current( $path, WP_Post $post ) {

--- a/plugins/push-md/Tests/ci-mu-test-helper.php
+++ b/plugins/push-md/Tests/ci-mu-test-helper.php
@@ -29,3 +29,29 @@ add_filter( 'push_md_seed_time_budget_seconds', static function () {
 add_filter( 'push_md_seed_tick_reschedule_seconds', static function () {
 	return 0;
 } );
+
+// CI-only route so the e2e suite can flip push_md_allow_create_on_missing_id
+// (local one-way seeding mode) over HTTP -- the test process has no wp-cli.
+// Admin-only; this mu-plugin is dropped in only by the e2e workflow.
+add_action( 'rest_api_init', static function () {
+	register_rest_route(
+		'push-md-test/v1',
+		'/allow-create-on-missing-id',
+		array(
+			'methods'             => 'POST',
+			'permission_callback' => static function () {
+				return current_user_can( 'manage_options' );
+			},
+			'callback'            => static function ( $request ) {
+				$enabled = (bool) $request->get_param( 'enabled' );
+				if ( $enabled ) {
+					update_option( 'push_md_allow_create_on_missing_id', 1 );
+				} else {
+					delete_option( 'push_md_allow_create_on_missing_id' );
+				}
+
+				return array( 'enabled' => $enabled );
+			},
+		)
+	);
+} );

--- a/plugins/push-md/admin-shell.css
+++ b/plugins/push-md/admin-shell.css
@@ -449,3 +449,54 @@
 		padding-top: 0;
 	}
 }
+
+.push-md-collisions-panel {
+	border-color: var(--push-md-red);
+	background: #fff5f5;
+}
+
+.push-md-collisions-panel[hidden] {
+	display: none;
+}
+
+.push-md-collisions-panel h2 {
+	color: #8a1f11;
+}
+
+.push-md-collisions-panel p {
+	margin: 0 0 12px;
+	color: var(--push-md-ink);
+	font-size: 13px;
+	line-height: 1.4;
+}
+
+.push-md-collisions-list {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	margin: 0;
+}
+
+.push-md-collisions-list > li {
+	margin: 0;
+	font-size: 12px;
+	line-height: 1.35;
+}
+
+.push-md-collisions-list > li > code {
+	color: #8a1f11;
+	background: #ffe3e3;
+	border-radius: 4px;
+	padding: 1px 4px;
+}
+
+.push-md-collisions-list ul {
+	margin: 6px 0 0;
+	padding-left: 18px;
+	list-style: disc;
+	color: var(--push-md-muted);
+}
+
+.push-md-collisions-list ul li {
+	margin: 2px 0;
+}

--- a/plugins/push-md/admin-shell.js
+++ b/plugins/push-md/admin-shell.js
@@ -30,6 +30,8 @@
 	var cwdEl             = document.getElementById( 'push-md-prompt-cwd' );
 	var titleEl           = document.getElementById( 'push-md-terminal-title' );
 	var commitListEl      = document.getElementById( 'push-md-commit-list' );
+	var collisionPanelEl  = document.getElementById( 'push-md-collisions-panel' );
+	var collisionListEl   = document.getElementById( 'push-md-collisions-list' );
 	var checkout          = normalizeCheckout( progress.checkout );
 	var cwd               = '/';
 	var history           = [];
@@ -58,6 +60,7 @@
 		);
 		messageEl.textContent = progress.message;
 		renderCommits( progress.commits || [] );
+		renderCollisions( progress.collisions || [] );
 		if (previousState !== 'done' && progress.state === 'done' && ! hasAnnouncedReady) {
 			hasAnnouncedReady = true;
 			appendLine( __( 'remote: Initial import complete. The checkout is ready.', 'push-md' ), 'is-success' );
@@ -117,6 +120,51 @@
 				item.appendChild( oid );
 				item.appendChild( subject );
 				commitListEl.appendChild( item );
+			}
+		);
+	}
+
+	function renderCollisions(collisions) {
+		if ( ! collisionPanelEl || ! collisionListEl) {
+			return;
+		}
+		collisionListEl.textContent = '';
+		if ( ! collisions.length) {
+			collisionPanelEl.hidden = true;
+			return;
+		}
+		collisionPanelEl.hidden = false;
+		collisions.forEach(
+			function (collision) {
+				var item     = document.createElement( 'li' );
+				var pathCode = document.createElement( 'code' );
+				pathCode.textContent = collision.path;
+				item.appendChild( pathCode );
+
+				var postsList = document.createElement( 'ul' );
+				(collision.posts || []).forEach(
+					function (post) {
+						var label = sprintf(
+							/* translators: 1: Post title, 2: Post ID, 3: Post status. */
+							__( '%1$s (ID %2$d, %3$s)', 'push-md' ),
+							post.title || __( '(untitled)', 'push-md' ),
+							post.id,
+							post.status
+						);
+						var postItem = document.createElement( 'li' );
+						if (post.edit_url) {
+							var link         = document.createElement( 'a' );
+							link.href        = post.edit_url;
+							link.textContent = label;
+							postItem.appendChild( link );
+						} else {
+							postItem.textContent = label;
+						}
+						postsList.appendChild( postItem );
+					}
+				);
+				item.appendChild( postsList );
+				collisionListEl.appendChild( item );
 			}
 		);
 	}

--- a/plugins/push-md/class-push-md-admin.php
+++ b/plugins/push-md/class-push-md-admin.php
@@ -9,11 +9,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Push_MD_Admin {
 
-	const PAGE_SLUG      = 'push-md';
-	const REST_NAMESPACE = 'push-md/v1';
-	const STATUS_ROUTE   = '/seed-status';
-	const RETRY_ROUTE    = '/seed-retry';
-	const ASSET_VERSION  = '0.6.6';
+	const PAGE_SLUG            = 'push-md';
+	const REST_NAMESPACE       = 'push-md/v1';
+	const STATUS_ROUTE         = '/seed-status';
+	const RETRY_ROUTE          = '/seed-retry';
+	const ASSET_VERSION        = '0.6.6';
+	const COLLISIONS_TRANSIENT = 'push_md_collisions';
 
 	public static function bootstrap() {
 		add_action( 'admin_menu', array( __CLASS__, 'register_menu' ) );
@@ -81,15 +82,66 @@ class Push_MD_Admin {
 	public static function rest_status() {
 		Push_MD_Seeder::drive( 1.5 );
 
-		return rest_ensure_response( Push_MD_Seeder::get_progress() );
+		$progress               = Push_MD_Seeder::get_progress();
+		$progress['collisions'] = self::collisions_for_display();
+
+		return rest_ensure_response( $progress );
 	}
 
 	public static function rest_retry() {
 		Push_MD_Seeder::reset();
 		Push_MD_Seeder::on_activation();
 		Push_MD_Seeder::tick();
+		delete_transient( self::COLLISIONS_TRANSIENT );
 
-		return rest_ensure_response( Push_MD_Seeder::get_progress() );
+		$progress               = Push_MD_Seeder::get_progress();
+		$progress['collisions'] = self::collisions_for_display();
+
+		return rest_ensure_response( $progress );
+	}
+
+	/**
+	 * Build the collision report consumed by the admin page and status route.
+	 *
+	 * Detection mirrors the export query and can scan every supported post, so
+	 * the result is cached briefly because the status route is polled.
+	 *
+	 * @return array List of array( 'path' => string, 'posts' => array ) where
+	 *               each post carries id, title, status, and an edit URL.
+	 */
+	private static function collisions_for_display() {
+		$cached = get_transient( self::COLLISIONS_TRANSIENT );
+		if ( is_array( $cached ) ) {
+			return $cached;
+		}
+
+		$payload = array();
+		foreach ( Push_MD_Plugin::detect_export_path_collisions() as $collision ) {
+			$posts = array();
+			foreach ( $collision['post_ids'] as $post_id ) {
+				$post = get_post( $post_id );
+				if ( ! $post ) {
+					continue;
+				}
+
+				$edit_url = get_edit_post_link( $post_id, 'raw' );
+				$posts[]  = array(
+					'id'       => intval( $post_id ),
+					'title'    => $post->post_title,
+					'status'   => $post->post_status,
+					'edit_url' => $edit_url ? $edit_url : '',
+				);
+			}
+
+			$payload[] = array(
+				'path'  => $collision['path'],
+				'posts' => $posts,
+			);
+		}
+
+		set_transient( self::COLLISIONS_TRANSIENT, $payload, 30 );
+
+		return $payload;
 	}
 
 	private static function add_username_to_url( $url, $username ) {
@@ -122,12 +174,14 @@ class Push_MD_Admin {
 		// Drive the seeder before painting so the first screen already
 		// has real checkout state whenever the host can do quick work.
 		Push_MD_Seeder::drive( 1.5 );
-		$progress   = Push_MD_Seeder::get_progress();
-		$nonce      = wp_create_nonce( 'wp_rest' );
-		$status_url = esc_url_raw( rest_url( self::REST_NAMESPACE . self::STATUS_ROUTE ) );
-		$retry_url  = esc_url_raw( rest_url( self::REST_NAMESPACE . self::RETRY_ROUTE ) );
-		$git_url    = esc_url_raw( rest_url( Push_MD_Plugin::ROUTE_NAMESPACE . '/md.git' ) );
-		$user       = wp_get_current_user();
+		$progress               = Push_MD_Seeder::get_progress();
+		$collisions             = self::collisions_for_display();
+		$progress['collisions'] = $collisions;
+		$nonce                  = wp_create_nonce( 'wp_rest' );
+		$status_url             = esc_url_raw( rest_url( self::REST_NAMESPACE . self::STATUS_ROUTE ) );
+		$retry_url              = esc_url_raw( rest_url( self::REST_NAMESPACE . self::RETRY_ROUTE ) );
+		$git_url                = esc_url_raw( rest_url( Push_MD_Plugin::ROUTE_NAMESPACE . '/md.git' ) );
+		$user                   = wp_get_current_user();
 		if ( $user && $user->exists() ) {
 			$git_url = self::add_username_to_url( $git_url, $user->user_login );
 		}
@@ -190,6 +244,12 @@ class Push_MD_Admin {
 						<span class="push-md-state-dot" aria-hidden="true"></span>
 						<span id="push-md-state"><?php echo esc_html( $progress['state'] ); ?></span>
 					</div>
+				</div>
+
+				<div class="push-md-panel push-md-collisions-panel" id="push-md-collisions-panel"<?php echo empty( $collisions ) ? ' hidden' : ''; ?>>
+					<h2><?php esc_html_e( 'Path collisions', 'push-md' ); ?></h2>
+					<p><?php esc_html_e( 'Two or more items map to the same file path, which blocks Push MD from exporting until you resolve it. Change a slug or trash a duplicate, then pull again.', 'push-md' ); ?></p>
+					<ul class="push-md-collisions-list" id="push-md-collisions-list"></ul>
 				</div>
 
 				<div class="push-md-emulator-note">

--- a/plugins/push-md/class-push-md-plugin.php
+++ b/plugins/push-md/class-push-md-plugin.php
@@ -2452,15 +2452,21 @@ class Push_MD_Plugin {
 				$include_trash
 			);
 		}
+		// During local one-way seeding (push_md_allow_create_on_missing_id), the front
+		// matter ids are foreign production ids that do not map to this site, so resolve
+		// purely by slug/path and ignore the id. This stops a production id that happens
+		// to collide with an unrelated local post id from rejecting the whole push.
+		// Production pushes leave the option off and keep strict id-based resolution.
+		$ignore_frontmatter_id = self::allow_create_on_missing_id();
 		if ( 'page' === $post_type ) {
-			if ( isset( $metadata['id'] ) ) {
+			if ( isset( $metadata['id'] ) && ! $ignore_frontmatter_id ) {
 				return self::find_post_id_by_frontmatter_id( $path, $metadata, $include_trash );
 			}
 
 			return self::find_page_id_by_path( $path, $include_trash );
 		}
 
-		if ( isset( $metadata['id'] ) ) {
+		if ( isset( $metadata['id'] ) && ! $ignore_frontmatter_id ) {
 			return self::find_post_id_by_frontmatter_id( $path, $metadata, $include_trash );
 		}
 

--- a/plugins/push-md/class-push-md-plugin.php
+++ b/plugins/push-md/class-push-md-plugin.php
@@ -645,7 +645,14 @@ class Push_MD_Plugin {
 
 			$path = self::build_markdown_path( $post );
 			if ( isset( $files[ $path ] ) ) {
-				throw new Exception( 'Git export rejected because multiple WordPress entities map to the same Push MD path: ' . esc_html( $path ) );
+				throw new Exception(
+					sprintf(
+						'Git export rejected because multiple WordPress entities map to the same Push MD path: %1$s (WordPress post IDs %2$d and %3$d). Change a slug or trash a duplicate, then pull again.',
+						esc_html( $path ),
+						intval( $files[ $path ]['post']->ID ),
+						intval( $post->ID )
+					)
+				);
 			}
 
 			$content = self::export_post_to_markdown( $post );
@@ -690,6 +697,55 @@ class Push_MD_Plugin {
 		ksort( $files );
 
 		return $files;
+	}
+
+	/**
+	 * Detect WordPress entities that would export to the same Push MD path.
+	 *
+	 * Mirrors the post query used by export_wordpress_content() so the report
+	 * matches what blocks the export. Posts whose path cannot be built (for
+	 * example a page whose parent hierarchy is broken) are skipped because that
+	 * is a separate export failure, not a path collision.
+	 *
+	 * @return array List of array( 'path' => string, 'post_ids' => int[] ) for
+	 *               every path claimed by more than one post.
+	 */
+	public static function detect_export_path_collisions() {
+		$posts = get_posts(
+			array(
+				'post_type'      => self::get_export_post_types(),
+				'post_status'    => self::$supported_post_statuses,
+				'posts_per_page' => -1,
+				'orderby'        => 'ID',
+				'order'          => 'ASC',
+			)
+		);
+
+		$paths = array();
+		foreach ( $posts as $post ) {
+			try {
+				$path = self::build_markdown_path( $post );
+			} catch ( Exception $e ) {
+				continue;
+			}
+
+			if ( ! isset( $paths[ $path ] ) ) {
+				$paths[ $path ] = array();
+			}
+			$paths[ $path ][] = intval( $post->ID );
+		}
+
+		$collisions = array();
+		foreach ( $paths as $path => $post_ids ) {
+			if ( count( $post_ids ) > 1 ) {
+				$collisions[] = array(
+					'path'     => $path,
+					'post_ids' => $post_ids,
+				);
+			}
+		}
+
+		return $collisions;
 	}
 
 	private static function add_default_agent_guidance_files( &$files, &$has_guideline_skills, &$agent_guide_skill_path ) {

--- a/plugins/push-md/class-push-md-plugin.php
+++ b/plugins/push-md/class-push-md-plugin.php
@@ -1508,6 +1508,19 @@ class Push_MD_Plugin {
 			);
 		}
 
+		if ( self::allow_create_on_missing_id() ) {
+			// Seeding a fresh site: apply ancestor pages before their nested children so
+			// each parent exists before a child resolves it. Sorting paths ascending
+			// orders e.g. page/features.md before page/features/security.md (the ".md"
+			// dot sorts before the "/" path separator).
+			usort(
+				$upsert_plans,
+				static function ( $a, $b ) {
+					return strcmp( $a['path'], $b['path'] );
+				}
+			);
+		}
+
 		foreach ( $upsert_plans as $plan ) {
 			$applied = self::upsert_post_from_markdown(
 				$plan['path'],
@@ -1684,6 +1697,24 @@ class Push_MD_Plugin {
 				throw new Exception( 'Push rejected because executable file modes are not supported by Push MD content exports.' );
 			}
 		}
+	}
+
+	/**
+	 * Public entry point for seeding a single content file into this site.
+	 *
+	 * Delegates to the private upsert. Intended for non-git transports that have
+	 * the markdown in hand (e.g. a WordPress Playground runPHP blueprint step that
+	 * cannot reach the git endpoint). Set the push_md_allow_create_on_missing_id
+	 * option BEFORE calling this if the front matter id may not exist on the
+	 * target (a fresh seed/preview site); this method does not change that option.
+	 *
+	 * @param string $path     Repo-relative content path, e.g. post/<slug>.md.
+	 * @param string $markdown The file's markdown (with front matter).
+	 * @param array  $options  Optional upsert options (e.g. skip_modified_check).
+	 * @return array{post_id:int,change:?array} Same shape upsert returns.
+	 */
+	public static function seed_markdown_file( $path, $markdown, $options = array() ) {
+		return self::upsert_post_from_markdown( $path, $markdown, $options );
 	}
 
 	private static function upsert_post_from_markdown( $path, $markdown, $options = array() ) {
@@ -2481,6 +2512,15 @@ class Push_MD_Plugin {
 		$post      = get_post( $id );
 
 		if ( ! $post ) {
+			if ( self::allow_create_on_missing_id() ) {
+				// Local one-way seeding (e.g. a fresh Studio site): the front matter id
+				// references a post id that does not exist here. Fall back to slug/path
+				// resolution so the push updates a matching post or creates a new one,
+				// instead of rejecting the whole push. Stays idempotent across re-seeds.
+				$path_metadata = $metadata;
+				unset( $path_metadata['id'] );
+				return self::find_post_id_by_path_metadata( $path, $path_metadata, $include_trash );
+			}
 			throw new Exception( 'Push rejected because Markdown front matter id does not reference an existing WordPress post.' );
 		}
 		if ( $post_type !== $post->post_type ) {
@@ -2502,6 +2542,20 @@ class Push_MD_Plugin {
 		}
 
 		return $id;
+	}
+
+	/**
+	 * Whether a push may resolve by slug/path (updating or creating a post) when a
+	 * front matter id does not reference an existing post, instead of rejecting.
+	 *
+	 * Defaults to false so production pushes still fail fast on an id mismatch -- a
+	 * guard against pushing to the wrong or incomplete site. Local one-way seeding
+	 * (e.g. Studio) opts in via the push_md_allow_create_on_missing_id option, or a
+	 * filter of the same name.
+	 */
+	private static function allow_create_on_missing_id() {
+		return (bool) get_option( 'push_md_allow_create_on_missing_id', false )
+			|| (bool) apply_filters( 'push_md_allow_create_on_missing_id', false );
 	}
 
 	private static function normalize_frontmatter_post_id( $id ) {
@@ -2591,6 +2645,14 @@ class Push_MD_Plugin {
 			if ( empty( $parents ) ) {
 				$page_id = self::find_slugless_page_id_by_fallback_slug( $slug, $parent_id, $statuses );
 				if ( ! $page_id ) {
+					if ( self::allow_create_on_missing_id() ) {
+						// Seeding a fresh site: this parent page does not exist yet. The
+						// validation (dry-run) pass tolerates the gap by returning no
+						// parent, and the apply pass applies ancestor pages before their
+						// children (the upsert plans are path-sorted), so the real parent
+						// exists by the time a child page is created.
+						return 0;
+					}
 					throw new Exception( 'Push rejected because nested page paths must reference existing WordPress parent pages.' );
 				}
 

--- a/plugins/push-md/class-push-md-seeder.php
+++ b/plugins/push-md/class-push-md-seeder.php
@@ -589,6 +589,11 @@ class Push_MD_Seeder {
 		);
 		// phpcs:enable
 
+		$collisions = Push_MD_Plugin::detect_export_path_collisions();
+		if ( ! empty( $collisions ) ) {
+			throw new Exception( self::format_collision_failure_message( $collisions ) );
+		}
+
 		$existing   = self::get_progress_storage();
 		$tick_count = isset( $existing['tick_count'] ) ? intval( $existing['tick_count'] ) : 0;
 		$progress   = array(
@@ -617,6 +622,26 @@ class Push_MD_Seeder {
 		} else {
 			update_option( self::STATE_OPTION, self::STATE_IN_PROGRESS, false );
 		}
+	}
+
+	private static function format_collision_failure_message( $collisions ) {
+		$shown   = array_slice( $collisions, 0, 5 );
+		$details = array();
+		foreach ( $shown as $collision ) {
+			$details[] = sprintf(
+				'%s (post IDs %s)',
+				$collision['path'],
+				implode( ', ', array_map( 'intval', $collision['post_ids'] ) )
+			);
+		}
+
+		$message   = 'Push MD import blocked because multiple WordPress entities map to the same path. Change a slug or trash a duplicate, then retry: ' . implode( '; ', $details );
+		$remaining = count( $collisions ) - count( $shown );
+		if ( $remaining > 0 ) {
+			$message .= sprintf( ' (and %d more)', $remaining );
+		}
+
+		return $message . '.';
 	}
 
 	private static function initialize_theme_base_commit() {

--- a/plugins/push-md/push-md.php
+++ b/plugins/push-md/push-md.php
@@ -3,7 +3,7 @@
  * Plugin Name: Push MD
  * Plugin URI: https://pushmd.blog/
  * Description: Edit WordPress content with Git, Markdown and block files, reviewable diffs, and safe pushes.
- * Version: 0.6.6
+ * Version: 0.6.7
  * Requires at least: 6.9
  * Requires PHP: 7.2
  * Author: Automattic

--- a/plugins/push-md/readme.txt
+++ b/plugins/push-md/readme.txt
@@ -99,6 +99,10 @@ Push MD checks permissions for each changed object. Updating or trashing existin
 
 No. File paths are the identity model. Push MD rejects `id`, `slug`, `type`, and unknown front matter fields. Rename or move files only when the corresponding path operation is supported and safe.
 
+= What happens if two posts map to the same file path? =
+
+Every exported item needs a unique file path. If two or more items would map to the same path — for example two posts that share a slug after an import or migration — Push MD blocks the export and reports the conflict on Tools → Push MD, naming the conflicting posts. Change one post's slug or trash the duplicate, then pull again.
+
 = Can I still edit content in WP-Admin? =
 
 Yes. WordPress remains the source of truth. Pull before editing locally to pick up recent WP-Admin changes, and Push MD will reject stale pushes that could overwrite newer WordPress edits.
@@ -138,6 +142,10 @@ Uninstalling Push MD removes its Git object-store database tables, seed progress
 The removed tables contain Push MD's derived Git repository history. Reinstalling Push MD can seed a new repository from the current WordPress content, but it cannot restore the previous Push MD Git history unless you kept a clone or database backup.
 
 == Changelog ==
+
+= 0.6.6 =
+
+Reject exports when multiple WordPress items map to the same file path, with a clearer Git error and a Path collisions report on Tools → Push MD so the conflict can be resolved at the source.
 
 = 0.5.0 =
 

--- a/plugins/push-md/readme.txt
+++ b/plugins/push-md/readme.txt
@@ -4,7 +4,7 @@ Tags: git, markdown, content, workflow
 Requires at least: 6.9
 Tested up to: 7.0
 Requires PHP: 7.2
-Stable tag: 0.6.6
+Stable tag: 0.6.7
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -142,6 +142,10 @@ Uninstalling Push MD removes its Git object-store database tables, seed progress
 The removed tables contain Push MD's derived Git repository history. Reinstalling Push MD can seed a new repository from the current WordPress content, but it cannot restore the previous Push MD Git history unless you kept a clone or database backup.
 
 == Changelog ==
+
+= 0.6.7 =
+
+When seeding content onto a fresh site (the push_md_allow_create_on_missing_id option), resolve posts and pages by slug/path and ignore the Markdown front matter id. Foreign production ids that happen to collide with unrelated local post ids no longer reject the push. Production pushes are unaffected and keep strict id-based resolution.
 
 = 0.6.6 =
 


### PR DESCRIPTION
## Summary

Makes Push MD reliable when **seeding production content onto a fresh WordPress site** (the `push_md_allow_create_on_missing_id` flow used by local Studio setup), and hardens export path-collision handling. This branch is a small stack:

1. **Reject duplicate export paths** (`34daeddc`) — when multiple WordPress items map to the same Markdown file path, fail the export with a clear Git error and report the collisions on Tools → Push MD.
2. **Seed id'd content onto fresh sites** (`c92c6b65`) — `push_md_allow_create_on_missing_id` lets a push create posts whose front-matter id doesn't exist locally (plus a front-matter scalar parsing fix).
3. **Resolve by slug when seeding, ignoring the front-matter id** (`e1c832e4`) — the fix below.

## The seeding bug this fixes

Push MD treats the Markdown front-matter `id` as the local WordPress post ID (`get_post($frontmatter_id)`), which is correct for round-trip on one site but wrong when seeding production content onto a fresh site: those production IDs don't exist locally, so created posts get fresh **sequential auto-increment IDs**. `push_md_allow_create_on_missing_id` only rescued the *missing-id* case. When a production front-matter ID happened to collide with an unrelated local post's auto-ID, the (atomic) push was hard-rejected:

- "Push rejected because Markdown front matter id references a different WordPress post type."
- "Push rejected because multiple Markdown files reference the same WordPress post ID."

One collision blocked the entire push (e.g. ~1,224 objects for jetpack.com).

## Change

In `find_post_id_by_path_metadata()`, gate the two id-resolver branches on `! self::allow_create_on_missing_id()`. When the option is on, resolution falls through to the existing slug/path resolvers and the front-matter id is ignored entirely, so the type/duplicate/path-conflict rejects can't fire. **Production pushes leave the option off and keep strict id-based resolution unchanged.** Bumped to `0.6.7`.

## Test plan

- Four new E2E methods in `Tests/EndToEndTest.php` (run by `.github/workflows/push-md-e2e.yml`):
  - seeding resolves by slug when the front-matter id points at another same-type post;
  - seeding resolves by slug when the id collides with a different post **type**;
  - two files with colliding ids both resolve correctly (no duplicate-id rejection);
  - **production mode (option off) still rejects** a cross-type id mismatch.
- A CI-only REST toggle for `push_md_allow_create_on_missing_id` added to `Tests/ci-mu-test-helper.php` (the test process has no wp-cli).
- `phpcs` clean; the Push MD suite is green locally (E2E skips without `PUSH_MD_E2E_*`).
- **Verified end-to-end**: seeded a fresh Studio site with the v0.6.7 build — 988 published posts + 143 published pages landed at low auto-increment IDs (8–1440), with 1,223 objects in the previously collision-prone ID range and **zero rejections**.
