### PR TITLE
fix(push-md): fully-qualify scoped inline references in bundle scoper

### DIFF
--- a/bin/inspect-push-md-zip.sh
+++ b/bin/inspect-push-md-zip.sh
@@ -88,6 +88,7 @@ reject_content_pattern 'utf8_decode[[:space:]]*\(' 'Push MD zip must not call de
 reject_content_pattern "define[[:space:]]*\\([[:space:]]*['\"]FILTER_VALIDATE_BOOL['\"]" 'Push MD zip must not define the unprefixed FILTER_VALIDATE_BOOL constant.'
 reject_content_pattern 'namespace[[:space:]]+Artpi\\PushMD' 'Push MD zip should use reviewer-friendly prefixes rather than the temporary namespace-only approach.'
 reject_content_pattern 'namespace[[:space:]]+(WordPress|League|Nette|Symfony|Dflydev|Psr|Composer)(\\|[[:space:]]*[{;])' 'Push MD zip must scope bundled runtime namespaces.'
+reject_content_pattern '^[[:space:]]+use[[:space:]]+PushMDVendor\\' 'Push MD zip scopes an inline trait `use` to a relative name (missing leading backslash) — PHP would double the namespace prefix and fatal on load.'
 reject_content_pattern "['\"](PhpToken|ValueError|Attribute|UnhandledMatchError|Stringable)['\"][[:space:]]*=>" 'Push MD autoload metadata must not register unprefixed PHP 8 polyfill stubs.'
 reject_content_pattern 'class[[:space:]]+PMD_|interface[[:space:]]+PMD_|trait[[:space:]]+PMD_|function[[:space:]]+PMD_|define[[:space:]]*\([[:space:]]*['\''"]PMD_' 'Push MD zip must not declare old three-letter PMD globals.'
 reject_content_pattern '['\''"]pmd_(seed|auth|required|forbidden|error|invalid|files|directory_entries)' 'Push MD zip must not use old three-letter pmd_ storage or error identifiers.'

--- a/bin/scope-push-md-bundle.php
+++ b/bin/scope-push-md-bundle.php
@@ -157,7 +157,20 @@ function push_md_scope_php_code( $code, $relative_path ) {
 		}
 
 		if ( in_array( $token[0], $name_token_ids, true ) ) {
-			$rewritten .= push_md_scope_qualified_name( $token[1] );
+			$scoped_name = push_md_scope_qualified_name( $token[1] );
+
+			if (
+				$scoped_name !== $token[1] &&
+				isset( $scoped_name[0] ) && '\\' !== $scoped_name[0] &&
+				! push_md_token_is_namespace_declaration_root( $tokens, $index )
+			) {
+				// Fully-qualify inline references; a relative scoped name resolves against
+				// the already-scoped namespace and doubles the prefix. Namespace
+				// declarations must stay relative.
+				$scoped_name = '\\' . $scoped_name;
+			}
+
+			$rewritten .= $scoped_name;
 			continue;
 		}
 


### PR DESCRIPTION
Fixes #68.

## Problem

Pushing any Markdown change to a site running the **scoped** push-md build (v0.6.6) fails. The `git-receive-pack` response is a PHP fatal instead of git protocol, so the client reports `fatal: protocol error: bad line length character: <br`. The underlying fatal:

```
Fatal error: Trait "PushMDVendor\Nette\Schema\PushMDVendor\Nette\StaticClass" not found
```

Note the **doubled** `PushMDVendor\…\PushMDVendor\…` prefix. Clone / `info/refs` work fine — only the import/push path (which loads the CommonMark → league/config → Nette\Schema stack) fatals, so it was easy to miss.

Introduced by #63 (`0bcc9806`), which added the hand-rolled scoper `bin/scope-push-md-bundle.php`.

## Root cause

`push_md_scope_qualified_name()` returned a scoped name **without a leading `\`** when the source had none. For a `T_NAME_QUALIFIED` token used as an **inline reference** — e.g. the indented trait `use Nette\StaticClass;` in `nette/schema/src/Schema/Helpers.php` — this yields `use PushMDVendor\Nette\StaticClass;`. Inside the now-scoped `namespace PushMDVendor\Nette\Schema;`, PHP resolves that **relative** → `PushMDVendor\Nette\Schema\PushMDVendor\Nette\StaticClass` → fatal.

Top-level `use` imports escape this because import names are always absolute; the doubling only hits inline references (trait `use`, some `extends`/`implements`/`new`, type hints).

## Fix

Emit a leading `\` for rewritten **inline** references (everything except namespace declarations, where a leading `\` is a parse error). Verified PHP name-resolution semantics directly:

| Construct | Result |
|---|---|
| `use \C\D as DD;` (leading `\` on top-level import) | valid |
| `use function \C\foo;` / `use const \C\BAR;` | valid |
| trait `use P\T;` (relative) inside `namespace P\N\S` | **fatal** `P\N\S\P\T not found` (the bug) |
| trait `use \P\T;` (absolute) | works (the fix) |
| `namespace \A\B;` (leading `\` on declaration) | parse error |

So a leading `\` is safe in every rewritten context **except** namespace declarations. The change reuses the existing `push_md_token_is_namespace_declaration_root()` helper — no new context-detection logic. `T_NAME_FULLY_QUALIFIED` tokens already carry a leading `\` and are skipped (no doubling).

Also adds a regression guard to `bin/inspect-push-md-zip.sh` that fails the build if any scoped name is emitted as an indented (in-class) trait `use` without a leading `\` — a cheap automatic canary in the release build for this exact bug class.

## Verification

- **Micro-test:** ran the scoper on a fixture mirroring `Nette\Schema\Helpers` — `namespace` stays relative, trait `use` / `new` / type-hint references become `\PushMDVendor\…`.
- **Build:** `bash bin/build-plugins.sh` passes, incl. the new inspect guard. Scanned all 335 bundled PHP files: 0 doubled prefixes, all parse cleanly (`php -l`).
- **Functional load-test:** through the real bundled autoloader (classmap + ClassLoader), `class_exists()` now loads the classes that fatal today — `PushMDVendor\Nette\Schema\Helpers` (the reported `StaticClass` trait fatal), plus `Expect`, `Processor`, `League\Config\Configuration`, `League\CommonMark\Environment\Environment`.
- `phpcs` clean on both changed files.
- **Manual testing:** set up a local site (e.g., Studio) with push-md, try to clone and then push the repository content.

> Note: the e2e suite only exercises the **unscoped** source tree (`bin/run-push-md-playground.sh` mounts `plugins/push-md` + `components` + `vendor` directly), which is probably why this scoped-build regression shipped uncaught. Tracked as #70 — a follow-up to run e2e against the built zip would close that gap.
