### PR TITLE
Add Pull Request reviews to Push MD

### DIFF
--- a/plugins/push-md/Tests/EndToEndTest.php
+++ b/plugins/push-md/Tests/EndToEndTest.php
@@ -61,6 +61,28 @@ class PMD_End_To_End_Test extends TestCase {
 		$this->assertGreaterThan( 0, $state['total'], "Seeder reports zero total posts: $body" );
 	}
 
+	public function testLegacyBranchPreviewMigrationIsIdempotent() {
+		$branch = 'legacy/' . uniqid();
+		$url    = $this->base_url . '/wp-json/push-md-test/v1/migrate-legacy-preview';
+		$first  = $this->curl_post_json( $url, array( 'branch' => $branch ) );
+		$this->assertSame( 200, $first['status'], 'Legacy migration helper failed: ' . $first['body'] );
+		$first_result = json_decode( $first['body'], true );
+		$this->assertNotEmpty( $first_result['id'] );
+		$this->assertSame( 'push_md_active', $first_result['status'] );
+		$this->assertSame( $branch, $first_result['branch'] );
+		$this->assertSame( str_repeat( 'a', 40 ), $first_result['base_oid'] );
+		$this->assertSame( str_repeat( 'b', 40 ), $first_result['tip_oid'] );
+		$this->assertSame( 'pending', $first_result['review_state'] );
+		$this->assertTrue( $first_result['option_removed'] );
+
+		$second = $this->curl_post_json( $url, array( 'branch' => $branch ) );
+		$this->assertSame( 200, $second['status'], 'Repeated legacy migration failed: ' . $second['body'] );
+		$second_result = json_decode( $second['body'], true );
+		$this->assertSame( $first_result['id'], $second_result['id'] );
+		$this->assertSame( 'pending', $second_result['review_state'] );
+		$this->assertTrue( $second_result['option_removed'] );
+	}
+
 	public function testSeedingSpansMultipleCronTicks() {
 		// The CI workflow seeds 30 posts and drops a mu-plugin that
 		// shrinks the batch size to 5 and the time budget to 0
@@ -167,7 +189,7 @@ class PMD_End_To_End_Test extends TestCase {
 			"---\nstatus: \"publish\"\ntitle: \"Branch Only $suffix\"\n---\n\n$new_text\n"
 		);
 		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', 'post/' . $slug . '.md', 'post/' . $new_slug . '.md' ) );
-		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Preview branch content' ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Preview branch content', '-m', 'Adds a new post and updates the existing preview.' ) );
 
 		$push_result = $this->run_cmd( array( 'git', '-C', $clone_dir, 'push', 'origin', 'HEAD:refs/heads/' . $branch ) );
 		$this->assertStringContainsString( 'Push MD stored preview branch ' . $branch . ' without changing WordPress content.', $push_result['output'] );
@@ -216,7 +238,7 @@ class PMD_End_To_End_Test extends TestCase {
 		$this->assertSame( array( $branch ), $preview_response['headers']['x-push-md-preview-branch'] );
 		$this->assertSame( $revision_count_before, $this->count_revisions( $post_id, 'posts' ), 'Preview rendering must not create WordPress revisions.' );
 
-		$branches = json_decode( $this->curl_get( $this->base_url . '/wp-json/push-md/v1/branches' ), true );
+		$branches = array( 'branches' => $this->get_pull_requests() );
 		$this->assertIsArray( $branches, 'Unexpected branch listing response.' );
 		$this->assertArrayHasKey( 'branches', $branches );
 		$branch_metadata = $this->find_branch_metadata( $branches['branches'], $branch );
@@ -231,6 +253,172 @@ class PMD_End_To_End_Test extends TestCase {
 		$this->assertStringContainsString( '/' . rawurlencode( $slug ) . '/?branch=' . $branch, $updated_preview_url['url'] );
 		$this->assertStringContainsString( '/' . rawurlencode( $new_slug ) . '/?branch=' . $branch, $created_preview_url['url'] );
 		$this->assertArrayHasNoTokenKeys( $branch_metadata );
+		$this->assertNotEmpty( $branch_metadata['pull_request_id'] );
+		$this->assertNotEmpty( $branch_metadata['diff']['files'] );
+		$this->assertNotEmpty( $branch_metadata['diff']['commits'] );
+		$this->assertSame( 'Preview branch content', $branch_metadata['diff']['commits'][0]['subject'] );
+		$this->assertSame( 'Adds a new post and updates the existing preview.', $branch_metadata['diff']['commits'][0]['description'] );
+		$this->assertSame( 'pending', $branch_metadata['review_state'] );
+
+		$description = 'This Pull Request updates preview content ' . $suffix;
+		$description_response = $this->curl_post_json(
+			$this->base_url . '/wp-json/wp/v2/push-md-pull-requests/' . $branch_metadata['pull_request_id'],
+			array( 'content' => $description )
+		);
+		$this->assertSame( 200, $description_response['status'], 'The active Pull Request description should be editable: ' . $description_response['body'] );
+		$description_item = json_decode( $description_response['body'], true );
+		$this->assertSame( $description, $description_item['content']['raw'] );
+
+		$general_note_response = $this->curl_post_json(
+			$this->base_url . '/wp-json/wp/v2/comments',
+			array(
+				'post'    => $branch_metadata['pull_request_id'],
+				'type'    => 'note',
+				'content' => 'General Pull Request note ' . $suffix,
+			)
+		);
+		$this->assertSame( 201, $general_note_response['status'], 'A general Pull Request Note should be created: ' . $general_note_response['body'] );
+		$branches_after_general_note = array( 'branches' => $this->get_pull_requests() );
+		$this->assertSame( 'pending', $this->find_branch_metadata( $branches_after_general_note['branches'], $branch )['review_state'], 'An ordinary Note must not change the review state.' );
+
+		$approved_note_response = $this->curl_post_json(
+			$this->base_url . '/wp-json/wp/v2/comments',
+			array(
+				'post'    => $branch_metadata['pull_request_id'],
+				'type'    => 'note',
+				'content' => 'Approve Pull Request ' . $suffix,
+				'meta'    => array( 'push_md_review_state' => 'approved' ),
+			)
+		);
+		$this->assertSame( 201, $approved_note_response['status'], 'A state-changing Note should be created: ' . $approved_note_response['body'] );
+		$approved_note = json_decode( $approved_note_response['body'], true );
+		$this->assertSame( 'approved', $approved_note['meta']['push_md_review_state'] );
+		$branches_after_approval = array( 'branches' => $this->get_pull_requests() );
+		$this->assertSame( 'approved', $this->find_branch_metadata( $branches_after_approval['branches'], $branch )['review_state'] );
+
+		$approved_note_update = $this->curl_post_json(
+			$this->base_url . '/wp-json/wp/v2/comments/' . $approved_note['id'],
+			array( 'content' => 'State-changing Notes are immutable.' )
+		);
+		$this->assertSame( 409, $approved_note_update['status'], 'A state-changing Note must not be edited.' );
+		$approved_note_delete = $this->curl_delete( $this->base_url . '/wp-json/wp/v2/comments/' . $approved_note['id'] . '?force=true' );
+		$this->assertSame( 409, $approved_note_delete['status'], 'A state-changing Note must not be deleted.' );
+
+		$invalid_state_response = $this->curl_post_json(
+			$this->base_url . '/wp-json/wp/v2/comments',
+			array(
+				'post'    => $branch_metadata['pull_request_id'],
+				'type'    => 'note',
+				'content' => 'Invalid Pull Request state ' . $suffix,
+				'meta'    => array( 'push_md_review_state' => 'not_registered' ),
+			)
+		);
+		$this->assertSame( 400, $invalid_state_response['status'], 'An unregistered review state must be rejected.' );
+
+		$inline_anchor = $this->find_diff_anchor( $branch_metadata['diff']['files'] );
+		$this->assertNotEmpty( $inline_anchor, 'The changed files should expose at least one inline Note anchor.' );
+		$inline_note_response = $this->curl_post_json(
+			$this->base_url . '/wp-json/wp/v2/comments',
+			array(
+				'post'    => $branch_metadata['pull_request_id'],
+				'type'    => 'note',
+				'content' => 'Inline Pull Request note ' . $suffix,
+				'meta'    => array(
+					'push_md_path' => $inline_anchor['path'],
+					'push_md_side' => $inline_anchor['side'],
+					'push_md_line' => $inline_anchor['line'],
+				),
+			)
+		);
+		$this->assertSame( 201, $inline_note_response['status'], 'An inline Pull Request Note should be created: ' . $inline_note_response['body'] );
+		$inline_note = json_decode( $inline_note_response['body'], true );
+		$this->assertSame( $inline_anchor['path'], $inline_note['meta']['push_md_path'] );
+		$this->assertSame( $inline_anchor['side'], $inline_note['meta']['push_md_side'] );
+		$this->assertSame( $inline_anchor['line'], $inline_note['meta']['push_md_line'] );
+		$this->assertSame( $branch_metadata['tip_oid'], $inline_note['push_md_tip_oid'] );
+
+		$inline_state_response = $this->curl_post_json(
+			$this->base_url . '/wp-json/wp/v2/comments',
+			array(
+				'post'    => $branch_metadata['pull_request_id'],
+				'type'    => 'note',
+				'content' => 'Inline state change ' . $suffix,
+				'meta'    => array(
+					'push_md_path'         => $inline_anchor['path'],
+					'push_md_side'         => $inline_anchor['side'],
+					'push_md_line'         => $inline_anchor['line'],
+					'push_md_review_state' => 'approved',
+				),
+			)
+		);
+		$this->assertSame( 400, $inline_state_response['status'], 'An inline Note must not change the review state.' );
+
+		$custom_state_response = $this->curl_post_json(
+			$this->base_url . '/wp-json/wp/v2/comments',
+			array(
+				'post'    => $branch_metadata['pull_request_id'],
+				'type'    => 'note',
+				'content' => 'Request Pull Request changes ' . $suffix,
+				'meta'    => array( 'push_md_review_state' => 'changes_requested' ),
+			)
+		);
+		$this->assertSame( 201, $custom_state_response['status'], 'A filtered review state should be accepted: ' . $custom_state_response['body'] );
+		$custom_state_note = json_decode( $custom_state_response['body'], true );
+		$this->assertSame( 'changes_requested', $custom_state_note['meta']['push_md_review_state'] );
+		$branches_after_custom_state = array( 'branches' => $this->get_pull_requests() );
+		$this->assertSame( 'changes_requested', $this->find_branch_metadata( $branches_after_custom_state['branches'], $branch )['review_state'] );
+
+		$final_approval_response = $this->curl_post_json(
+			$this->base_url . '/wp-json/wp/v2/comments',
+			array(
+				'post'    => $branch_metadata['pull_request_id'],
+				'type'    => 'note',
+				'content' => 'Approve corrected Pull Request ' . $suffix,
+				'meta'    => array( 'push_md_review_state' => 'approved' ),
+			)
+		);
+		$this->assertSame( 201, $final_approval_response['status'], 'A later Note should correct the review state: ' . $final_approval_response['body'] );
+
+		$invalid_anchor_response = $this->curl_post_json(
+			$this->base_url . '/wp-json/wp/v2/comments',
+			array(
+				'post'    => $branch_metadata['pull_request_id'],
+				'type'    => 'note',
+				'content' => 'Invalid inline Pull Request note ' . $suffix,
+				'meta'    => array(
+					'push_md_path' => $inline_anchor['path'],
+					'push_md_side' => $inline_anchor['side'],
+					'push_md_line' => 999999,
+				),
+			)
+		);
+		$this->assertSame( 409, $invalid_anchor_response['status'], 'An inline Note must point at the current diff.' );
+
+		$incomplete_anchor_response = $this->curl_post_json(
+			$this->base_url . '/wp-json/wp/v2/comments',
+			array(
+				'post'    => $branch_metadata['pull_request_id'],
+				'type'    => 'note',
+				'content' => 'Incomplete inline Pull Request note ' . $suffix,
+				'meta'    => array( 'push_md_path' => $inline_anchor['path'] ),
+			)
+		);
+		$this->assertSame( 400, $incomplete_anchor_response['status'], 'An inline Note must provide the complete anchor.' );
+
+		$direct_update_response = $this->curl_post_json(
+			$this->base_url . '/wp-json/wp/v2/push-md-pull-requests/' . $branch_metadata['pull_request_id'],
+			array( 'title' => 'REST must not update Pull Requests' )
+		);
+		$this->assertSame( 403, $direct_update_response['status'], 'The native controller must not update Pull Requests directly.' );
+		$direct_create_response = $this->curl_post_json(
+			$this->base_url . '/wp-json/wp/v2/push-md-pull-requests',
+			array( 'title' => 'REST must not create Pull Requests' )
+		);
+		$this->assertSame( 403, $direct_create_response['status'], 'The native controller must not create Pull Requests directly.' );
+		$direct_delete_response = $this->curl_delete(
+			$this->base_url . '/wp-json/wp/v2/push-md-pull-requests/' . $branch_metadata['pull_request_id'] . '?force=true'
+		);
+		$this->assertSame( 403, $direct_delete_response['status'], 'The native controller must not delete Pull Requests directly.' );
 
 		$live_only_id = $this->create_post_via_rest(
 			array(
@@ -270,14 +458,33 @@ class PMD_End_To_End_Test extends TestCase {
 		$remote_branch = $this->run_cmd( array( 'git', 'ls-remote', $this->remote_url(), 'refs/heads/' . $branch ) );
 		$this->assertSame( '', trim( $remote_branch['output'] ), 'Merged preview branch ref should no longer be advertised.' );
 
-		$branches_after_merge = json_decode( $this->curl_get( $this->base_url . '/wp-json/push-md/v1/branches' ), true );
+		$branches_after_merge = array( 'branches' => $this->get_pull_requests() );
 		$merged_metadata      = $this->find_branch_metadata( $branches_after_merge['branches'], $branch );
 		$this->assertNotEmpty( $merged_metadata, 'Merged preview branch metadata should remain available for history.' );
 		$this->assertSame( 'merged', $merged_metadata['status'] );
 		$this->assertFalse( $merged_metadata['active'] );
 		$this->assertNotEmpty( $merged_metadata['merged_at'] );
 		$this->assertSame( $branch, $merged_metadata['branch'] );
+		$this->assertSame( 'approved', $merged_metadata['review_state'], 'Merge must preserve the review state.' );
 		$this->assertNotEmpty( $merged_metadata['changed_urls'], 'Merged branch history should keep the changed URL list.' );
+		$merged_pull_request = json_decode(
+			$this->curl_get( $this->base_url . '/wp-json/wp/v2/push-md-pull-requests/' . $branch_metadata['pull_request_id'] . '?context=edit&_fields=content' ),
+			true
+		);
+		$this->assertSame( $description, $merged_pull_request['content']['raw'], 'Merge must preserve the Pull Request description.' );
+		$merged_description_update = $this->curl_post_json(
+			$this->base_url . '/wp-json/wp/v2/push-md-pull-requests/' . $branch_metadata['pull_request_id'],
+			array( 'content' => 'Merged descriptions are read-only.' )
+		);
+		$this->assertSame( 409, $merged_description_update['status'], 'A merged Pull Request description must be read-only.' );
+
+		$closed_note_update = $this->curl_post_json(
+			$this->base_url . '/wp-json/wp/v2/comments/' . $inline_note['id'],
+			array( 'content' => 'Merged Pull Request Notes are immutable.' )
+		);
+		$this->assertSame( 409, $closed_note_update['status'], 'Merged Pull Request Notes must be read-only.' );
+		$closed_note_delete = $this->curl_delete( $this->base_url . '/wp-json/wp/v2/comments/' . $inline_note['id'] . '?force=true' );
+		$this->assertSame( 409, $closed_note_delete['status'], 'Merged Pull Request Notes must not be deleted.' );
 	}
 
 	public function testPreviewBranchUpdatesRenderLatestBranchCommitWithoutMutatingLiveContent() {
@@ -318,8 +525,26 @@ class PMD_End_To_End_Test extends TestCase {
 		$this->assertSame( 200, $first_preview_response['status'], 'Authenticated preview request should render the first branch tip.' );
 		$this->assertStringContainsString( $first_preview_text, $first_preview_response['body'] );
 		$this->assertStringNotContainsString( $live_text, $first_preview_response['body'] );
-		$branches = json_decode( $this->curl_get( $this->base_url . '/wp-json/push-md/v1/branches' ), true );
-		$this->assertSame( $first_tip, $this->find_branch_metadata( $branches['branches'], $branch )['tip_oid'] );
+		$branches = array( 'branches' => $this->get_pull_requests() );
+		$first_branch_metadata = $this->find_branch_metadata( $branches['branches'], $branch );
+		$this->assertSame( $first_tip, $first_branch_metadata['tip_oid'] );
+		$this->assertSame( 'pending', $first_branch_metadata['review_state'] );
+		$description = 'Description preserved across pushes ' . $suffix;
+		$description_response = $this->curl_post_json(
+			$this->base_url . '/wp-json/wp/v2/push-md-pull-requests/' . $first_branch_metadata['pull_request_id'],
+			array( 'content' => $description )
+		);
+		$this->assertSame( 200, $description_response['status'], 'The active Pull Request description should be editable: ' . $description_response['body'] );
+		$approval_response = $this->curl_post_json(
+			$this->base_url . '/wp-json/wp/v2/comments',
+			array(
+				'post'    => $first_branch_metadata['pull_request_id'],
+				'type'    => 'note',
+				'content' => 'Approve before another push ' . $suffix,
+				'meta'    => array( 'push_md_review_state' => 'approved' ),
+			)
+		);
+		$this->assertSame( 201, $approval_response['status'], 'The review state should be changeable before another push: ' . $approval_response['body'] );
 
 		$this->edit_file(
 			$clone_dir . '/post/' . $slug . '.md',
@@ -340,14 +565,35 @@ class PMD_End_To_End_Test extends TestCase {
 		$this->assertStringContainsString( $next_preview_text, $next_preview_response['body'] );
 		$this->assertStringNotContainsString( $first_preview_text, $next_preview_response['body'] );
 		$this->assertStringNotContainsString( $live_text, $next_preview_response['body'] );
-		$branches = json_decode( $this->curl_get( $this->base_url . '/wp-json/push-md/v1/branches' ), true );
-		$this->assertSame( $next_tip, $this->find_branch_metadata( $branches['branches'], $branch )['tip_oid'] );
+		$branches = array( 'branches' => $this->get_pull_requests() );
+		$next_branch_metadata = $this->find_branch_metadata( $branches['branches'], $branch );
+		$this->assertSame( $next_tip, $next_branch_metadata['tip_oid'] );
+		$this->assertSame( 'approved', $next_branch_metadata['review_state'], 'A later push must preserve the review state.' );
+		$pull_request_after_push = json_decode(
+			$this->curl_get( $this->base_url . '/wp-json/wp/v2/push-md-pull-requests/' . $first_branch_metadata['pull_request_id'] . '?context=edit&_fields=content' ),
+			true
+		);
+		$this->assertSame( $description, $pull_request_after_push['content']['raw'], 'A later push must preserve the Pull Request description.' );
 
 		$this->assertSame( $revision_count_before, $this->count_revisions( $post_id, 'posts' ), 'Preview branch updates must not create WordPress revisions.' );
 		$this->assertStringContainsString( $live_text, $this->fetch_content( $post_id, 'posts' ) );
 		$this->assertStringNotContainsString( $next_preview_text, $this->fetch_content( $post_id, 'posts' ) );
 
 		$this->delete_preview_branch( $clone_dir, $branch );
+		$branches_after_close = array( 'branches' => $this->get_pull_requests() );
+		$closed_metadata      = $this->find_branch_metadata( $branches_after_close['branches'], $branch );
+		$this->assertSame( 'closed', $closed_metadata['status'] );
+		$this->assertSame( 'approved', $closed_metadata['review_state'], 'Closing a Pull Request must preserve the review state.' );
+		$pull_request_after_close = json_decode(
+			$this->curl_get( $this->base_url . '/wp-json/wp/v2/push-md-pull-requests/' . $first_branch_metadata['pull_request_id'] . '?context=edit&_fields=content' ),
+			true
+		);
+		$this->assertSame( $description, $pull_request_after_close['content']['raw'], 'Closing a Pull Request must preserve its description.' );
+		$closed_description_update = $this->curl_post_json(
+			$this->base_url . '/wp-json/wp/v2/push-md-pull-requests/' . $first_branch_metadata['pull_request_id'],
+			array( 'content' => 'Closed descriptions are read-only.' )
+		);
+		$this->assertSame( 409, $closed_description_update['status'], 'A closed Pull Request description must be read-only.' );
 	}
 
 	public function testPreviewBranchForceWithLeaseUpdateAfterRebaseResetsBaseToCurrentTrunk() {
@@ -453,7 +699,7 @@ class PMD_End_To_End_Test extends TestCase {
 		$this->assertStringContainsString( $live_text, $this->fetch_content( $post_id, 'posts' ) );
 		$this->assertStringNotContainsString( $next_preview_text, $this->fetch_content( $post_id, 'posts' ) );
 
-		$branches        = json_decode( $this->curl_get( $this->base_url . '/wp-json/push-md/v1/branches' ), true );
+		$branches        = array( 'branches' => $this->get_pull_requests() );
 		$branch_metadata = $this->find_branch_metadata( $branches['branches'], $branch );
 		$this->assertSame( $next_tip, $branch_metadata['tip_oid'] );
 		$this->assertSame( $rebased_base, $branch_metadata['base_oid'], 'Rebased preview updates should reset the preview base to current trunk.' );
@@ -561,7 +807,7 @@ class PMD_End_To_End_Test extends TestCase {
 
 	public function testPreviewBranchRestRoutesRequireAdmin() {
 		$suffix        = uniqid( 'branch-permission-' );
-		$list_url      = $this->base_url . '/wp-json/push-md/v1/branches';
+		$list_url      = $this->base_url . '/wp-json/wp/v2/push-md-pull-requests?context=edit&status=push_md_active,push_md_merged,push_md_closed';
 		$merge_url     = $this->base_url . '/wp-json/push-md/v1/branches/merge';
 		$branch        = 'preview/' . $suffix;
 		$anonymous     = $this->curl_get_with_headers( $list_url, false );
@@ -580,11 +826,19 @@ class PMD_End_To_End_Test extends TestCase {
 		$subscriber_list     = $this->curl_get_with_headers( $list_url, $subscriber_header );
 		$subscriber_merge    = $this->curl_post_json_with_auth( $merge_url, array( 'branch' => $branch ), $subscriber_header );
 		$admin_list          = $this->curl_get_with_headers( $list_url, true );
+		$admin_pull_requests = json_decode( $admin_list['body'], true );
+		$this->assertNotEmpty( $admin_pull_requests, 'The permission test requires an existing Pull Request.' );
+		$subscriber_update = $this->curl_post_json_with_auth(
+			$this->base_url . '/wp-json/wp/v2/push-md-pull-requests/' . $admin_pull_requests[0]['id'],
+			array( 'content' => 'Subscribers cannot edit Pull Request descriptions.' ),
+			$subscriber_header
+		);
 
 		$this->assertContains( $anonymous['status'], array( 401, 403 ), 'Anonymous branch list request should be denied.' );
 		$this->assertContains( $anon_merge['status'], array( 401, 403 ), 'Anonymous branch merge request should be denied.' );
 		$this->assertSame( 403, $subscriber_list['status'], 'Subscriber branch list request should be denied.' );
 		$this->assertSame( 403, $subscriber_merge['status'], 'Subscriber branch merge request should be denied.' );
+		$this->assertSame( 403, $subscriber_update['status'], 'Subscriber Pull Request description updates should be denied.' );
 		$this->assertSame( 200, $admin_list['status'], 'Admin branch list request should be allowed.' );
 	}
 
@@ -1363,10 +1617,10 @@ class PMD_End_To_End_Test extends TestCase {
 		$this->assertStringContainsString( 'Update template HTML from Git', $log['output'] );
 		$this->assertStringContainsString( 'Create and delete content from Git', $log['output'] );
 
-		// 11) The CPT-based persistence model is gone.
-		$this->assertNotSame(
+		// 11) Pull Requests use the native CPT REST controller.
+		$this->assertSame(
 			200,
-			$this->http_status( $this->base_url . '/wp-json/wp/v2/types/pmd_commit' )
+			$this->http_status( $this->base_url . '/wp-json/wp/v2/types/push_md_pull_request' )
 		);
 	}
 
@@ -1641,6 +1895,26 @@ class PMD_End_To_End_Test extends TestCase {
 		return $this->curl_post_json_with_auth( $url, $payload, true );
 	}
 
+	private function curl_delete( $url ) {
+		$ch = curl_init( $url );
+		curl_setopt_array(
+			$ch,
+			array(
+				CURLOPT_RETURNTRANSFER => true,
+				CURLOPT_CUSTOMREQUEST  => 'DELETE',
+				CURLOPT_HTTPHEADER     => array( $this->auth_header ),
+			)
+		);
+		$body   = curl_exec( $ch );
+		$status = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
+		curl_close( $ch );
+
+		return array(
+			'status' => $status,
+			'body'   => $body,
+		);
+	}
+
 	private function curl_post_json_with_auth( $url, array $payload, $authenticated ) {
 		$ch = curl_init( $url );
 		curl_setopt_array(
@@ -1704,6 +1978,82 @@ class PMD_End_To_End_Test extends TestCase {
 		$this->assertIsArray( $revisions, "Unexpected revisions response for $endpoint/$id: $body" );
 
 		return count( $revisions );
+	}
+
+	private function get_pull_requests() {
+		$url   = $this->base_url . '/wp-json/wp/v2/push-md-pull-requests'
+			. '?context=edit&per_page=100&status=push_md_active,push_md_merged,push_md_closed'
+			. '&_fields=id,status,date,modified,author,meta,push_md_preview_url,push_md_diff';
+		$body  = $this->curl_get( $url );
+		$items = json_decode( $body, true );
+		$this->assertIsArray( $items, 'Unexpected Pull Request listing response: ' . $body );
+
+		$pull_requests = array();
+		foreach ( $items as $item ) {
+			$meta   = isset( $item['meta'] ) && is_array( $item['meta'] ) ? $item['meta'] : array();
+			$status = isset( $item['status'] ) ? $item['status'] : '';
+			$diff   = isset( $item['push_md_diff'] ) && is_array( $item['push_md_diff'] )
+				? $item['push_md_diff']
+				: array( 'files' => array() );
+			$changed_urls = array();
+			foreach ( $diff['files'] as $file ) {
+				$changed_urls[] = array(
+					'action' => isset( $file['action'] ) ? $file['action'] : '',
+					'path'   => isset( $file['path'] ) ? $file['path'] : '',
+					'url'    => isset( $file['preview_url'] ) ? $file['preview_url'] : '',
+				);
+			}
+
+			$pull_request = array(
+				'pull_request_id' => isset( $item['id'] ) ? intval( $item['id'] ) : 0,
+				'branch'          => isset( $meta['push_md_branch'] ) ? $meta['push_md_branch'] : '',
+				'owner'           => isset( $item['author'] ) ? intval( $item['author'] ) : 0,
+				'base_oid'        => isset( $meta['push_md_base_oid'] ) ? $meta['push_md_base_oid'] : '',
+				'tip_oid'         => isset( $meta['push_md_tip_oid'] ) ? $meta['push_md_tip_oid'] : '',
+				'review_state'    => isset( $meta['push_md_review_state'] ) ? $meta['push_md_review_state'] : 'pending',
+				'url'             => isset( $item['push_md_preview_url'] ) ? $item['push_md_preview_url'] : '',
+				'status'          => str_replace( 'push_md_', '', $status ),
+				'active'          => 'push_md_active' === $status,
+				'created_at'      => isset( $item['date'] ) ? strtotime( $item['date'] ) : 0,
+				'updated_at'      => isset( $item['modified'] ) ? strtotime( $item['modified'] ) : 0,
+				'changed_urls'    => $changed_urls,
+				'diff'            => $diff,
+			);
+			if ( 'push_md_merged' === $status ) {
+				$pull_request['merged_oid'] = isset( $meta['push_md_merged_oid'] ) ? $meta['push_md_merged_oid'] : '';
+				$pull_request['merged_by']  = isset( $meta['push_md_merged_by'] ) ? intval( $meta['push_md_merged_by'] ) : 0;
+				$pull_request['merged_at']  = $pull_request['updated_at'];
+			}
+			$pull_requests[] = $pull_request;
+		}
+
+		return $pull_requests;
+	}
+
+	private function find_diff_anchor( $files ) {
+		foreach ( $files as $file ) {
+			if ( empty( $file['path'] ) || empty( $file['rows'] ) ) {
+				continue;
+			}
+			foreach ( $file['rows'] as $row ) {
+				if ( ! empty( $row['new_line'] ) ) {
+					return array(
+						'path' => $file['path'],
+						'side' => 'new',
+						'line' => intval( $row['new_line'] ),
+					);
+				}
+				if ( ! empty( $row['old_line'] ) ) {
+					return array(
+						'path' => $file['path'],
+						'side' => 'old',
+						'line' => intval( $row['old_line'] ),
+					);
+				}
+			}
+		}
+
+		return array();
 	}
 
 	private function find_branch_metadata( $branches, $branch_name ) {

--- a/plugins/push-md/Tests/ci-mu-test-helper.php
+++ b/plugins/push-md/Tests/ci-mu-test-helper.php
@@ -29,3 +29,78 @@ add_filter( 'push_md_seed_time_budget_seconds', static function () {
 add_filter( 'push_md_seed_tick_reschedule_seconds', static function () {
 	return 0;
 } );
+
+add_filter(
+	'push_md_review_states',
+	static function ( $states ) {
+		$states['changes_requested'] = array(
+			'label' => 'Changes requested',
+		);
+
+		return $states;
+	}
+);
+
+add_action(
+	'rest_api_init',
+	static function () {
+		register_rest_route(
+			'push-md-test/v1',
+			'/migrate-legacy-preview',
+			array(
+				'methods'             => 'POST',
+				'permission_callback' => static function () {
+					return current_user_can( 'manage_options' );
+				},
+				'callback'            => static function ( WP_REST_Request $request ) {
+					$branch_name = sanitize_text_field( $request->get_param( 'branch' ) );
+					update_option(
+						'push_md_branch_previews',
+						array(
+							$branch_name => array(
+								'branch'     => $branch_name,
+								'owner'      => get_current_user_id(),
+								'base_oid'   => str_repeat( 'a', 40 ),
+								'tip_oid'    => str_repeat( 'b', 40 ),
+								'created_at' => 1700000000,
+								'updated_at' => 1700000100,
+							),
+						),
+						false
+					);
+					Push_MD_Pull_Requests::migrate_legacy_branch_previews();
+
+					$posts = get_posts(
+						array(
+							'post_type'      => Push_MD_Pull_Requests::POST_TYPE,
+							'post_status'    => Push_MD_Pull_Requests::STATUS_ACTIVE,
+							'posts_per_page' => 1,
+							'meta_key'       => 'push_md_branch', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+							'meta_value'     => $branch_name, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+						)
+					);
+					$post  = empty( $posts ) ? null : $posts[0];
+
+					return rest_ensure_response(
+						array(
+							'id'             => $post ? $post->ID : 0,
+							'status'         => $post ? $post->post_status : '',
+							'branch'         => $post ? get_post_meta( $post->ID, 'push_md_branch', true ) : '',
+							'base_oid'       => $post ? get_post_meta( $post->ID, 'push_md_base_oid', true ) : '',
+							'tip_oid'        => $post ? get_post_meta( $post->ID, 'push_md_tip_oid', true ) : '',
+							'review_state'   => $post ? get_post_meta( $post->ID, 'push_md_review_state', true ) : '',
+							'option_removed' => null === get_option( 'push_md_branch_previews', null ),
+						)
+					);
+				},
+				'args'                => array(
+					'branch' => array(
+						'required'          => true,
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+			)
+		);
+	}
+);

--- a/plugins/push-md/admin-shell.css
+++ b/plugins/push-md/admin-shell.css
@@ -392,6 +392,329 @@
 	background: #edf6ff;
 	color: #0a4b78;
 	overflow-wrap: anywhere;
+	text-decoration: none;
+}
+
+.push-md-review-state {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 22px;
+	margin: 0 0 8px 8px;
+	padding: 2px 8px;
+	border-radius: 999px;
+	background: #fff8c5;
+	color: #633c01;
+	font-size: 11px;
+	font-weight: 600;
+	vertical-align: middle;
+}
+
+.push-md-review-state.is-approved {
+	background: #dafbe1;
+	color: #116329;
+}
+
+.push-md-review-frame {
+	max-width: 1380px;
+}
+
+.push-md-pr-header {
+	display: grid;
+	grid-template-columns: auto minmax(0, 1fr) auto;
+	align-items: center;
+	gap: 12px 16px;
+	margin: 18px 0;
+	padding: 20px;
+	border: 1px solid var(--push-md-line);
+	border-radius: 8px;
+	background: var(--push-md-panel);
+}
+
+.push-md-pr-header h1 {
+	margin: 0;
+	font-size: 24px;
+}
+
+.push-md-pr-header .push-md-branch-meta {
+	grid-column: 2;
+}
+
+.push-md-pr-states {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 6px;
+}
+
+.push-md-pr-states .push-md-review-state {
+	min-height: 30px;
+	margin: 0;
+	padding: 4px 10px;
+	font-size: 12px;
+}
+
+.push-md-pr-status {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 30px;
+	padding: 4px 10px;
+	border-radius: 999px;
+	background: #1f883d;
+	color: #fff;
+	font-size: 12px;
+	font-weight: 600;
+}
+
+.push-md-pr-status.push_md_merged {
+	background: #8250df;
+}
+
+.push-md-pr-status.push_md_closed {
+	background: #cf222e;
+}
+
+.push-md-pr-actions {
+	display: flex;
+	grid-column: 3;
+	grid-row: 1 / span 2;
+	gap: 8px;
+}
+
+.push-md-pr-description {
+	grid-column: 1 / -1;
+	margin-top: 4px;
+	padding-top: 16px;
+	border-top: 1px solid var(--push-md-line);
+}
+
+.push-md-pr-description h2 {
+	margin: 0 0 6px;
+	font-size: 14px;
+}
+
+.push-md-pr-description-content {
+	min-height: 40px;
+	padding: 8px;
+	border: 1px solid transparent;
+	border-radius: 6px;
+	white-space: pre-wrap;
+}
+
+.push-md-pr-description-content.is-empty {
+	color: var(--push-md-muted);
+}
+
+.push-md-pr-description-content[contenteditable="true"]:empty::before {
+	color: var(--push-md-muted);
+	content: attr(data-placeholder);
+}
+
+.push-md-pr-description-content[contenteditable="true"]:hover {
+	background: #f6f8fa;
+}
+
+.push-md-pr-description-content[contenteditable="true"]:focus {
+	border-color: #3858e9;
+	background: #fff;
+	outline: 1px solid #3858e9;
+}
+
+.push-md-pr-description-form {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
+	gap: 8px;
+}
+
+.push-md-pr-description-form .push-md-pr-description-content {
+	width: 100%;
+}
+
+.push-md-pr-description-form button[hidden] {
+	display: none;
+}
+
+.push-md-pr-commit-history {
+	margin-bottom: 18px;
+}
+
+.push-md-pr-commit-list {
+	display: flex;
+	flex-direction: column;
+	gap: 0;
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.push-md-pr-commit-list li {
+	display: grid;
+	grid-template-columns: 112px minmax(0, 1fr);
+	align-items: start;
+	gap: 12px;
+	margin: 0;
+	padding: 10px 0;
+	border-top: 1px solid var(--push-md-line);
+}
+
+.push-md-pr-commit-list code {
+	display: inline-block;
+	justify-self: start;
+	white-space: nowrap;
+}
+
+.push-md-pr-commit-list li:first-child {
+	border-top: 0;
+}
+
+.push-md-pr-commit-list li.is-empty {
+	display: block;
+	color: var(--push-md-muted);
+}
+
+.push-md-pr-commit-copy {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.push-md-pr-commit-copy p {
+	margin: 0;
+	color: var(--push-md-muted);
+	white-space: pre-wrap;
+}
+
+.push-md-notes {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
+
+.push-md-note {
+	margin: 8px 0;
+	border: 1px solid var(--push-md-line);
+	border-radius: 6px;
+	background: #fff;
+	overflow: hidden;
+}
+
+.push-md-note-header {
+	padding: 7px 10px;
+	border-bottom: 1px solid var(--push-md-line);
+	background: #f6f8fa;
+	color: var(--push-md-muted);
+	font-size: 12px;
+	font-weight: 600;
+}
+
+.push-md-note-content {
+	padding: 10px;
+	white-space: pre-wrap;
+}
+
+.push-md-note-form {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	align-items: center;
+	gap: 8px;
+	margin-top: 12px;
+	padding: 10px;
+	border: 1px solid var(--push-md-line);
+	border-radius: 6px;
+	background: #f6f8fa;
+}
+
+#push-md-admin .push-md-note-form textarea {
+	grid-column: 1 / -1;
+	width: 100%;
+	min-height: 72px;
+}
+
+.push-md-note-state-field {
+	display: flex;
+	align-items: center;
+	justify-self: end;
+	gap: 8px;
+	color: var(--push-md-muted);
+	font-size: 12px;
+}
+
+.push-md-diff-file {
+	margin-top: 18px;
+	border: 1px solid var(--push-md-line);
+	border-radius: 8px;
+	background: #fff;
+	overflow: hidden;
+}
+
+.push-md-diff-header {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	min-height: 46px;
+	padding: 10px 14px;
+	border-bottom: 1px solid var(--push-md-line);
+	background: #f6f8fa;
+}
+
+.push-md-diff-header code {
+	flex: 1;
+	overflow-wrap: anywhere;
+}
+
+.push-md-diff-rows {
+	overflow-x: auto;
+	font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+	font-size: 12px;
+}
+
+.push-md-diff-line {
+	display: grid;
+	grid-template-columns: 30px 52px 52px minmax(600px, 1fr);
+	min-height: 24px;
+	border-bottom: 1px solid #eef1f4;
+}
+
+.push-md-diff-line > span {
+	padding: 3px 8px;
+	border-right: 1px solid #e5e7eb;
+	color: var(--push-md-muted);
+	text-align: right;
+	user-select: none;
+}
+
+.push-md-diff-line > code {
+	padding: 3px 10px;
+	white-space: pre;
+}
+
+.push-md-diff-line.is-added {
+	background: #dafbe1;
+}
+
+.push-md-diff-line.is-deleted {
+	background: #ffebe9;
+}
+
+.push-md-diff-add {
+	border: 0;
+	background: transparent;
+	color: #0969da;
+	cursor: pointer;
+	font-weight: 700;
+}
+
+.push-md-diff-add:disabled {
+	color: transparent;
+	cursor: default;
+}
+
+.push-md-diff-rows > .push-md-note,
+.push-md-diff-rows > .push-md-inline-form {
+	margin: 8px 14px 8px 134px;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
 .push-md-branch-meta {
@@ -601,6 +924,21 @@
 	.push-md-branch-actions {
 		justify-content: flex-start;
 		min-width: 0;
+	}
+
+	.push-md-pr-header {
+		grid-template-columns: 1fr;
+	}
+
+	.push-md-pr-header .push-md-branch-meta,
+	.push-md-pr-actions {
+		grid-column: 1;
+		grid-row: auto;
+	}
+
+	.push-md-diff-rows > .push-md-note,
+	.push-md-diff-rows > .push-md-inline-form {
+		margin-left: 14px;
 	}
 
 	.push-md-changed-url-list li {

--- a/plugins/push-md/admin-shell.js
+++ b/plugins/push-md/admin-shell.js
@@ -14,8 +14,12 @@
 	var nonce             = config.nonce || '';
 	var statusUrl         = config.statusUrl || '';
 	var retryUrl          = config.retryUrl || '';
-	var branchesUrl       = config.branchesUrl || '';
+	var pullRequestsUrl   = config.pullRequestsUrl || '';
+	var commentsUrl       = config.commentsUrl || '';
 	var mergeBranchUrl    = config.mergeBranchUrl || '';
+	var adminPageUrl      = config.adminPageUrl || '';
+	var pullRequestId     = intval( config.pullRequestId );
+	var reviewStates      = config.reviewStates || {};
 	var remoteUrl         = config.remoteUrl || '';
 	var checkoutDir       = config.checkoutDir || 'site';
 	var cloneCommand      = config.cloneCommand || ('git clone ' + remoteUrl + ' ' + checkoutDir);
@@ -32,6 +36,7 @@
 	var cwdEl             = document.getElementById( 'push-md-prompt-cwd' );
 	var titleEl           = document.getElementById( 'push-md-terminal-title' );
 	var commitListEl      = document.getElementById( 'push-md-commit-list' );
+	var branchPanelEl     = document.getElementById( 'push-md-branches-panel' );
 	var branchListEl      = document.getElementById( 'push-md-branch-list' );
 	var branchMessageEl   = document.getElementById( 'push-md-branches-message' );
 	var branchRefreshEl   = document.getElementById( 'push-md-branches-refresh' );
@@ -40,6 +45,11 @@
 	var history           = [];
 	var historyIndex      = 0;
 	var hasAnnouncedReady = progress.state === 'done';
+
+	if (pullRequestId) {
+		bootPullRequestReview();
+		return;
+	}
 
 	if ( ! stateEl || ! outputEl || ! inputEl) {
 		return;
@@ -157,13 +167,13 @@
 	}
 
 	function fetchBranches() {
-		if ( ! branchesUrl || ! branchListEl || ! branchMessageEl) {
+		if ( ! pullRequestsUrl || ! branchListEl || ! branchMessageEl) {
 			return;
 		}
 
-		setBranchMessage( __( 'Loading preview branches...', 'push-md' ), 'is-muted' );
+		setBranchMessage( __( 'Loading Pull Requests...', 'push-md' ), 'is-muted' );
 		fetch(
-			branchesUrl,
+			pullRequestsUrl + '?context=edit&per_page=100&status=push_md_active,push_md_merged,push_md_closed&_fields=id,title,status,date,modified,meta,push_md_preview_url',
 			{
 				credentials: 'same-origin',
 				headers: { 'X-WP-Nonce': nonce }
@@ -172,19 +182,39 @@
 			parseJsonResponse
 		).then(
 			function (data) {
-				renderBranches( data.branches || [] );
+				renderBranches( (data || []).map( normalizePullRequest ) );
 			}
 		).catch(
 			function (error) {
 				branchListEl.textContent = '';
-				setBranchMessage( error.message || __( 'Could not load preview branches.', 'push-md' ), 'is-error' );
+				setBranchMessage( error.message || __( 'Could not load Pull Requests.', 'push-md' ), 'is-error' );
 			}
 		);
 	}
 
+	function normalizePullRequest(item) {
+		var meta = item.meta || {};
+		return {
+			id: item.id,
+			branch: meta.push_md_branch || (item.title && (item.title.raw || item.title.rendered)) || '',
+			base_oid: meta.push_md_base_oid || '',
+			tip_oid: meta.push_md_tip_oid || '',
+			review_state: meta.push_md_review_state || 'pending',
+			description: item.content && (item.content.raw || item.content.rendered) ? (item.content.raw || stripHtml( item.content.rendered )) : '',
+			description_rendered: item.content && item.content.rendered ? item.content.rendered : '',
+			status: item.status || '',
+			url: item.push_md_preview_url || '',
+			pull_request_url: adminPageUrl + '&pr=' + item.id,
+			updated_at: Math.floor( Date.parse( item.modified || item.date || '' ) / 1000 )
+		};
+	}
+
 	function renderBranches(branches) {
 		branchListEl.textContent = '';
-		branches = Array.isArray( branches ) ? branches.slice( 0 ) : [];
+		branches                 = Array.isArray( branches ) ? branches.slice( 0 ) : [];
+		if (branchPanelEl) {
+			branchPanelEl.hidden = ! branches.length;
+		}
 		branches.sort(
 			function (left, right) {
 				return intval( right.updated_at ) - intval( left.updated_at );
@@ -192,16 +222,19 @@
 		);
 
 		if ( ! branches.length) {
-			setBranchMessage( __( 'No preview branches.', 'push-md' ), 'is-muted' );
+			setBranchMessage( __( 'No Pull Requests.', 'push-md' ), 'is-muted' );
 			return;
 		}
 
 		var activeBranches = [];
 		var mergedBranches = [];
+		var closedBranches = [];
 		branches.forEach(
 			function (branch) {
-				if (branch.merged_at) {
+				if (branch.status === 'push_md_merged') {
 					mergedBranches.push( branch );
+				} else if (branch.status === 'push_md_closed') {
+					closedBranches.push( branch );
 				} else {
 					activeBranches.push( branch );
 				}
@@ -210,13 +243,16 @@
 
 		setBranchMessage( '' );
 		if (activeBranches.length) {
-			branchListEl.appendChild( createBranchSection( __( 'Active previews', 'push-md' ), activeBranches, 'is-active' ) );
+			branchListEl.appendChild( createBranchSection( __( 'Open', 'push-md' ), activeBranches, 'is-active' ) );
 		}
 		if (mergedBranches.length) {
-			branchListEl.appendChild( createBranchSection( __( 'Merged branches', 'push-md' ), mergedBranches, 'is-merged' ) );
+			branchListEl.appendChild( createBranchSection( __( 'Merged', 'push-md' ), mergedBranches, 'is-merged' ) );
+		}
+		if (closedBranches.length) {
+			branchListEl.appendChild( createBranchSection( __( 'Closed', 'push-md' ), closedBranches, 'is-closed' ) );
 		}
 		if ( ! activeBranches.length) {
-			setBranchMessage( __( 'No active preview branches.', 'push-md' ), 'is-muted' );
+			setBranchMessage( __( 'No open Pull Requests.', 'push-md' ), 'is-muted' );
 		}
 	}
 
@@ -224,8 +260,8 @@
 		var section = document.createElement( 'div' );
 		var heading = document.createElement( 'h3' );
 
-		section.className = 'push-md-branch-section ' + className;
-		heading.className = 'push-md-branch-section-title';
+		section.className   = 'push-md-branch-section ' + className;
+		heading.className   = 'push-md-branch-section-title';
 		heading.textContent = title;
 		section.appendChild( heading );
 
@@ -241,22 +277,23 @@
 	function createBranchRow(branch) {
 		var branchName = String( branch.branch || '' );
 		var previewUrl = String( branch.url || '' );
-		var isMerged   = Boolean( branch.merged_at );
+		var isActive   = branch.status === 'push_md_active';
 		var row        = document.createElement( 'div' );
 		var details    = document.createElement( 'div' );
 		var actions    = document.createElement( 'div' );
-		var name       = document.createElement( 'code' );
+		var name       = document.createElement( 'a' );
 		var meta       = document.createElement( 'div' );
 		var preview    = document.createElement( 'a' );
 		var copy       = document.createElement( 'button' );
 		var merge      = document.createElement( 'button' );
 
-		row.className     = 'push-md-branch-row' + (isMerged ? ' is-merged' : '');
+		row.className     = 'push-md-branch-row' + (isActive ? '' : ' is-merged');
 		details.className = 'push-md-branch-details';
 		actions.className = 'push-md-branch-actions';
 		name.className    = 'push-md-branch-name';
 		meta.className    = 'push-md-branch-meta';
 		name.textContent  = branchName;
+		name.href         = branch.pull_request_url;
 
 		meta.appendChild(
 			createMetaItem(
@@ -270,20 +307,17 @@
 		if (branch.base_oid) {
 			meta.appendChild( createMetaItem( __( 'Base', 'push-md' ), shortOid( branch.base_oid ) ) );
 		}
-		if (branch.merged_at) {
-			meta.appendChild( createMetaItem( __( 'Merged', 'push-md' ), formatTimestamp( branch.merged_at ) ) );
-		}
-
 		details.appendChild( name );
+		details.appendChild( createReviewStateBadge( branch.review_state ) );
 		details.appendChild( meta );
-		details.appendChild( createChangedUrlList( branch.changed_urls || [], isMerged ) );
 
-		if (isMerged) {
-			merge.type        = 'button';
-			merge.className   = 'button';
-			merge.disabled    = true;
-			merge.textContent = __( 'Merged', 'push-md' );
-			actions.appendChild( merge );
+		var review         = document.createElement( 'a' );
+		review.className   = 'button';
+		review.href        = branch.pull_request_url;
+		review.textContent = __( 'Review', 'push-md' );
+		actions.appendChild( review );
+
+		if ( ! isActive) {
 			row.appendChild( details );
 			row.appendChild( actions );
 
@@ -316,7 +350,9 @@
 			}
 		);
 
-		actions.appendChild( preview );
+		if (previewUrl) {
+			actions.appendChild( preview );
+		}
 		actions.appendChild( copy );
 		actions.appendChild( merge );
 		row.appendChild( details );
@@ -326,10 +362,10 @@
 	}
 
 	function createMetaItem(label, value) {
-		var item        = document.createElement( 'span' );
-		var labelEl     = document.createElement( 'span' );
-		var valueEl     = document.createElement( 'strong' );
-		item.className  = 'push-md-branch-meta-item';
+		var item            = document.createElement( 'span' );
+		var labelEl         = document.createElement( 'span' );
+		var valueEl         = document.createElement( 'strong' );
+		item.className      = 'push-md-branch-meta-item';
 		labelEl.textContent = label + ': ';
 		valueEl.textContent = value;
 		item.appendChild( labelEl );
@@ -338,13 +374,26 @@
 		return item;
 	}
 
+	function reviewStateLabel(state) {
+		return reviewStates[state] && reviewStates[state].label ? reviewStates[state].label : state;
+	}
+
+	function createReviewStateBadge(state) {
+		var badge         = document.createElement( 'span' );
+		state             = String( state || 'pending' );
+		badge.className   = 'push-md-review-state is-' + state.replace( /[^a-z0-9_-]/g, '-' );
+		badge.textContent = reviewStateLabel( state );
+
+		return badge;
+	}
+
 	function createChangedUrlList(changedUrls, isMerged) {
-		var list = document.createElement( 'ul' );
+		var list       = document.createElement( 'ul' );
 		list.className = 'push-md-changed-url-list';
-		changedUrls = Array.isArray( changedUrls ) ? changedUrls : [];
+		changedUrls    = Array.isArray( changedUrls ) ? changedUrls : [];
 
 		if ( ! changedUrls.length) {
-			var empty = document.createElement( 'li' );
+			var empty         = document.createElement( 'li' );
 			empty.className   = 'is-muted';
 			empty.textContent = __( 'No changed preview URLs available.', 'push-md' );
 			list.appendChild( empty );
@@ -390,6 +439,454 @@
 		return __( 'Changed', 'push-md' );
 	}
 
+	function bootPullRequestReview() {
+		var view    = document.getElementById( 'push-md-pr-view' );
+		var message = document.getElementById( 'push-md-pr-message' );
+		if ( ! view || ! pullRequestsUrl || ! commentsUrl) {
+			return;
+		}
+
+		message.textContent = __( 'Loading Pull Request...', 'push-md' );
+		Promise.all(
+			[
+				fetch(
+					pullRequestsUrl + '/' + pullRequestId + '?context=edit&_fields=id,title,content,status,date,modified,meta,push_md_diff,push_md_preview_url',
+					{ credentials: 'same-origin', headers: { 'X-WP-Nonce': nonce } }
+				).then( parseJsonResponse ),
+				fetch(
+					commentsUrl + '?context=edit&post=' + pullRequestId + '&type=note&status=all&per_page=100&_fields=id,author_name,date,content,meta,parent,push_md_tip_oid',
+					{ credentials: 'same-origin', headers: { 'X-WP-Nonce': nonce } }
+				).then( parseJsonResponse )
+			]
+		).then(
+			function (results) {
+				message.textContent = '';
+				renderPullRequestReview( normalizePullRequest( results[0] ), results[0].push_md_diff || { files: [] }, results[1] || [] );
+			}
+		).catch(
+			function (error) {
+				view.textContent    = '';
+				message.textContent = error.message || __( 'Could not load Pull Request.', 'push-md' );
+				message.className   = 'push-md-branch-message is-error';
+			}
+		);
+	}
+
+	function renderPullRequestReview(pullRequest, diff, notes) {
+		var view         = document.getElementById( 'push-md-pr-view' );
+		var header       = document.createElement( 'div' );
+		var title        = document.createElement( 'h1' );
+		var status       = document.createElement( 'span' );
+		var reviewState  = createReviewStateBadge( pullRequest.review_state );
+		var statusGroup  = document.createElement( 'div' );
+		var meta         = document.createElement( 'div' );
+		var actions      = document.createElement( 'div' );
+		var isActive     = pullRequest.status === 'push_md_active';
+		var usedNoteIds  = {};
+		var generalNotes = notes.filter(
+			function (note) {
+				return ! note.meta || ! note.meta.push_md_path;
+			}
+		);
+
+		view.textContent      = '';
+		header.className      = 'push-md-pr-header';
+		title.textContent     = pullRequest.branch;
+		status.className      = 'push-md-pr-status ' + pullRequest.status;
+		status.textContent    = pullRequest.status === 'push_md_merged' ? __( 'Merged', 'push-md' ) : (pullRequest.status === 'push_md_closed' ? __( 'Closed', 'push-md' ) : __( 'Open', 'push-md' ));
+		statusGroup.className = 'push-md-pr-states';
+		statusGroup.appendChild( status );
+		statusGroup.appendChild( reviewState );
+		meta.className = 'push-md-branch-meta';
+		meta.appendChild( createMetaItem( __( 'Base', 'push-md' ), shortOid( pullRequest.base_oid ) ) );
+		meta.appendChild( createMetaItem( __( 'Tip', 'push-md' ), shortOid( pullRequest.tip_oid ) ) );
+		meta.appendChild( createMetaItem( __( 'Updated', 'push-md' ), formatTimestamp( pullRequest.updated_at ) ) );
+		actions.className = 'push-md-pr-actions';
+		if (isActive && pullRequest.url) {
+			var preview         = document.createElement( 'a' );
+			preview.className   = 'button';
+			preview.href        = pullRequest.url;
+			preview.target      = '_blank';
+			preview.rel         = 'noopener noreferrer';
+			preview.textContent = __( 'Preview', 'push-md' );
+			actions.appendChild( preview );
+
+			var merge         = document.createElement( 'button' );
+			merge.type        = 'button';
+			merge.className   = 'button button-primary';
+			merge.textContent = __( 'Merge', 'push-md' );
+			merge.addEventListener(
+				'click',
+				function () {
+					mergeBranch( pullRequest.branch, merge ); }
+			);
+			actions.appendChild( merge );
+		}
+		header.appendChild( statusGroup );
+		header.appendChild( title );
+		header.appendChild( meta );
+		header.appendChild( actions );
+		header.appendChild( createDescriptionPanel( pullRequest, isActive ) );
+		view.appendChild( header );
+		view.appendChild( createCommitHistoryPanel( diff && diff.commits ? diff.commits : [] ) );
+		view.appendChild( createConversationPanel( generalNotes, isActive, usedNoteIds ) );
+
+		var files = diff && Array.isArray( diff.files ) ? diff.files : [];
+		files.forEach(
+			function (file) {
+				view.appendChild( createDiffFile( file, notes, isActive, usedNoteIds ) );
+			}
+		);
+		if ( ! files.length) {
+			var empty         = document.createElement( 'div' );
+			empty.className   = 'push-md-panel';
+			empty.textContent = __( 'No changed files.', 'push-md' );
+			view.appendChild( empty );
+		}
+
+		var unplaced = notes.filter(
+			function (note) {
+				return note.meta && note.meta.push_md_path && ! usedNoteIds[note.id];
+			}
+		);
+		if (unplaced.length) {
+			var unplacedPanel         = document.createElement( 'div' );
+			var unplacedTitle         = document.createElement( 'h2' );
+			unplacedPanel.className   = 'push-md-panel';
+			unplacedTitle.textContent = __( 'Unplaced comments', 'push-md' );
+			unplacedPanel.appendChild( unplacedTitle );
+			unplaced.forEach(
+				function (note) {
+					unplacedPanel.appendChild( createNote( note, noteAnchorLabel( note ) ) ); }
+			);
+			view.appendChild( unplacedPanel );
+		}
+	}
+
+	function createDescriptionPanel(pullRequest, isActive) {
+		var panel         = document.createElement( 'section' );
+		var title         = document.createElement( 'h2' );
+		var description   = document.createElement( 'div' );
+		panel.className   = 'push-md-pr-description';
+		title.textContent = __( 'Description', 'push-md' );
+		panel.appendChild( title );
+		description.className = 'push-md-pr-description-content' + (pullRequest.description ? '' : ' is-empty');
+		description.innerHTML = pullRequest.description_rendered || '';
+
+		if ( ! isActive) {
+			if ( ! pullRequest.description) {
+				description.textContent = __( 'No description provided.', 'push-md' );
+			}
+			panel.appendChild( description );
+
+			return panel;
+		}
+
+		var form                    = document.createElement( 'form' );
+		var button                  = document.createElement( 'button' );
+		var initialContent          = description.innerHTML;
+		form.className              = 'push-md-pr-description-form';
+		description.contentEditable = 'true';
+		description.setAttribute( 'role', 'textbox' );
+		description.setAttribute( 'aria-multiline', 'true' );
+		description.setAttribute( 'data-placeholder', __( 'Describe this Pull Request.', 'push-md' ) );
+		button.type        = 'submit';
+		button.className   = 'button button-primary';
+		button.textContent = __( 'Save description', 'push-md' );
+		button.hidden      = true;
+		form.appendChild( description );
+		form.appendChild( button );
+		description.addEventListener(
+			'input',
+			function () {
+				description.classList.toggle( 'is-empty', '' === description.textContent.trim() );
+				button.hidden = description.innerHTML === initialContent;
+			}
+		);
+		form.addEventListener(
+			'submit',
+			function (event) {
+				event.preventDefault();
+				if (button.hidden) {
+					return;
+				}
+				button.disabled = true;
+				updatePullRequestDescription( description.textContent.trim() ? description.innerHTML : '' ).catch(
+					function (error) {
+						button.disabled = false;
+						window.alert( error.message || __( 'Could not save the Pull Request description.', 'push-md' ) );
+					}
+				);
+			}
+		);
+		panel.appendChild( form );
+
+		return panel;
+	}
+
+	function createCommitHistoryPanel(commits) {
+		var panel         = document.createElement( 'section' );
+		var title         = document.createElement( 'h2' );
+		var list          = document.createElement( 'ol' );
+		panel.className   = 'push-md-panel push-md-pr-commit-history';
+		title.textContent = __( 'Commit history', 'push-md' );
+		list.className    = 'push-md-pr-commit-list';
+		panel.appendChild( title );
+		panel.appendChild( list );
+		commits = Array.isArray( commits ) ? commits : [];
+		if ( ! commits.length) {
+			var empty         = document.createElement( 'li' );
+			empty.className   = 'is-empty';
+			empty.textContent = __( 'No commits in this Pull Request.', 'push-md' );
+			list.appendChild( empty );
+
+			return panel;
+		}
+
+		commits.forEach(
+			function (commit) {
+				var item            = document.createElement( 'li' );
+				var oid             = document.createElement( 'code' );
+				var copy            = document.createElement( 'div' );
+				var subject         = document.createElement( 'strong' );
+				oid.textContent     = shortOid( commit.oid );
+				subject.textContent = commit.subject || __( '(no message)', 'push-md' );
+				copy.className      = 'push-md-pr-commit-copy';
+				item.appendChild( oid );
+				copy.appendChild( subject );
+				if (commit.description) {
+					var description         = document.createElement( 'p' );
+					description.textContent = commit.description;
+					copy.appendChild( description );
+				}
+				item.appendChild( copy );
+				list.appendChild( item );
+			}
+		);
+
+		return panel;
+	}
+
+	function createConversationPanel(notes, isActive, usedNoteIds) {
+		var panel         = document.createElement( 'div' );
+		var title         = document.createElement( 'h2' );
+		var list          = document.createElement( 'div' );
+		panel.className   = 'push-md-panel push-md-conversation';
+		title.textContent = __( 'Conversation', 'push-md' );
+		list.className    = 'push-md-notes';
+		notes.forEach(
+			function (note) {
+				usedNoteIds[note.id] = true;
+				list.appendChild( createNote( note, '' ) );
+			}
+		);
+		panel.appendChild( title );
+		panel.appendChild( list );
+		if (isActive) {
+			panel.appendChild( createNoteForm( {}, __( 'Leave a comment', 'push-md' ), true ) );
+		}
+		return panel;
+	}
+
+	function createDiffFile(file, notes, isActive, usedNoteIds) {
+		var container       = document.createElement( 'section' );
+		var header          = document.createElement( 'div' );
+		var path            = document.createElement( 'code' );
+		var badge           = document.createElement( 'span' );
+		var rows            = document.createElement( 'div' );
+		container.className = 'push-md-diff-file';
+		header.className    = 'push-md-diff-header';
+		path.textContent    = file.path;
+		badge.className     = 'push-md-changed-action';
+		badge.textContent   = formatChangedAction( file.action );
+		header.appendChild( path );
+		header.appendChild( badge );
+		if (file.preview_url) {
+			var preview         = document.createElement( 'a' );
+			preview.href        = file.preview_url;
+			preview.target      = '_blank';
+			preview.rel         = 'noopener noreferrer';
+			preview.textContent = __( 'Preview file', 'push-md' );
+			header.appendChild( preview );
+		}
+		rows.className = 'push-md-diff-rows';
+		(file.rows || []).forEach(
+			function (row) {
+				var line              = document.createElement( 'div' );
+				var add               = document.createElement( 'button' );
+				var oldNumber         = document.createElement( 'span' );
+				var newNumber         = document.createElement( 'span' );
+				var content           = document.createElement( 'code' );
+				var anchorSide        = row.new_line !== null ? 'new' : 'old';
+				var anchorLine        = row.new_line !== null ? row.new_line : row.old_line;
+				line.className        = 'push-md-diff-line is-' + row.type;
+				add.type              = 'button';
+				add.className         = 'push-md-diff-add';
+				add.textContent       = '+';
+				add.title             = __( 'Comment on this line', 'push-md' );
+				add.disabled          = ! isActive;
+				oldNumber.textContent = row.old_line === null ? '' : row.old_line;
+				newNumber.textContent = row.new_line === null ? '' : row.new_line;
+				content.textContent   = row.content;
+				line.appendChild( add );
+				line.appendChild( oldNumber );
+				line.appendChild( newNumber );
+				line.appendChild( content );
+				if (isActive) {
+					add.addEventListener(
+						'click',
+						function () {
+							var existing = line.nextSibling;
+							if (existing && existing.classList && existing.classList.contains( 'push-md-inline-form' )) {
+								existing.remove();
+								return;
+							}
+							var form = createNoteForm(
+								{ push_md_path: file.path, push_md_side: anchorSide, push_md_line: anchorLine },
+								__( 'Comment on line', 'push-md' ) + ' ' + anchorLine
+							);
+							form.classList.add( 'push-md-inline-form' );
+							line.parentNode.insertBefore( form, line.nextSibling );
+						}
+					);
+				}
+				rows.appendChild( line );
+				appendAnchoredNotes( rows, notes, file.path, row, usedNoteIds );
+			}
+		);
+		container.appendChild( header );
+		container.appendChild( rows );
+		return container;
+	}
+
+	function appendAnchoredNotes(container, notes, path, row, usedNoteIds) {
+		notes.forEach(
+			function (note) {
+				var meta       = note.meta || {};
+				var matchesOld = meta.push_md_path === path && meta.push_md_side === 'old' && intval( meta.push_md_line ) === intval( row.old_line );
+				var matchesNew = meta.push_md_path === path && meta.push_md_side === 'new' && intval( meta.push_md_line ) === intval( row.new_line );
+				if (matchesOld || matchesNew) {
+					usedNoteIds[note.id] = true;
+					container.appendChild( createNote( note, noteAnchorLabel( note ) ) );
+				}
+			}
+		);
+	}
+
+	function createNote(note, label) {
+		var element         = document.createElement( 'article' );
+		var header          = document.createElement( 'div' );
+		var content         = document.createElement( 'div' );
+		element.className   = 'push-md-note';
+		header.className    = 'push-md-note-header';
+		var stateLabel      = note.meta && note.meta.push_md_review_state
+			? sprintf( __( 'Changed state to %s', 'push-md' ), reviewStateLabel( note.meta.push_md_review_state ) )
+			: '';
+		header.textContent  = (note.author_name || __( 'Reviewer', 'push-md' )) + (label ? ' · ' + label : '') + (stateLabel ? ' · ' + stateLabel : '');
+		content.className   = 'push-md-note-content';
+		content.textContent = note.content && (note.content.raw || note.content.rendered) ? (note.content.raw || stripHtml( note.content.rendered )) : '';
+		element.appendChild( header );
+		element.appendChild( content );
+		return element;
+	}
+
+	function createNoteForm(meta, label, allowReviewState) {
+		var form             = document.createElement( 'form' );
+		var textarea         = document.createElement( 'textarea' );
+		var button           = document.createElement( 'button' );
+		var stateSelect      = null;
+		form.className       = 'push-md-note-form';
+		textarea.rows        = 3;
+		textarea.placeholder = label;
+		button.type          = 'submit';
+		button.className     = 'button button-primary';
+		button.textContent   = __( 'Comment', 'push-md' );
+		form.appendChild( textarea );
+		if (allowReviewState) {
+			var stateField             = document.createElement( 'label' );
+			var stateFieldText         = document.createElement( 'span' );
+			stateSelect                = document.createElement( 'select' );
+			stateField.className       = 'push-md-note-state-field';
+			stateFieldText.textContent = __( 'Change state', 'push-md' );
+			var noChange               = document.createElement( 'option' );
+			noChange.value             = '';
+			noChange.textContent       = __( 'No state change', 'push-md' );
+			stateSelect.appendChild( noChange );
+			Object.keys( reviewStates ).forEach(
+				function (state) {
+					var option         = document.createElement( 'option' );
+					option.value       = state;
+					option.textContent = reviewStateLabel( state );
+					stateSelect.appendChild( option );
+				}
+			);
+			stateField.appendChild( stateFieldText );
+			stateField.appendChild( stateSelect );
+			form.appendChild( stateField );
+		}
+		form.appendChild( button );
+		form.addEventListener(
+			'submit',
+			function (event) {
+				event.preventDefault();
+				if ( ! textarea.value.trim()) {
+					return;
+				}
+				var submittedMeta = {};
+				Object.keys( meta ).forEach(
+					function (key) {
+						submittedMeta[key] = meta[key]; }
+				);
+				if (stateSelect && stateSelect.value) {
+					submittedMeta.push_md_review_state = stateSelect.value;
+				}
+				button.disabled = true;
+				postNote( textarea.value, submittedMeta ).catch(
+					function (error) {
+						button.disabled = false;
+						window.alert( error.message || __( 'Could not save comment.', 'push-md' ) );
+					}
+				);
+			}
+		);
+		return form;
+	}
+
+	function postNote(content, meta) {
+		return fetch(
+			commentsUrl,
+			{
+				method: 'POST',
+				credentials: 'same-origin',
+				headers: { 'Content-Type': 'application/json', 'X-WP-Nonce': nonce },
+				body: JSON.stringify( { post: pullRequestId, type: 'note', content: content, meta: meta } )
+			}
+		).then( parseJsonResponse ).then( bootPullRequestReview );
+	}
+
+	function updatePullRequestDescription(content) {
+		return fetch(
+			pullRequestsUrl + '/' + pullRequestId,
+			{
+				method: 'POST',
+				credentials: 'same-origin',
+				headers: { 'Content-Type': 'application/json', 'X-WP-Nonce': nonce },
+				body: JSON.stringify( { content: content } )
+			}
+		).then( parseJsonResponse ).then( bootPullRequestReview );
+	}
+
+	function noteAnchorLabel(note) {
+		var meta = note.meta || {};
+		return String( meta.push_md_path || '' ) + ':' + String( meta.push_md_line || '' ) + ' (' + String( meta.push_md_side || '' ) + ')';
+	}
+
+	function stripHtml(value) {
+		var element       = document.createElement( 'div' );
+		element.innerHTML = String( value || '' );
+		return element.textContent || '';
+	}
+
 	function mergeBranch(branchName, button) {
 		if ( ! mergeBranchUrl) {
 			return;
@@ -419,8 +916,12 @@
 		).then(
 			function (data) {
 				setBranchMessage( sprintf( __( 'Merged %s into live content.', 'push-md' ), data.branch || branchName ), 'is-success' );
-				fetchBranches();
-				poll();
+				if (pullRequestId) {
+					bootPullRequestReview();
+				} else {
+					fetchBranches();
+					poll();
+				}
 			}
 		).catch(
 			function (error) {

--- a/plugins/push-md/class-push-md-admin.php
+++ b/plugins/push-md/class-push-md-admin.php
@@ -13,9 +13,8 @@ class Push_MD_Admin {
 	const REST_NAMESPACE = 'push-md/v1';
 	const STATUS_ROUTE   = '/seed-status';
 	const RETRY_ROUTE    = '/seed-retry';
-	const BRANCHES_ROUTE = '/branches';
 	const MERGE_ROUTE    = '/branches/merge';
-	const ASSET_VERSION  = '0.6.8';
+	const ASSET_VERSION  = '0.7.1';
 
 	public static function bootstrap() {
 		add_action( 'admin_menu', array( __CLASS__, 'register_menu' ) );
@@ -76,15 +75,6 @@ class Push_MD_Admin {
 		);
 		register_rest_route(
 			self::REST_NAMESPACE,
-			self::BRANCHES_ROUTE,
-			array(
-				'methods'             => 'GET',
-				'callback'            => array( __CLASS__, 'rest_branches' ),
-				'permission_callback' => array( __CLASS__, 'admin_only' ),
-			)
-		);
-		register_rest_route(
-			self::REST_NAMESPACE,
 			self::MERGE_ROUTE,
 			array(
 				'methods'             => 'POST',
@@ -117,14 +107,6 @@ class Push_MD_Admin {
 		Push_MD_Seeder::tick();
 
 		return rest_ensure_response( Push_MD_Seeder::get_progress() );
-	}
-
-	public static function rest_branches() {
-		return rest_ensure_response(
-			array(
-				'branches' => Push_MD_Plugin::list_preview_branches(),
-			)
-		);
 	}
 
 	public static function rest_merge_branch( WP_REST_Request $request ) {
@@ -170,17 +152,24 @@ class Push_MD_Admin {
 			return;
 		}
 
+		$pull_request_id = isset( $_GET['pr'] ) ? absint( wp_unslash( $_GET['pr'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Selects a read-only admin view.
+		if ( $pull_request_id ) {
+			self::render_pull_request_page( $pull_request_id );
+			return;
+		}
+
 		// Drive the seeder before painting so the first screen already
 		// has real checkout state whenever the host can do quick work.
 		Push_MD_Seeder::drive( 1.5 );
-		$progress     = Push_MD_Seeder::get_progress();
-		$nonce        = wp_create_nonce( 'wp_rest' );
-		$status_url   = esc_url_raw( rest_url( self::REST_NAMESPACE . self::STATUS_ROUTE ) );
-		$retry_url    = esc_url_raw( rest_url( self::REST_NAMESPACE . self::RETRY_ROUTE ) );
-		$branches_url = esc_url_raw( rest_url( self::REST_NAMESPACE . self::BRANCHES_ROUTE ) );
-		$merge_url    = esc_url_raw( rest_url( self::REST_NAMESPACE . self::MERGE_ROUTE ) );
-		$git_url      = esc_url_raw( rest_url( Push_MD_Plugin::ROUTE_NAMESPACE . '/md.git' ) );
-		$user         = wp_get_current_user();
+		$progress          = Push_MD_Seeder::get_progress();
+		$nonce             = wp_create_nonce( 'wp_rest' );
+		$status_url        = esc_url_raw( rest_url( self::REST_NAMESPACE . self::STATUS_ROUTE ) );
+		$retry_url         = esc_url_raw( rest_url( self::REST_NAMESPACE . self::RETRY_ROUTE ) );
+		$pull_requests_url = esc_url_raw( rest_url( 'wp/v2/push-md-pull-requests' ) );
+		$comments_url      = esc_url_raw( rest_url( 'wp/v2/comments' ) );
+		$merge_url         = esc_url_raw( rest_url( self::REST_NAMESPACE . self::MERGE_ROUTE ) );
+		$git_url           = esc_url_raw( rest_url( Push_MD_Plugin::ROUTE_NAMESPACE . '/md.git' ) );
+		$user              = wp_get_current_user();
 		if ( $user && $user->exists() ) {
 			$git_url = self::add_username_to_url( $git_url, $user->user_login );
 		}
@@ -213,8 +202,11 @@ class Push_MD_Admin {
 			'nonce'           => $nonce,
 			'statusUrl'       => $status_url,
 			'retryUrl'        => $retry_url,
-			'branchesUrl'     => $branches_url,
+			'pullRequestsUrl' => $pull_requests_url,
+			'commentsUrl'     => $comments_url,
 			'mergeBranchUrl'  => $merge_url,
+			'adminPageUrl'    => admin_url( 'tools.php?page=' . self::PAGE_SLUG ),
+			'reviewStates'    => Push_MD_Pull_Requests::get_review_states(),
 			'remoteUrl'       => $git_url,
 			'cloneCommand'    => $clone_command,
 			'checkoutDir'     => $site_slug,
@@ -245,6 +237,15 @@ class Push_MD_Admin {
 						<span class="push-md-state-dot" aria-hidden="true"></span>
 						<span id="push-md-state"><?php echo esc_html( $progress['state'] ); ?></span>
 					</div>
+				</div>
+
+				<div class="push-md-panel push-md-branches-panel" id="push-md-branches-panel" hidden>
+					<div class="push-md-branches-header">
+						<h2><?php esc_html_e( 'Pull Requests', 'push-md' ); ?></h2>
+						<button type="button" class="button" id="push-md-branches-refresh"><?php esc_html_e( 'Refresh', 'push-md' ); ?></button>
+					</div>
+					<div class="push-md-branch-message" id="push-md-branches-message" aria-live="polite"></div>
+					<div class="push-md-branch-list" id="push-md-branch-list"></div>
 				</div>
 
 				<div class="push-md-emulator-note">
@@ -321,15 +322,6 @@ class Push_MD_Admin {
 					</table>
 				</div>
 
-				<div class="push-md-panel push-md-branches-panel">
-					<div class="push-md-branches-header">
-						<h2><?php esc_html_e( 'Branch Previews', 'push-md' ); ?></h2>
-						<button type="button" class="button" id="push-md-branches-refresh"><?php esc_html_e( 'Refresh', 'push-md' ); ?></button>
-					</div>
-					<div class="push-md-branch-message" id="push-md-branches-message" aria-live="polite"></div>
-					<div class="push-md-branch-list" id="push-md-branch-list"></div>
-				</div>
-
 				<div class="push-md-panel push-md-commit-panel">
 					<h2><?php esc_html_e( 'Commit History', 'push-md' ); ?></h2>
 					<ul class="push-md-commit-list" id="push-md-commit-list"></ul>
@@ -358,6 +350,37 @@ class Push_MD_Admin {
 					</div>
 					<p class="push-md-message" id="push-md-message"><?php echo esc_html( $progress['message'] ); ?></p>
 				</div>
+			</div>
+		</div>
+		<?php
+	}
+
+	private static function render_pull_request_page( $pull_request_id ) {
+		$post = get_post( $pull_request_id );
+		if ( ! $post || Push_MD_Pull_Requests::POST_TYPE !== $post->post_type ) {
+			wp_die( esc_html__( 'Pull Request not found.', 'push-md' ) );
+		}
+
+		$config = array(
+			'nonce'           => wp_create_nonce( 'wp_rest' ),
+			'pullRequestsUrl' => esc_url_raw( rest_url( 'wp/v2/push-md-pull-requests' ) ),
+			'commentsUrl'     => esc_url_raw( rest_url( 'wp/v2/comments' ) ),
+			'mergeBranchUrl'  => esc_url_raw( rest_url( self::REST_NAMESPACE . self::MERGE_ROUTE ) ),
+			'adminPageUrl'    => admin_url( 'tools.php?page=' . self::PAGE_SLUG ),
+			'pullRequestId'   => $pull_request_id,
+			'reviewStates'    => Push_MD_Pull_Requests::get_review_states(),
+		);
+		wp_add_inline_script(
+			'push-md-admin-shell',
+			'window.pushMdAdminShell = ' . wp_json_encode( $config ) . ';',
+			'before'
+		);
+		?>
+		<div class="wrap push-md-shell-page" id="push-md-admin">
+			<div class="push-md-shell-frame push-md-review-frame">
+				<p><a href="<?php echo esc_url( admin_url( 'tools.php?page=' . self::PAGE_SLUG ) ); ?>">&larr; <?php esc_html_e( 'All Pull Requests', 'push-md' ); ?></a></p>
+				<div id="push-md-pr-message" class="push-md-branch-message" aria-live="polite"><?php esc_html_e( 'Loading Pull Request…', 'push-md' ); ?></div>
+				<div id="push-md-pr-view"></div>
 			</div>
 		</div>
 		<?php

--- a/plugins/push-md/class-push-md-plugin.php
+++ b/plugins/push-md/class-push-md-plugin.php
@@ -10,6 +10,8 @@ use WordPress\Git\Model\TreeEntry;
 use WordPress\Git\Protocol\GitProtocolEncoderPipe;
 use WordPress\Markdown\MarkdownConsumer;
 use WordPress\Markdown\MarkdownProducer;
+use WordPress\Merge\Diff\Diff;
+use WordPress\Merge\Diff\LineDiffer;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -85,6 +87,7 @@ class Push_MD_Plugin {
 
 		Push_MD_Seeder::bootstrap();
 		Push_MD_Admin::bootstrap();
+		Push_MD_Pull_Requests::bootstrap();
 	}
 
 	public static function on_activation() {
@@ -724,6 +727,8 @@ class Push_MD_Plugin {
 		if ( ! self::is_branch_preview_active() ) {
 			return;
 		}
+		$pull_request     = Push_MD_Pull_Requests::get_active_pull_request_for_branch( self::$active_preview_branch );
+		$pull_request_url = $pull_request ? Push_MD_Pull_Requests::get_pull_request_admin_url( $pull_request->ID ) : '';
 		?>
 		<div id="push-md-branch-preview-notice" style="position:fixed;right:16px;bottom:16px;z-index:99999;padding:8px 10px;border-radius:4px;background:#1d2327;color:#f6f7f7;font:13px/1.4 -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;box-shadow:0 6px 18px rgba(0,0,0,.2);">
 			<?php
@@ -735,6 +740,9 @@ class Push_MD_Plugin {
 				)
 			);
 			?>
+			<?php if ( $pull_request_url ) : ?>
+				<a href="<?php echo esc_url( $pull_request_url ); ?>" style="margin-left:8px;color:#72aee6;text-decoration:underline;"><?php esc_html_e( 'Review pull request', 'push-md' ); ?></a>
+			<?php endif; ?>
 		</div>
 		<?php
 	}
@@ -3158,6 +3166,135 @@ class Push_MD_Plugin {
 		return $items;
 	}
 
+	public static function get_pull_request_diff( $post_id ) {
+		$post = get_post( $post_id );
+		if ( ! $post || Push_MD_Pull_Requests::POST_TYPE !== $post->post_type ) {
+			return array(
+				'files'   => array(),
+				'commits' => array(),
+			);
+		}
+
+		$base_oid = get_post_meta( $post->ID, 'push_md_base_oid', true );
+		$tip_oid  = get_post_meta( $post->ID, 'push_md_tip_oid', true );
+		if ( ! is_string( $base_oid ) || ! is_string( $tip_oid ) || Commit::is_null_hash( $tip_oid ) ) {
+			return array(
+				'files'   => array(),
+				'commits' => array(),
+			);
+		}
+
+		$repository = self::open_repository();
+		if ( ! $repository->has_object( $tip_oid ) || ( ! Commit::is_null_hash( $base_oid ) && ! $repository->has_object( $base_oid ) ) ) {
+			return array(
+				'files'   => array(),
+				'commits' => array(),
+			);
+		}
+
+		$commits = array();
+		try {
+			$commit_oids = $repository->get_commits_range(
+				$tip_oid,
+				$base_oid,
+				array( 'include_ancestor' => false )
+			);
+			foreach ( array_slice( $commit_oids, 0, 100 ) as $commit_oid ) {
+				$commit      = $repository->read_object( $commit_oid )->as_commit();
+				$message     = trim( (string) $commit->message );
+				$message     = preg_split( "/\r\n|\n|\r/", $message );
+				$subject     = is_array( $message ) && ! empty( $message ) ? trim( array_shift( $message ) ) : '';
+				$description = is_array( $message ) ? trim( implode( "\n", $message ) ) : '';
+				$commits[]   = array(
+					'oid'         => $commit_oid,
+					'subject'     => '' !== $subject ? $subject : __( '(no message)', 'push-md' ),
+					'description' => $description,
+				);
+			}
+		} catch ( Throwable $exception ) {
+			unset( $exception );
+		}
+
+		$base_files = Commit::is_null_hash( $base_oid )
+			? array()
+			: self::read_repository_entries_from_commit( $repository, $base_oid );
+		$tip_files  = self::read_repository_entries_from_commit( $repository, $tip_oid );
+		$paths      = self::calculate_repository_changed_paths( $base_files, $tip_files );
+		ksort( $paths );
+		$branch_name = get_post_meta( $post->ID, 'push_md_branch', true );
+		$line_differ = new LineDiffer();
+		$files       = array();
+
+		foreach ( array_keys( $paths ) as $path ) {
+			$old_entry = isset( $base_files[ $path ] ) ? $base_files[ $path ] : null;
+			$new_entry = isset( $tip_files[ $path ] ) ? $tip_files[ $path ] : null;
+			$old_text  = is_array( $old_entry ) ? $old_entry['content'] : '';
+			$new_text  = is_array( $new_entry ) ? $new_entry['content'] : '';
+			$rows      = array();
+			$old_line  = 1;
+			$new_line  = 1;
+
+			foreach ( $line_differ->diff( $old_text, $new_text )->get_changes() as $change ) {
+				$row = array(
+					'type'     => 'context',
+					'old_line' => null,
+					'new_line' => null,
+					'content'  => rtrim( $change[1], "\n" ),
+				);
+				if ( Diff::DIFF_DELETE === $change[0] ) {
+					$row['type']     = 'deleted';
+					$row['old_line'] = $old_line;
+					++$old_line;
+				} elseif ( Diff::DIFF_INSERT === $change[0] ) {
+					$row['type']     = 'added';
+					$row['new_line'] = $new_line;
+					++$new_line;
+				} else {
+					$row['old_line'] = $old_line;
+					$row['new_line'] = $new_line;
+					++$old_line;
+					++$new_line;
+				}
+				$rows[] = $row;
+			}
+
+			$preview_entry = $new_entry ? $new_entry : $old_entry;
+			$files[]       = array(
+				'action'      => $new_entry ? ( $old_entry ? 'updated' : 'created' ) : 'deleted',
+				'path'        => $path,
+				'preview_url' => Push_MD_Pull_Requests::STATUS_ACTIVE === $post->post_status
+					? self::get_preview_url_for_repository_path( $path, $preview_entry, $branch_name )
+					: '',
+				'rows'        => $rows,
+			);
+		}
+
+		return array(
+			'files'   => $files,
+			'commits' => $commits,
+		);
+	}
+
+	public static function pull_request_diff_has_anchor( $post_id, $path, $side, $line ) {
+		if ( ! in_array( $side, array( 'old', 'new' ), true ) || $line < 1 ) {
+			return false;
+		}
+
+		$diff = self::get_pull_request_diff( $post_id );
+		foreach ( $diff['files'] as $file ) {
+			if ( $path !== $file['path'] ) {
+				continue;
+			}
+			foreach ( $file['rows'] as $row ) {
+				if ( $line === $row[ $side . '_line' ] ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
 	private static function get_preview_url_for_repository_path( $path, $entry, $branch_name ) {
 		$branch_url = self::get_preview_branch_url( $branch_name );
 		if ( ! is_array( $entry ) || TreeEntry::FILE_MODE_SYMBOLIC_LINK === $entry['mode'] ) {
@@ -3240,6 +3377,10 @@ class Push_MD_Plugin {
 	}
 
 	public static function get_preview_branches() {
+		if ( class_exists( 'Push_MD_Pull_Requests' ) ) {
+			return Push_MD_Pull_Requests::get_branch_metadata_map();
+		}
+
 		$branches = get_option( self::BRANCH_PREVIEWS_OPTION, array() );
 
 		return is_array( $branches ) ? $branches : array();
@@ -3265,32 +3406,11 @@ class Push_MD_Plugin {
 	}
 
 	private static function update_preview_branch_metadata( $push_header ) {
-		$branches    = self::get_preview_branches();
-		$branch_name = $push_header['branch_name'];
-		$existing    = isset( $branches[ $branch_name ] ) && is_array( $branches[ $branch_name ] )
-			? $branches[ $branch_name ]
-			: array();
-		$created_at  = isset( $existing['created_at'] ) && ! self::is_preview_branch_merged( $existing ) ? intval( $existing['created_at'] ) : time();
-
-		$branches[ $branch_name ] = array(
-			'branch'     => $branch_name,
-			'ref'        => $push_header['ref_name'],
-			'owner'      => get_current_user_id(),
-			'base_oid'   => $push_header['base_oid'],
-			'tip_oid'    => $push_header['new_oid'],
-			'url'        => self::get_preview_branch_url( $branch_name ),
-			'created_at' => $created_at,
-			'updated_at' => time(),
-		);
-
-		update_option( self::BRANCH_PREVIEWS_OPTION, $branches, false );
+		Push_MD_Pull_Requests::update_active_pull_request( $push_header );
 	}
 
 	private static function delete_preview_branch_metadata( $branch_name ) {
-		$branches = self::get_preview_branches();
-		unset( $branches[ $branch_name ] );
-
-		update_option( self::BRANCH_PREVIEWS_OPTION, $branches, false );
+		Push_MD_Pull_Requests::close_pull_request( $branch_name );
 	}
 
 	public static function list_preview_branches() {
@@ -3354,27 +3474,17 @@ class Push_MD_Plugin {
 		$branch_metadata = isset( $branches[ $branch_name ] ) && is_array( $branches[ $branch_name ] )
 			? $branches[ $branch_name ]
 			: array();
+		if ( empty( $branch_metadata ) ) {
+			throw new Exception( 'Active Pull Request not found.' );
+		}
 		if ( self::is_preview_branch_merged( $branch_metadata ) ) {
 			throw new Exception( 'Preview branch has already been merged.' );
 		}
 
-		$base_oid     = isset( $branch_metadata['base_oid'] ) && is_string( $branch_metadata['base_oid'] )
+		$base_oid   = isset( $branch_metadata['base_oid'] ) && is_string( $branch_metadata['base_oid'] )
 			? $branch_metadata['base_oid']
 			: $current_head;
-		$merged_oid   = $branch_tip;
-		$changed_urls = array();
-		try {
-			$changed_urls = self::get_preview_branch_changed_url_items(
-				$repository,
-				array(
-					'branch_name' => $branch_name,
-					'base_oid'    => $base_oid,
-					'new_oid'     => $branch_tip,
-				)
-			);
-		} catch ( Throwable $exception ) {
-			$changed_urls = array();
-		}
+		$merged_oid = $branch_tip;
 
 		$can_fast_forward = true;
 		$range_exception  = null;
@@ -3408,27 +3518,7 @@ class Push_MD_Plugin {
 			$repository->set_branch_tip( 'refs/heads/' . self::DEFAULT_BRANCH, $merged_oid );
 		}
 
-		$merged_at                 = time();
-		$archived_branch           = $branch_metadata;
-		$archived_branch['branch'] = $branch_name;
-		$archived_branch['ref']    = $ref_name;
-		if ( ! isset( $archived_branch['owner'] ) ) {
-			$archived_branch['owner'] = get_current_user_id();
-		}
-		if ( ! isset( $archived_branch['created_at'] ) ) {
-			$archived_branch['created_at'] = $merged_at;
-		}
-		$archived_branch['updated_at']     = isset( $archived_branch['updated_at'] ) ? intval( $archived_branch['updated_at'] ) : $merged_at;
-		$archived_branch['base_oid']       = $base_oid;
-		$archived_branch['tip_oid']        = $branch_tip;
-		$archived_branch['merged_oid']     = $merged_oid;
-		$archived_branch['merged_at']      = $merged_at;
-		$archived_branch['merged_by']      = get_current_user_id();
-		$archived_branch['url']            = self::get_preview_branch_url( $branch_name );
-		$archived_branch['changed_urls']   = $changed_urls;
-		$archived_branch['ref_deleted_at'] = 0;
-		$branches[ $branch_name ]          = $archived_branch;
-		update_option( self::BRANCH_PREVIEWS_OPTION, $branches, false );
+		Push_MD_Pull_Requests::merge_pull_request( $branch_name, $merged_oid );
 
 		$branch_deleted = false;
 		try {
@@ -3438,13 +3528,6 @@ class Push_MD_Plugin {
 			}
 		} catch ( Throwable $exception ) {
 			$branch_deleted = false;
-		}
-
-		if ( $branch_deleted ) {
-			$branches                                      = self::get_preview_branches();
-			$branches[ $branch_name ]['ref_deleted_at']    = time();
-			$branches[ $branch_name ]['ref_delete_failed'] = false;
-			update_option( self::BRANCH_PREVIEWS_OPTION, $branches, false );
 		}
 
 		return array(

--- a/plugins/push-md/class-push-md-pull-requests.php
+++ b/plugins/push-md/class-push-md-pull-requests.php
@@ -1,0 +1,728 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Stores preview branches as Pull Requests and exposes their review data.
+ */
+class Push_MD_Pull_Requests {
+
+	const POST_TYPE     = 'push_md_pull_request';
+	const STATUS_ACTIVE = 'push_md_active';
+	const STATUS_MERGED = 'push_md_merged';
+	const STATUS_CLOSED = 'push_md_closed';
+
+	private static $review_states = null;
+
+	public static function bootstrap() {
+		add_action( 'init', array( __CLASS__, 'register_data_model' ), 5 );
+		add_action( 'init', array( __CLASS__, 'migrate_legacy_branch_previews' ), 30 );
+		add_action( 'rest_api_init', array( __CLASS__, 'register_rest_fields' ) );
+		add_filter( 'rest_pre_insert_' . self::POST_TYPE, array( __CLASS__, 'validate_rest_pull_request_write' ), 10, 2 );
+		add_filter( 'rest_pre_insert_comment', array( __CLASS__, 'validate_rest_note' ), 10, 2 );
+		add_action( 'rest_after_insert_comment', array( __CLASS__, 'store_note_tip_oid' ), 10, 3 );
+		add_filter( 'rest_pre_dispatch', array( __CLASS__, 'guard_review_routes' ), 10, 3 );
+		add_filter( 'rest_request_before_callbacks', array( __CLASS__, 'protect_review_request' ), 10, 3 );
+		add_filter( 'notify_post_author', array( __CLASS__, 'disable_note_notifications' ), 10, 2 );
+		add_filter( 'notify_moderator', array( __CLASS__, 'disable_note_notifications' ), 10, 2 );
+	}
+
+	public static function register_data_model() {
+		$review_states = array_keys( self::get_review_states() );
+
+		register_post_status(
+			self::STATUS_ACTIVE,
+			array(
+				'label'       => __( 'Open', 'push-md' ),
+				'public'      => false,
+				'internal'    => true,
+				'show_in_rest' => true,
+			)
+		);
+		register_post_status(
+			self::STATUS_MERGED,
+			array(
+				'label'       => __( 'Merged', 'push-md' ),
+				'public'      => false,
+				'internal'    => true,
+				'show_in_rest' => true,
+			)
+		);
+		register_post_status(
+			self::STATUS_CLOSED,
+			array(
+				'label'       => __( 'Closed', 'push-md' ),
+				'public'      => false,
+				'internal'    => true,
+				'show_in_rest' => true,
+			)
+		);
+
+		register_post_type(
+			self::POST_TYPE,
+			array(
+				'label'              => __( 'Push MD Pull Requests', 'push-md' ),
+				'public'             => false,
+				'publicly_queryable' => false,
+				'show_ui'            => false,
+				'show_in_rest'       => true,
+				'rest_base'          => 'push-md-pull-requests',
+				'supports'           => array(
+					'title',
+					'author',
+					'comments',
+					'custom-fields',
+					'editor' => array( 'notes' => true ),
+				),
+				'capabilities'       => array(
+					'read_post'          => 'manage_options',
+					'read_private_posts' => 'manage_options',
+					'edit_post'          => 'manage_options',
+					'edit_posts'         => 'manage_options',
+					'edit_others_posts'  => 'manage_options',
+					'create_posts'       => 'do_not_allow',
+					'publish_posts'      => 'do_not_allow',
+					'delete_post'        => 'do_not_allow',
+					'delete_posts'       => 'do_not_allow',
+				),
+			)
+		);
+
+		$post_meta = array(
+			'push_md_branch'      => 'string',
+			'push_md_base_oid'    => 'string',
+			'push_md_tip_oid'     => 'string',
+			'push_md_merged_oid'  => 'string',
+			'push_md_merged_by'   => 'integer',
+		);
+		foreach ( $post_meta as $meta_key => $type ) {
+			register_post_meta(
+				self::POST_TYPE,
+				$meta_key,
+				array(
+					'type'              => $type,
+					'single'            => true,
+					'show_in_rest'      => true,
+					'sanitize_callback' => 'integer' === $type ? 'absint' : 'sanitize_text_field',
+					'auth_callback'     => array( __CLASS__, 'can_access_review_meta' ),
+				)
+			);
+		}
+		register_post_meta(
+			self::POST_TYPE,
+			'push_md_review_state',
+			array(
+				'type'              => 'string',
+				'single'            => true,
+				'default'           => 'pending',
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'    => 'string',
+						'enum'    => $review_states,
+						'default' => 'pending',
+					),
+				),
+				'sanitize_callback' => array( __CLASS__, 'sanitize_review_state' ),
+				'auth_callback'     => array( __CLASS__, 'can_access_review_meta' ),
+			)
+		);
+
+		register_meta(
+			'comment',
+			'push_md_path',
+			array(
+				'type'              => 'string',
+				'single'            => true,
+				'show_in_rest'      => true,
+				'sanitize_callback' => 'sanitize_text_field',
+				'auth_callback'     => array( __CLASS__, 'can_access_note_meta' ),
+			)
+		);
+		register_meta(
+			'comment',
+			'push_md_side',
+			array(
+				'type'              => 'string',
+				'single'            => true,
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type' => 'string',
+						'enum' => array( 'old', 'new' ),
+					),
+				),
+				'sanitize_callback' => 'sanitize_key',
+				'auth_callback'     => array( __CLASS__, 'can_access_note_meta' ),
+			)
+		);
+		register_meta(
+			'comment',
+			'push_md_line',
+			array(
+				'type'              => 'integer',
+				'single'            => true,
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'    => 'integer',
+						'minimum' => 1,
+					),
+				),
+				'sanitize_callback' => 'absint',
+				'auth_callback'     => array( __CLASS__, 'can_access_note_meta' ),
+			)
+		);
+		register_meta(
+			'comment',
+			'push_md_review_state',
+			array(
+				'type'              => 'string',
+				'single'            => true,
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type' => 'string',
+						'enum' => $review_states,
+					),
+				),
+				'sanitize_callback' => array( __CLASS__, 'sanitize_review_state' ),
+				'auth_callback'     => array( __CLASS__, 'can_access_note_meta' ),
+			)
+		);
+	}
+
+	public static function get_review_states() {
+		if ( null !== self::$review_states ) {
+			return self::$review_states;
+		}
+
+		$defaults = array(
+			'pending'  => array( 'label' => __( 'Pending', 'push-md' ) ),
+			'approved' => array( 'label' => __( 'Approved', 'push-md' ) ),
+		);
+		$states   = apply_filters( 'push_md_review_states', $defaults );
+		$states   = is_array( $states ) ? $states : array();
+		$clean    = array();
+		foreach ( $states as $state => $config ) {
+			$state = sanitize_key( $state );
+			$label = is_array( $config ) && isset( $config['label'] ) ? sanitize_text_field( $config['label'] ) : '';
+			if ( '' === $state || '' === $label ) {
+				continue;
+			}
+			$clean[ $state ] = array( 'label' => $label );
+		}
+		foreach ( $defaults as $state => $config ) {
+			if ( ! isset( $clean[ $state ] ) ) {
+				$clean[ $state ] = $config;
+			}
+		}
+
+		self::$review_states = $clean;
+
+		return self::$review_states;
+	}
+
+	public static function sanitize_review_state( $state ) {
+		$state = sanitize_key( $state );
+
+		return isset( self::get_review_states()[ $state ] ) ? $state : 'pending';
+	}
+
+	public static function register_rest_fields() {
+		register_rest_field(
+			self::POST_TYPE,
+			'push_md_diff',
+			array(
+				'get_callback' => array( __CLASS__, 'get_rest_diff' ),
+				'schema'       => array(
+					'description' => __( 'Changed files and line diff for this Pull Request.', 'push-md' ),
+					'type'        => 'object',
+					'context'     => array( 'edit' ),
+					'readonly'    => true,
+				),
+			)
+		);
+		register_rest_field(
+			self::POST_TYPE,
+			'push_md_preview_url',
+			array(
+				'get_callback' => array( __CLASS__, 'get_rest_preview_url' ),
+				'schema'       => array(
+					'type'     => 'string',
+					'format'   => 'uri',
+					'context'  => array( 'edit' ),
+					'readonly' => true,
+				),
+			)
+		);
+		register_rest_field(
+			'comment',
+			'push_md_tip_oid',
+			array(
+				'get_callback' => array( __CLASS__, 'get_rest_note_tip_oid' ),
+				'schema'       => array(
+					'type'     => 'string',
+					'context'  => array( 'edit' ),
+					'readonly' => true,
+				),
+			)
+		);
+	}
+
+	public static function can_access_review_meta() {
+		return current_user_can( 'manage_options' );
+	}
+
+	public static function can_access_note_meta( $allowed, $meta_key, $comment_id ) {
+		unset( $allowed, $meta_key );
+
+		$comment = get_comment( $comment_id );
+
+		return current_user_can( 'manage_options' )
+			&& $comment
+			&& self::POST_TYPE === get_post_type( $comment->comment_post_ID );
+	}
+
+	public static function validate_rest_pull_request_write( $prepared_post, WP_REST_Request $request ) {
+		if ( ! $request->get_param( 'id' ) ) {
+			return new WP_Error(
+				'push_md_pull_request_read_only',
+				__( 'Push MD Pull Requests are created only by Git branch operations.', 'push-md' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$post = get_post( intval( $request->get_param( 'id' ) ) );
+		if ( ! $post || self::STATUS_ACTIVE !== $post->post_status ) {
+			return new WP_Error(
+				'push_md_pull_request_read_only',
+				__( 'Merged and closed Pull Requests are read-only.', 'push-md' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		$body = $request->get_json_params();
+		$body = is_array( $body ) ? $body : $request->get_body_params();
+		if ( ! is_array( $body ) || array( 'content' ) !== array_keys( $body ) ) {
+			return new WP_Error(
+				'push_md_pull_request_fields_read_only',
+				__( 'Only the Pull Request description can be updated directly.', 'push-md' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return $prepared_post;
+	}
+
+	public static function migrate_legacy_branch_previews() {
+		$branches = get_option( Push_MD_Plugin::BRANCH_PREVIEWS_OPTION, null );
+		if ( ! is_array( $branches ) ) {
+			return;
+		}
+
+		foreach ( $branches as $branch_name => $branch ) {
+			if ( ! is_array( $branch ) || '' === (string) $branch_name ) {
+				return;
+			}
+
+			$status = empty( $branch['merged_at'] ) ? self::STATUS_ACTIVE : self::STATUS_MERGED;
+			if ( self::find_pull_request( $branch_name, $status ) ) {
+				continue;
+			}
+
+			$post_id = self::insert_pull_request(
+				$branch_name,
+				$status,
+				isset( $branch['owner'] ) ? intval( $branch['owner'] ) : 0,
+				isset( $branch['base_oid'] ) ? $branch['base_oid'] : '',
+				isset( $branch['tip_oid'] ) ? $branch['tip_oid'] : '',
+				isset( $branch['created_at'] ) ? intval( $branch['created_at'] ) : time(),
+				isset( $branch['updated_at'] ) ? intval( $branch['updated_at'] ) : time()
+			);
+			if ( is_wp_error( $post_id ) ) {
+				return;
+			}
+			if ( ! empty( $branch['merged_oid'] ) ) {
+				update_post_meta( $post_id, 'push_md_merged_oid', sanitize_text_field( $branch['merged_oid'] ) );
+			}
+			if ( ! empty( $branch['merged_by'] ) ) {
+				update_post_meta( $post_id, 'push_md_merged_by', intval( $branch['merged_by'] ) );
+			}
+		}
+
+		delete_option( Push_MD_Plugin::BRANCH_PREVIEWS_OPTION );
+	}
+
+	public static function update_active_pull_request( $push_header ) {
+		$branch_name = $push_header['branch_name'];
+		$post        = self::find_pull_request( $branch_name, self::STATUS_ACTIVE );
+		if ( ! $post ) {
+			$post_id = self::insert_pull_request(
+				$branch_name,
+				self::STATUS_ACTIVE,
+				get_current_user_id(),
+				$push_header['base_oid'],
+				$push_header['new_oid'],
+				time(),
+				time()
+			);
+			if ( is_wp_error( $post_id ) ) {
+				throw new Exception( $post_id->get_error_message() );
+			}
+
+			return $post_id;
+		}
+
+		update_post_meta( $post->ID, 'push_md_base_oid', sanitize_text_field( $push_header['base_oid'] ) );
+		update_post_meta( $post->ID, 'push_md_tip_oid', sanitize_text_field( $push_header['new_oid'] ) );
+		$result = wp_update_post(
+			array(
+				'ID'            => $post->ID,
+				'post_modified' => current_time( 'mysql' ),
+			),
+			true
+		);
+		if ( is_wp_error( $result ) ) {
+			throw new Exception( $result->get_error_message() );
+		}
+
+		return $post->ID;
+	}
+
+	public static function close_pull_request( $branch_name ) {
+		$post = self::find_pull_request( $branch_name, self::STATUS_ACTIVE );
+		if ( ! $post ) {
+			return;
+		}
+
+		$result = wp_update_post(
+			array(
+				'ID'             => $post->ID,
+				'post_status'    => self::STATUS_CLOSED,
+				'comment_status' => 'closed',
+				'post_modified'  => current_time( 'mysql' ),
+			),
+			true
+		);
+		if ( is_wp_error( $result ) ) {
+			throw new Exception( $result->get_error_message() );
+		}
+	}
+
+	public static function merge_pull_request( $branch_name, $merged_oid ) {
+		$post = self::find_pull_request( $branch_name, self::STATUS_ACTIVE );
+		if ( ! $post ) {
+			throw new Exception( 'Active Pull Request not found.' );
+		}
+
+		update_post_meta( $post->ID, 'push_md_merged_oid', sanitize_text_field( $merged_oid ) );
+		update_post_meta( $post->ID, 'push_md_merged_by', get_current_user_id() );
+		$result = wp_update_post(
+			array(
+				'ID'             => $post->ID,
+				'post_status'    => self::STATUS_MERGED,
+				'comment_status' => 'closed',
+				'post_modified'  => current_time( 'mysql' ),
+			),
+			true
+		);
+		if ( is_wp_error( $result ) ) {
+			throw new Exception( $result->get_error_message() );
+		}
+	}
+
+	public static function get_branch_metadata_map() {
+		$posts    = get_posts(
+			array(
+				'post_type'      => self::POST_TYPE,
+				'post_status'    => array( self::STATUS_ACTIVE, self::STATUS_MERGED ),
+				'posts_per_page' => -1,
+				'no_found_rows'  => true,
+				'orderby'        => 'modified',
+				'order'          => 'DESC',
+			)
+		);
+		$branches = array();
+		foreach ( $posts as $post ) {
+			$branch_name = get_post_meta( $post->ID, 'push_md_branch', true );
+			if ( '' === $branch_name ) {
+				continue;
+			}
+			if ( isset( $branches[ $branch_name ] ) ) {
+				if ( self::STATUS_ACTIVE !== $post->post_status || empty( $branches[ $branch_name ]['merged_at'] ) ) {
+					continue;
+				}
+			}
+			$branches[ $branch_name ] = self::post_to_branch_metadata( $post );
+		}
+
+		return $branches;
+	}
+
+	public static function get_pull_request_admin_url( $post_id ) {
+		return add_query_arg(
+			array(
+				'page' => Push_MD_Admin::PAGE_SLUG,
+				'pr'   => intval( $post_id ),
+			),
+			admin_url( 'tools.php' )
+		);
+	}
+
+	public static function get_active_pull_request_for_branch( $branch_name ) {
+		return self::find_pull_request( $branch_name, self::STATUS_ACTIVE );
+	}
+
+	public static function get_rest_diff( $item ) {
+		$post_id = isset( $item['id'] ) ? intval( $item['id'] ) : 0;
+
+		return Push_MD_Plugin::get_pull_request_diff( $post_id );
+	}
+
+	public static function get_rest_preview_url( $item ) {
+		$post_id = isset( $item['id'] ) ? intval( $item['id'] ) : 0;
+		$post    = get_post( $post_id );
+		if ( ! $post || self::STATUS_ACTIVE !== $post->post_status ) {
+			return '';
+		}
+
+		return Push_MD_Plugin::get_preview_branch_url( get_post_meta( $post_id, 'push_md_branch', true ) );
+	}
+
+	public static function validate_rest_note( $prepared_comment, WP_REST_Request $request ) {
+		$post_id = isset( $prepared_comment['comment_post_ID'] ) ? intval( $prepared_comment['comment_post_ID'] ) : 0;
+		if ( ! $post_id && $request->get_param( 'id' ) ) {
+			$comment = get_comment( intval( $request->get_param( 'id' ) ) );
+			$post_id = $comment ? intval( $comment->comment_post_ID ) : 0;
+		}
+		$post = get_post( $post_id );
+		if ( ! $post || self::POST_TYPE !== $post->post_type ) {
+			return $prepared_comment;
+		}
+		if ( 'note' !== $request->get_param( 'type' ) && ! $request->get_param( 'id' ) ) {
+			return new WP_Error( 'push_md_note_type_required', __( 'Pull Request feedback must use the WordPress note type.', 'push-md' ), array( 'status' => 400 ) );
+		}
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error( 'push_md_note_forbidden', __( 'You cannot review this Pull Request.', 'push-md' ), array( 'status' => 403 ) );
+		}
+		if ( self::STATUS_ACTIVE !== $post->post_status ) {
+			return new WP_Error( 'push_md_pull_request_read_only', __( 'Merged and closed Pull Requests are read-only.', 'push-md' ), array( 'status' => 409 ) );
+		}
+
+		$meta              = $request->get_param( 'meta' );
+		$meta              = is_array( $meta ) ? $meta : array();
+		$anchor_validation = self::validate_note_anchor( $post_id, $meta );
+		if ( is_wp_error( $anchor_validation ) ) {
+			return $anchor_validation;
+		}
+		$prepared_comment['comment_approved'] = 1;
+
+		return $prepared_comment;
+	}
+
+	public static function store_note_tip_oid( WP_Comment $comment, WP_REST_Request $request, $creating ) {
+		unset( $request );
+		$post = get_post( $comment->comment_post_ID );
+		if ( ! $creating || ! $post || self::POST_TYPE !== $post->post_type || 'note' !== $comment->comment_type ) {
+			return;
+		}
+
+		update_comment_meta( $comment->comment_ID, 'push_md_tip_oid', get_post_meta( $post->ID, 'push_md_tip_oid', true ) );
+		$review_state = get_comment_meta( $comment->comment_ID, 'push_md_review_state', true );
+		if ( isset( self::get_review_states()[ $review_state ] ) ) {
+			update_post_meta( $post->ID, 'push_md_review_state', $review_state );
+		}
+	}
+
+	public static function get_rest_note_tip_oid( $item ) {
+		$comment_id = isset( $item['id'] ) ? intval( $item['id'] ) : 0;
+		$comment    = get_comment( $comment_id );
+		if ( ! current_user_can( 'manage_options' ) || ! $comment || self::POST_TYPE !== get_post_type( $comment->comment_post_ID ) ) {
+			return '';
+		}
+
+		return (string) get_comment_meta( $comment_id, 'push_md_tip_oid', true );
+	}
+
+	public static function guard_review_routes( $response, $server, WP_REST_Request $request ) {
+		unset( $server );
+		if ( null !== $response || current_user_can( 'manage_options' ) ) {
+			return $response;
+		}
+		if ( preg_match( '#^/wp/v2/push-md-pull-requests(?:/\d+)?$#', $request->get_route() ) ) {
+			return new WP_Error( 'push_md_pull_request_forbidden', __( 'You cannot review Pull Requests.', 'push-md' ), array( 'status' => 403 ) );
+		}
+
+		$post = self::get_comment_request_post( $request );
+		if ( $post && self::POST_TYPE === $post->post_type ) {
+			return new WP_Error( 'push_md_note_forbidden', __( 'You cannot review this Pull Request.', 'push-md' ), array( 'status' => 403 ) );
+		}
+
+		return $response;
+	}
+
+	public static function protect_review_request( $response, $handler, WP_REST_Request $request ) {
+		unset( $handler );
+		if ( null !== $response ) {
+			return $response;
+		}
+
+		if ( preg_match( '#^/wp/v2/push-md-pull-requests(?:/\d+)?$#', $request->get_route() ) ) {
+			return current_user_can( 'manage_options' )
+				? $response
+				: new WP_Error( 'push_md_pull_request_forbidden', __( 'You cannot review Pull Requests.', 'push-md' ), array( 'status' => 403 ) );
+		}
+
+		$post = self::get_comment_request_post( $request );
+		if ( ! $post || self::POST_TYPE !== $post->post_type ) {
+			return $response;
+		}
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error( 'push_md_note_forbidden', __( 'You cannot review this Pull Request.', 'push-md' ), array( 'status' => 403 ) );
+		}
+		if ( preg_match( '#^/wp/v2/comments/(?P<id>\d+)$#', $request->get_route(), $match ) && 'GET' !== $request->get_method() ) {
+			$review_state = get_comment_meta( intval( $match['id'] ), 'push_md_review_state', true );
+			if ( '' !== $review_state ) {
+				return new WP_Error( 'push_md_review_state_note_immutable', __( 'Notes that change Pull Request state cannot be edited or deleted.', 'push-md' ), array( 'status' => 409 ) );
+			}
+			$meta = $request->get_param( 'meta' );
+			if ( is_array( $meta ) && isset( $meta['push_md_review_state'] ) ) {
+				return new WP_Error( 'push_md_review_state_create_only', __( 'Pull Request state can be changed only by creating a new Note.', 'push-md' ), array( 'status' => 409 ) );
+			}
+		}
+		if ( preg_match( '#^/wp/v2/comments/\d+$#', $request->get_route() ) && 'GET' !== $request->get_method() && self::STATUS_ACTIVE !== $post->post_status ) {
+			return new WP_Error( 'push_md_pull_request_read_only', __( 'Merged and closed Pull Requests are read-only.', 'push-md' ), array( 'status' => 409 ) );
+		}
+		if ( preg_match( '#^/wp/v2/comments/\d+$#', $request->get_route() ) && 'GET' !== $request->get_method() && $request->has_param( 'meta' ) ) {
+			$meta              = $request->get_param( 'meta' );
+			$anchor_validation = self::validate_note_anchor( $post->ID, is_array( $meta ) ? $meta : array() );
+			if ( is_wp_error( $anchor_validation ) ) {
+				return $anchor_validation;
+			}
+		}
+
+		return $response;
+	}
+
+	public static function disable_note_notifications( $notify, $comment_id ) {
+		$comment = get_comment( $comment_id );
+		if ( $comment && 'note' === $comment->comment_type && self::POST_TYPE === get_post_type( $comment->comment_post_ID ) ) {
+			return false;
+		}
+
+		return $notify;
+	}
+
+	private static function get_comment_request_post( WP_REST_Request $request ) {
+		if ( preg_match( '#^/wp/v2/comments/(?P<id>\d+)$#', $request->get_route(), $match ) ) {
+			$comment = get_comment( intval( $match['id'] ) );
+
+			return $comment ? get_post( $comment->comment_post_ID ) : null;
+		}
+		if ( '/wp/v2/comments' === $request->get_route() && $request->get_param( 'post' ) ) {
+			return get_post( intval( $request->get_param( 'post' ) ) );
+		}
+
+		return null;
+	}
+
+	private static function validate_note_anchor( $post_id, $meta ) {
+		if ( isset( $meta['push_md_tip_oid'] ) ) {
+			return new WP_Error( 'push_md_note_tip_read_only', __( 'The Pull Request tip is set by Push MD.', 'push-md' ), array( 'status' => 400 ) );
+		}
+
+		$anchor_keys = array( 'push_md_path', 'push_md_side', 'push_md_line' );
+		$present     = 0;
+		foreach ( $anchor_keys as $key ) {
+			if ( isset( $meta[ $key ] ) && '' !== (string) $meta[ $key ] ) {
+				++$present;
+			}
+		}
+		$review_state = isset( $meta['push_md_review_state'] ) ? sanitize_key( $meta['push_md_review_state'] ) : '';
+		if ( '' !== $review_state && ! isset( self::get_review_states()[ $review_state ] ) ) {
+			return new WP_Error( 'push_md_review_state_invalid', __( 'That Pull Request review state is not registered.', 'push-md' ), array( 'status' => 400 ) );
+		}
+		if ( '' !== $review_state && 0 < $present ) {
+			return new WP_Error( 'push_md_review_state_inline', __( 'Inline Notes cannot change Pull Request state.', 'push-md' ), array( 'status' => 400 ) );
+		}
+		if ( 0 === $present ) {
+			return true;
+		}
+		if ( count( $anchor_keys ) !== $present ) {
+			return new WP_Error( 'push_md_note_anchor_incomplete', __( 'Inline feedback requires a path, side, and line.', 'push-md' ), array( 'status' => 400 ) );
+		}
+
+		$path = sanitize_text_field( $meta['push_md_path'] );
+		$side = sanitize_key( $meta['push_md_side'] );
+		$line = absint( $meta['push_md_line'] );
+		if ( ! Push_MD_Plugin::pull_request_diff_has_anchor( $post_id, $path, $side, $line ) ) {
+			return new WP_Error( 'push_md_note_anchor_invalid', __( 'That diff line no longer exists.', 'push-md' ), array( 'status' => 409 ) );
+		}
+
+		return true;
+	}
+
+	private static function insert_pull_request( $branch_name, $status, $owner, $base_oid, $tip_oid, $created_at, $updated_at ) {
+		$created  = wp_date( 'Y-m-d H:i:s', $created_at );
+		$modified = wp_date( 'Y-m-d H:i:s', $updated_at );
+		$post_id  = wp_insert_post(
+			array(
+				'post_type'      => self::POST_TYPE,
+				'post_status'    => $status,
+				'post_title'     => $branch_name,
+				'post_author'    => $owner,
+				'post_date'      => $created,
+				'post_modified'  => $modified,
+				'comment_status' => self::STATUS_ACTIVE === $status ? 'open' : 'closed',
+				'meta_input'     => array(
+					'push_md_branch'      => sanitize_text_field( $branch_name ),
+					'push_md_base_oid'    => sanitize_text_field( $base_oid ),
+					'push_md_tip_oid'     => sanitize_text_field( $tip_oid ),
+					'push_md_review_state' => 'pending',
+				),
+			),
+			true
+		);
+
+		return $post_id;
+	}
+
+	private static function find_pull_request( $branch_name, $status ) {
+		$posts = get_posts(
+			array(
+				'post_type'      => self::POST_TYPE,
+				'post_status'    => $status,
+				'posts_per_page' => 1,
+				'no_found_rows'  => true,
+				'orderby'        => 'modified',
+				'order'          => 'DESC',
+				'meta_key'       => 'push_md_branch', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value'     => $branch_name, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			)
+		);
+
+		return empty( $posts ) ? null : $posts[0];
+	}
+
+	private static function post_to_branch_metadata( WP_Post $post ) {
+		$branch_name = get_post_meta( $post->ID, 'push_md_branch', true );
+		$metadata    = array(
+			'pull_request_id'  => $post->ID,
+			'pull_request_url' => self::get_pull_request_admin_url( $post->ID ),
+			'branch'           => $branch_name,
+			'ref'              => 'refs/heads/' . $branch_name,
+			'owner'            => intval( $post->post_author ),
+			'base_oid'         => get_post_meta( $post->ID, 'push_md_base_oid', true ),
+			'tip_oid'          => get_post_meta( $post->ID, 'push_md_tip_oid', true ),
+			'url'              => Push_MD_Plugin::get_preview_branch_url( $branch_name ),
+			'created_at'       => get_post_time( 'U', true, $post ),
+			'updated_at'       => get_post_modified_time( 'U', true, $post ),
+		);
+		if ( self::STATUS_MERGED === $post->post_status ) {
+			$metadata['merged_oid'] = get_post_meta( $post->ID, 'push_md_merged_oid', true );
+			$metadata['merged_by']  = intval( get_post_meta( $post->ID, 'push_md_merged_by', true ) );
+			$metadata['merged_at']  = get_post_modified_time( 'U', true, $post );
+		}
+
+		return $metadata;
+	}
+}

--- a/plugins/push-md/push-md.php
+++ b/plugins/push-md/push-md.php
@@ -3,7 +3,7 @@
  * Plugin Name: Push MD
  * Plugin URI: https://pushmd.blog/
  * Description: Edit WordPress content with Git, Markdown and block files, reviewable diffs, and safe pushes.
- * Version: 0.6.8
+ * Version: 0.7.0
  * Requires at least: 6.9
  * Requires PHP: 7.2
  * Author: Automattic
@@ -32,6 +32,7 @@ require_once __DIR__ . '/class-push-md-plugin.php';
 require_once __DIR__ . '/class-push-md-buffering-response.php';
 require_once __DIR__ . '/class-push-md-seeder.php';
 require_once __DIR__ . '/class-push-md-admin.php';
+require_once __DIR__ . '/class-push-md-pull-requests.php';
 
 if ( ! defined( 'PUSH_MD_PLUGIN_FILE' ) ) {
 	define( 'PUSH_MD_PLUGIN_FILE', __FILE__ );

--- a/plugins/push-md/uninstall.php
+++ b/plugins/push-md/uninstall.php
@@ -52,9 +52,27 @@ function push_md_uninstall_cleanup() {
 function push_md_uninstall_cleanup_site() {
 	delete_option( 'push_md_seed_state' );
 	delete_option( 'push_md_seed_progress' );
+	delete_option( 'push_md_branch_previews' );
 	delete_transient( 'push_md_seed_lock' );
 	wp_clear_scheduled_hook( 'push_md_seed_tick' );
+	push_md_uninstall_delete_pull_requests();
 	push_md_uninstall_drop_repository_tables();
+}
+
+/**
+ * Delete Pull Requests through WordPress so their Notes and metadata follow.
+ */
+function push_md_uninstall_delete_pull_requests() {
+	global $wpdb;
+
+	// The CPT and its custom statuses are not registered while uninstall.php runs.
+	// Read only the IDs directly, then use WordPress deletion APIs for all cleanup.
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+	$post_ids = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_type = %s", 'push_md_pull_request' ) );
+
+	foreach ( $post_ids as $post_id ) {
+		wp_delete_post( intval( $post_id ), true );
+	}
 }
 
 /**


### PR DESCRIPTION

## Summary

- store preview branches as a private `push_md_pull_request` CPT with native lifecycle statuses
- add WordPress Notes for general and inline diff comments
- add comment-driven, extensible PR review states
- add editable PR descriptions and commit history with commit message bodies
- add a GitHub-like review UI with previews, diffs, lifecycle groups, and merge actions
- migrate legacy branch preview options and remove PR data on uninstall

## REST and permissions

- use the native post and comment REST controllers
- expose calculated changed files, line diffs, preview URLs, and commit history as read-only fields
- allow admins to update only the description of active PRs
- keep lifecycle, protected metadata, merged/closed PRs, and state-changing Notes guarded

## Testing

- `vendor/bin/phpcs plugins/push-md`
- `vendor/bin/phpunit plugins/push-md/Tests/`
- full WordPress E2E: 31 tests, 698 assertions
- `node --check plugins/push-md/admin-shell.js`
- `git diff --check`