### PR TITLE
Fix Push MD release bundle and show PR URL after push

### DIFF
--- a/bin/inspect-push-md-zip.sh
+++ b/bin/inspect-push-md-zip.sh
@@ -10,7 +10,12 @@ if [ ! -f "$ZIP_PATH" ]; then
 fi
 
 CONTENTS_FILE="$(mktemp)"
-trap 'rm -f "$CONTENTS_FILE"' EXIT
+EXTRACT_DIR="$(mktemp -d)"
+cleanup() {
+	rm -f "$CONTENTS_FILE"
+	rm -rf "$EXTRACT_DIR"
+}
+trap cleanup EXIT
 
 zipinfo -1 "$ZIP_PATH" > "$CONTENTS_FILE"
 
@@ -62,6 +67,9 @@ require_file 'push-md/skills/default-agent-skill.md'
 require_file 'push-md/skills/default-template-editor-skill.md'
 require_file 'push-md/php-toolkit/vendor/composer/ClassLoader.php'
 require_file 'push-md/php-toolkit/components/Markdown/class-markdownconsumer.php'
+require_file 'push-md/php-toolkit/components/Merge/Diff/class-diff.php'
+require_file 'push-md/php-toolkit/components/Merge/Diff/class-differ.php'
+require_file 'push-md/php-toolkit/components/Merge/Diff/class-linediffer.php'
 require_file 'push-md/php-toolkit/components/Markdown/vendor-patched/league/commonmark/LICENSE'
 require_file 'push-md/php-toolkit/components/Markdown/vendor-patched/league/config/LICENSE.md'
 require_file 'push-md/php-toolkit/components/Markdown/vendor-patched/dflydev/dot-access-data/LICENSE'
@@ -94,5 +102,25 @@ reject_content_pattern 'class[[:space:]]+PMD_|interface[[:space:]]+PMD_|trait[[:
 reject_content_pattern '['\''"]pmd_(seed|auth|required|forbidden|error|invalid|files|directory_entries)' 'Push MD zip must not use old three-letter pmd_ storage or error identifiers.'
 reject_content_pattern '['\''"]guideline_source['\''"]' 'Push MD zip must not use the unprefixed guideline_source post meta key.'
 reject_content_pattern '^Contributors:.*automattic' 'Push MD readme lists the unusual automattic contributor.'
+
+unzip -q "$ZIP_PATH" -d "$EXTRACT_DIR"
+PUSH_MD_INSPECT_PLUGIN_DIR="$EXTRACT_DIR/push-md" php <<'PHP'
+<?php
+
+define( 'ABSPATH', sys_get_temp_dir() . '/' );
+require getenv( 'PUSH_MD_INSPECT_PLUGIN_DIR' ) . '/push-md-toolkit-bootstrap.php';
+
+$line_differ_class = 'PushMDVendor\\WordPress\\Merge\\Diff\\LineDiffer';
+if ( ! class_exists( $line_differ_class ) ) {
+	fwrite( STDERR, "Push MD bundled runtime cannot autoload LineDiffer.\n" );
+	exit( 1 );
+}
+
+$changes = ( new $line_differ_class() )->diff( 'before', 'after' )->get_changes();
+if ( empty( $changes ) ) {
+	fwrite( STDERR, "Push MD bundled LineDiffer did not produce a diff.\n" );
+	exit( 1 );
+}
+PHP
 
 echo "Push MD zip contents look submission-ready: $ZIP_PATH"

--- a/bin/push-md-toolkit-manifest.txt
+++ b/bin/push-md-toolkit-manifest.txt
@@ -56,4 +56,8 @@ components/Git/Protocol/Parser/
 
 components/HttpServer/Response/class-responsewritestream.php
 
+components/Merge/Diff/class-diff.php
+components/Merge/Diff/class-differ.php
+components/Merge/Diff/class-linediffer.php
+
 components/Polyfill/mbstring.php

--- a/plugins/push-md/Tests/EndToEndTest.php
+++ b/plugins/push-md/Tests/EndToEndTest.php
@@ -195,6 +195,8 @@ class PMD_End_To_End_Test extends TestCase {
 		$this->assertStringContainsString( 'Push MD stored preview branch ' . $branch . ' without changing WordPress content.', $push_result['output'] );
 		$this->assertStringContainsString( 'Preview: ', $push_result['output'] );
 		$this->assertStringContainsString( '?branch=', $push_result['output'] );
+		$this->assertStringContainsString( 'Pull request: ', $push_result['output'] );
+		$this->assertStringContainsString( '/wp-admin/tools.php?page=push-md&pr=', $push_result['output'] );
 		$this->assertStringContainsString( 'Changed preview URLs:', $push_result['output'] );
 		$this->assertStringContainsString( 'Updated post/' . $slug . '.md: ', $push_result['output'] );
 		$this->assertStringContainsString( 'Created post/' . $new_slug . '.md: ', $push_result['output'] );

--- a/plugins/push-md/class-push-md-plugin.php
+++ b/plugins/push-md/class-push-md-plugin.php
@@ -2208,7 +2208,7 @@ class Push_MD_Plugin {
 			$push_header['validation_old_oid'],
 			$push_header['new_oid']
 		);
-		self::update_preview_branch_metadata( $push_header );
+		$push_header['pull_request_id'] = self::update_preview_branch_metadata( $push_header );
 	}
 
 	private static function is_commit_ancestor( GitRepository $repository, $ancestor, $descendant ) {
@@ -3107,6 +3107,12 @@ class Push_MD_Plugin {
 			'Preview: %s',
 			self::sanitize_push_summary_text( self::get_preview_branch_url( $push_header['branch_name'] ) )
 		);
+		if ( ! empty( $push_header['pull_request_id'] ) ) {
+			$messages[] = sprintf(
+				'Pull request: %s',
+				self::sanitize_push_summary_text( Push_MD_Pull_Requests::get_pull_request_admin_url( $push_header['pull_request_id'] ) )
+			);
+		}
 
 		$changed_urls = array();
 		if ( $repository ) {
@@ -3406,7 +3412,7 @@ class Push_MD_Plugin {
 	}
 
 	private static function update_preview_branch_metadata( $push_header ) {
-		Push_MD_Pull_Requests::update_active_pull_request( $push_header );
+		return Push_MD_Pull_Requests::update_active_pull_request( $push_header );
 	}
 
 	private static function delete_preview_branch_metadata( $branch_name ) {


### PR DESCRIPTION
## What changed

- include the Merge diff runtime used by Pull Request views in the Push MD toolkit manifest
- make ZIP inspection autoload `LineDiffer` from the built artifact and execute a smoke diff
- print the matching Pull Request admin URL after every successful preview-branch push

## Why

The v0.6.9 WordPress.org artifact fatals while rendering a Pull Request because `PushMDVendor\WordPress\Merge\Diff\LineDiffer` is not present in the release bundle. Development and E2E installs use the monorepo source tree, which masked the missing manifest entries. Returning the Pull Request URL also lets the person pushing open the review directly from the terminal.

## Validation

- `bash bin/build-plugins.sh`
- `bash bin/inspect-push-md-zip.sh`
- `vendor/bin/phpunit plugins/push-md/Tests/` (31 tests, 36 assertions, 12 skipped E2E tests)
- full Push MD E2E suite on a clean WordPress install (31 tests, 700 assertions)
- full Push MD E2E suite against an install using the generated ZIP before the URL addition (31 tests, 698 assertions)
- targeted PHPCS on `plugins/push-md/class-push-md-plugin.php`
- `bash -n bin/inspect-push-md-zip.sh`
- `git diff --check`

`composer lint` still exits non-zero on existing repository warnings; changed production PHP passes targeted PHPCS.