### PR TITLE
Add Push MD content adapter registry

### DIFF
--- a/bin/test-push-md-git-actions.sh
+++ b/bin/test-push-md-git-actions.sh
@@ -254,6 +254,49 @@ cd "$CLONE_DIR"
 git config user.name "Push MD E2E"
 git config user.email "push-md-e2e@example.com"
 
+ADAPTER_SUFFIX="adapter-$(date +%s)-$$"
+ADAPTER_FIXTURE="$(
+	php -r 'echo json_encode(array("suffix" => $argv[1]));' "$ADAPTER_SUFFIX" |
+		curl -sS -f \
+			-X POST \
+			-H "Authorization: Basic $AUTH_HEADER" \
+			-H "Content-Type: application/json" \
+			--data-binary @- \
+			"$BASE_URL/wp-json/push-md-test/v1/adapter-fixture"
+)"
+ADAPTER_CHILD_ID="$(printf '%s' "$ADAPTER_FIXTURE" | php -r '$fixture = json_decode(stream_get_contents(STDIN), true); echo $fixture["child_id"];')"
+ADAPTER_PATH="$(printf '%s' "$ADAPTER_FIXTURE" | php -r '$fixture = json_decode(stream_get_contents(STDIN), true); echo $fixture["path"];')"
+ADAPTER_COLLECTIONS="$(printf '%s' "$ADAPTER_FIXTURE" | php -r '$fixture = json_decode(stream_get_contents(STDIN), true); echo json_encode($fixture["collections"]);')"
+ADAPTER_TOPICS="$(printf '%s' "$ADAPTER_FIXTURE" | php -r '$fixture = json_decode(stream_get_contents(STDIN), true); echo json_encode($fixture["topics"]);')"
+ADAPTER_RETAINED_TOPIC="$(printf '%s' "$ADAPTER_FIXTURE" | php -r '$fixture = json_decode(stream_get_contents(STDIN), true); echo $fixture["topics"][1];')"
+git pull --rebase origin trunk
+test -f "$CLONE_DIR/$ADAPTER_PATH"
+grep -Fq "collections: $ADAPTER_COLLECTIONS" "$CLONE_DIR/$ADAPTER_PATH"
+grep -Fq "topics: $ADAPTER_TOPICS" "$CLONE_DIR/$ADAPTER_PATH"
+php -r '
+$path = $argv[1];
+$contents = file_get_contents($path);
+$contents = str_replace($argv[2], $argv[3], $contents);
+$contents = str_replace("topics: " . $argv[4], "topics: " . json_encode(array($argv[5])), $contents);
+file_put_contents($path, $contents);
+' "$CLONE_DIR/$ADAPTER_PATH" "Adapter child $ADAPTER_SUFFIX" "Adapter child updated from Git $ADAPTER_SUFFIX" "$ADAPTER_TOPICS" "$ADAPTER_RETAINED_TOPIC"
+git add "$ADAPTER_PATH"
+git commit -m "Update plugin-defined adapter content"
+if ! PUSH_OUTPUT="$(git push origin trunk 2>&1)"; then
+	printf '%s\n' "$PUSH_OUTPUT" >&2
+	exit 1
+fi
+assert_push_summary_contains "$PUSH_OUTPUT" 'Push MD applied 1 content change:'
+curl -sS -f --retry 5 --retry-all-errors --retry-delay 1 \
+	-H "Authorization: Basic $AUTH_HEADER" \
+	"$BASE_URL/wp-json/push-md-test/v1/adapter-document/$ADAPTER_CHILD_ID" |
+	php -r '
+$document = json_decode(stream_get_contents(STDIN), true);
+if (false === strpos($document["content"], $argv[1])) { exit(1); }
+if (array($argv[2]) !== $document["topics"]) { exit(1); }
+' "Adapter child updated from Git $ADAPTER_SUFFIX" "$ADAPTER_RETAINED_TOPIC"
+git pull --rebase origin trunk
+
 grep -Fq "id: \"$PAGE_ID\"" "$CLONE_DIR/page/sample-page.md"
 git mv page/sample-page.md page/renamed-sample-page.md
 php -r '

--- a/components/Markdown/Tests/MarkdownConsumerTest.php
+++ b/components/Markdown/Tests/MarkdownConsumerTest.php
@@ -252,6 +252,27 @@ MD;
 		);
 	}
 
+	public function test_frontmatter_inline_json_arrays_are_preserved() {
+		$markdown = <<<MD
+---
+collections: ["guides","reference"]
+topics: []
+---
+
+Content
+MD;
+		$consumer = new MarkdownConsumer( $markdown );
+		$result   = $consumer->consume();
+
+		$this->assertEquals(
+			array(
+				'collections' => array( array( 'guides', 'reference' ) ),
+				'topics'      => array( array() ),
+			),
+			$result->get_all_metadata()
+		);
+	}
+
 	public function test_gutenberg_fence_is_preserved_as_block_markup() {
 		$markdown = <<<MD
 ```gutenberg

--- a/components/Markdown/class-markdownconsumer.php
+++ b/components/Markdown/class-markdownconsumer.php
@@ -443,7 +443,16 @@ class MarkdownConsumer implements DataFormatConsumer {
 	}
 
 	private function parse_frontmatter_scalar( $raw ) {
-		if ( preg_match( '/^\[|\{|- /', $raw ) ) {
+		if ( '[' === substr( $raw, 0, 1 ) ) {
+			$decoded = json_decode( $raw, true );
+			if ( JSON_ERROR_NONE === json_last_error() && is_array( $decoded ) ) {
+				return $decoded;
+			}
+
+			return array();
+		}
+
+		if ( preg_match( '/^\{|- /', $raw ) ) {
 			return array();
 		}
 

--- a/homeboy.json
+++ b/homeboy.json
@@ -1,0 +1,25 @@
+{
+  "id": "push-md",
+  "remote_url": "https://github.com/Automattic/php-toolkit.git",
+  "remote_path": "../wp-content/plugins/push-md",
+  "build_artifact": "dist/plugins/push-md.zip",
+  "extract_command": "tmp=$(mktemp -d) && unzip -q {artifact} -d \"$tmp\" && cp -a \"$tmp/push-md/.\" . && rm -rf \"$tmp\" {artifact}",
+  "extensions": {
+    "wordpress": {}
+  },
+  "version_targets": [
+    {
+      "file": "plugins/push-md/push-md.php",
+      "artifact_path": "push-md/push-md.php",
+      "pattern": "Version:\\s*([0-9.]+)"
+    }
+  ],
+  "scripts": {
+    "build": [
+      "bash bin/build-plugins.sh"
+    ],
+    "test": [
+      "bash bin/inspect-push-md-zip.sh dist/plugins/push-md.zip"
+    ]
+  }
+}

--- a/plugins/push-md/Tests/BranchPreviewTest.php
+++ b/plugins/push-md/Tests/BranchPreviewTest.php
@@ -16,6 +16,7 @@ if ( ! class_exists( 'WP_Post' ) ) {
 		public $post_type   = 'post';
 		public $post_name   = '';
 		public $post_parent = 0;
+		public $post_status = 'publish';
 	}
 }
 

--- a/plugins/push-md/Tests/EndToEndTest.php
+++ b/plugins/push-md/Tests/EndToEndTest.php
@@ -154,6 +154,59 @@ class PMD_End_To_End_Test extends TestCase {
 		}
 	}
 
+	public function testPluginDefinedHierarchicalAdapterRoundTripsMetadata() {
+		$suffix   = uniqid( 'adapter-' );
+		$response = $this->curl_post_json(
+			$this->base_url . '/wp-json/push-md-test/v1/adapter-fixture',
+			array( 'suffix' => $suffix )
+		);
+		$this->assertSame( 200, $response['status'], 'Adapter fixture creation failed: ' . $response['body'] );
+		$fixture = json_decode( $response['body'], true );
+		$this->assertIsArray( $fixture );
+
+		$clone_dir = $this->clone_repo( 'content-adapter' );
+		$this->configure_git( $clone_dir );
+		$file = $clone_dir . '/' . $fixture['path'];
+		$this->assertFileExists( $file );
+		$markdown = file_get_contents( $file );
+		$this->assertStringContainsString( 'collections: ' . json_encode( $fixture['collections'] ), $markdown );
+		$this->assertStringContainsString( 'topics: ' . json_encode( $fixture['topics'] ), $markdown );
+
+		$updated_text = 'Adapter child updated from Git ' . $suffix;
+		$markdown     = str_replace( 'Adapter child ' . $suffix, $updated_text, $markdown );
+		$markdown     = str_replace(
+			'topics: ' . json_encode( $fixture['topics'] ),
+			'topics: ' . json_encode( array( $fixture['topics'][1] ) ),
+			$markdown
+		);
+		file_put_contents( $file, $markdown );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', $fixture['path'] ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Update plugin-defined adapter content' ) );
+		$push = $this->run_cmd( array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ) );
+		$this->assertStringContainsString( 'Push MD applied 1 content change:', $push['output'] );
+
+		$document = $this->curl_get( $this->base_url . '/wp-json/push-md-test/v1/adapter-document/' . $fixture['child_id'] );
+		$document = json_decode( $document, true );
+		$this->assertStringContainsString( $updated_text, $document['content'] );
+		$this->assertSame( array( $fixture['topics'][1] ), $document['topics'] );
+		$this->assertSame( $fixture['collections'], $document['collections'] );
+
+		$invalid = str_replace(
+			'topics: ' . json_encode( array( $fixture['topics'][1] ) ),
+			'topics: ' . json_encode( array( 'missing-' . $suffix ) ),
+			$markdown
+		);
+		file_put_contents( $file, $invalid );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'add', $fixture['path'] ) );
+		$this->run_cmd( array( 'git', '-C', $clone_dir, 'commit', '-m', 'Reject missing adapter term' ) );
+		$rejected = $this->run_cmd( array( 'git', '-C', $clone_dir, 'push', 'origin', 'trunk' ), true );
+		$this->assertNotSame( 0, $rejected['code'] );
+		$this->assertStringContainsString( 'Push MD test adapter terms must already exist.', $rejected['output'] );
+
+		$document = json_decode( $this->curl_get( $this->base_url . '/wp-json/push-md-test/v1/adapter-document/' . $fixture['child_id'] ), true );
+		$this->assertSame( array( $fixture['topics'][1] ), $document['topics'] );
+	}
+
 	public function testBranchPreviewPushRendersForAuthenticatedAdminWithoutMutatingLiveContent() {
 		$suffix       = uniqid( 'branch-preview-' );
 		$slug         = $suffix;

--- a/plugins/push-md/Tests/ExportPathTest.php
+++ b/plugins/push-md/Tests/ExportPathTest.php
@@ -12,6 +12,17 @@ if ( ! class_exists( 'WP_Post' ) ) {
 		public $post_type   = 'post';
 		public $post_name   = '';
 		public $post_parent = 0;
+		public $post_status = 'publish';
+	}
+}
+
+$push_md_test_posts = array();
+
+if ( ! function_exists( 'get_post' ) ) {
+	function get_post( $post_id ) {
+		global $push_md_test_posts;
+
+		return isset( $push_md_test_posts[ $post_id ] ) ? $push_md_test_posts[ $post_id ] : null;
 	}
 }
 
@@ -26,7 +37,25 @@ if ( ! function_exists( 'sanitize_title' ) ) {
 
 if ( ! function_exists( 'post_type_exists' ) ) {
 	function post_type_exists( $post_type ) {
-		return in_array( $post_type, array( 'post', 'page' ), true );
+		return in_array( $post_type, array( 'post', 'page', 'wpdocs_document' ), true );
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) {
+		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $key ) );
+	}
+}
+
+if ( ! function_exists( 'wp_parse_args' ) ) {
+	function wp_parse_args( $args, $defaults = array() ) {
+		return array_merge( $defaults, $args );
+	}
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $text ) {
+		return (string) $text;
 	}
 }
 
@@ -41,6 +70,21 @@ if ( ! function_exists( 'taxonomy_exists' ) ) {
 require_once dirname( __DIR__ ) . '/class-push-md-plugin.php';
 
 class PMD_Export_Path_Test extends TestCase {
+	public static function setUpBeforeClass(): void {
+		Push_MD_Plugin::register_content_adapter(
+			'wpdocs_document',
+			array(
+				'hierarchical'       => true,
+				'frontmatter_fields' => array( 'collections', 'topics' ),
+				'export_metadata'    => function () {
+					return array(
+						'collections' => array( 'reference', 'guides', 'guides' ),
+						'topics'      => array( 'wordpress' ),
+					);
+				},
+			)
+		);
+	}
 
 	public function testPostWithEmptySlugUsesStableIdFallbackPath() {
 		$this->assertSame(
@@ -100,12 +144,61 @@ class PMD_Export_Path_Test extends TestCase {
 		);
 	}
 
+	public function testCustomHierarchicalAdapterBuildsStableNestedPath() {
+		global $push_md_test_posts;
+
+		$parent                    = $this->post( 900, 'wpdocs_document', 'guides' );
+		$push_md_test_posts[900]    = $parent;
+		$child                     = $this->post( 901, 'wpdocs_document', 'getting-started' );
+		$child->post_parent        = 900;
+
+		$this->assertSame(
+			'wpdocs_document/guides/getting-started.md',
+			Push_MD_Plugin::build_markdown_path( $child )
+		);
+	}
+
+	public function testAdapterMetadataIsDeterministicAndDeduplicated() {
+		$method = new ReflectionMethod( Push_MD_Plugin::class, 'export_adapter_metadata' );
+		$method->setAccessible( true );
+		$result = $method->invoke( null, $this->post( 902, 'wpdocs_document', 'metadata' ) );
+
+		$this->assertSame( array( array( 'guides', 'reference' ) ), $result['collections'] );
+		$this->assertSame( array( array( 'wordpress' ) ), $result['topics'] );
+	}
+
+	public function testDuplicateAdapterRegistrationIsRejected() {
+		$this->expectException( InvalidArgumentException::class );
+		Push_MD_Plugin::register_content_adapter( 'wpdocs_document' );
+	}
+
+	/**
+	 * @dataProvider reservedAdapterFieldProvider
+	 */
+	public function testAdapterCannotClaimPushMdFrontMatterFields( $field ) {
+		$this->expectException( InvalidArgumentException::class );
+		Push_MD_Plugin::register_content_adapter(
+			'reserved_' . $field,
+			array( 'frontmatter_fields' => array( $field ) )
+		);
+	}
+
+	public function reservedAdapterFieldProvider() {
+		return array(
+			'identity slug'   => array( 'slug' ),
+			'identity type'   => array( 'type' ),
+			'content id'      => array( 'id' ),
+			'conflict marker' => array( 'modified_gmt' ),
+		);
+	}
+
 	private function post( $id, $post_type, $post_name ) {
 		$post              = new WP_Post();
 		$post->ID          = $id;
 		$post->post_type   = $post_type;
 		$post->post_name   = $post_name;
 		$post->post_parent = 0;
+		$post->post_status = 'publish';
 
 		return $post;
 	}

--- a/plugins/push-md/Tests/ExportPathTest.php
+++ b/plugins/push-md/Tests/ExportPathTest.php
@@ -167,6 +167,22 @@ class PMD_Export_Path_Test extends TestCase {
 		$this->assertSame( array( array( 'wordpress' ) ), $result['topics'] );
 	}
 
+	public function testAdapterMetadataIsExtractedFromInlineJsonArrays() {
+		$consumer = new WordPress\Markdown\MarkdownConsumer(
+			"---\ncollections: [\"guides\",\"reference\"]\ntopics: [\"wordpress\"]\n---\n\nContent\n"
+		);
+		$method = new ReflectionMethod( Push_MD_Plugin::class, 'extract_adapter_metadata' );
+		$method->setAccessible( true );
+
+		$this->assertSame(
+			array(
+				'collections' => array( 'guides', 'reference' ),
+				'topics'      => array( 'wordpress' ),
+			),
+			$method->invoke( null, 'wpdocs_document', $consumer->consume()->get_all_metadata() )
+		);
+	}
+
 	public function testDuplicateAdapterRegistrationIsRejected() {
 		$this->expectException( InvalidArgumentException::class );
 		Push_MD_Plugin::register_content_adapter( 'wpdocs_document' );

--- a/plugins/push-md/Tests/ci-mu-test-helper.php
+++ b/plugins/push-md/Tests/ci-mu-test-helper.php
@@ -12,6 +12,234 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+add_action(
+	'init',
+	static function () {
+		register_post_type(
+			'push_md_test_doc',
+			array(
+				'public'       => false,
+				'show_ui'      => true,
+				'show_in_rest' => true,
+				'rest_base'    => 'push-md-test-documents',
+				'hierarchical' => true,
+				'supports'     => array( 'title', 'editor', 'excerpt', 'revisions', 'page-attributes' ),
+			)
+		);
+		register_taxonomy(
+			'push_md_test_collection',
+			'push_md_test_doc',
+			array(
+				'public'       => false,
+				'show_ui'      => true,
+				'show_in_rest' => true,
+				'rest_base'    => 'push-md-test-collections',
+				'hierarchical' => true,
+			)
+		);
+		register_taxonomy(
+			'push_md_test_topic',
+			'push_md_test_doc',
+			array(
+				'public'       => false,
+				'show_ui'      => true,
+				'show_in_rest' => true,
+				'rest_base'    => 'push-md-test-topics',
+				'hierarchical' => false,
+			)
+		);
+
+		if ( ! function_exists( 'push_md_register_content_adapter' ) ) {
+			return;
+		}
+
+		push_md_register_content_adapter(
+			'push_md_test_doc',
+			array(
+				'hierarchical'       => true,
+				'frontmatter_fields' => array( 'collections', 'topics' ),
+				'export_metadata'    => 'push_md_test_export_metadata',
+				'validate_metadata'  => 'push_md_test_validate_metadata',
+				'apply_metadata'     => 'push_md_test_apply_metadata',
+			)
+		);
+	},
+	10
+);
+
+function push_md_test_export_metadata( WP_Post $post ) {
+	return array(
+		'collections' => push_md_test_term_slugs( $post->ID, 'push_md_test_collection' ),
+		'topics'      => push_md_test_term_slugs( $post->ID, 'push_md_test_topic' ),
+	);
+}
+
+function push_md_test_term_slugs( $post_id, $taxonomy ) {
+	$terms = wp_get_object_terms( $post_id, $taxonomy, array( 'fields' => 'slugs' ) );
+	if ( is_wp_error( $terms ) ) {
+		throw new RuntimeException( $terms->get_error_message() );
+	}
+	sort( $terms, SORT_STRING );
+	return $terms;
+}
+
+function push_md_test_validate_metadata( $metadata ) {
+	$mapping = array(
+		'collections' => 'push_md_test_collection',
+		'topics'      => 'push_md_test_topic',
+	);
+	foreach ( $mapping as $field => $taxonomy ) {
+		if ( ! array_key_exists( $field, $metadata ) ) {
+			continue;
+		}
+		$requested = array_values( array_unique( $metadata[ $field ] ) );
+		$existing  = get_terms(
+			array(
+				'taxonomy'   => $taxonomy,
+				'hide_empty' => false,
+				'slug'       => $requested,
+				'fields'     => 'slugs',
+			)
+		);
+		if ( is_wp_error( $existing ) ) {
+			throw new RuntimeException( $existing->get_error_message() );
+		}
+		sort( $requested, SORT_STRING );
+		sort( $existing, SORT_STRING );
+		if ( $requested !== $existing ) {
+			throw new InvalidArgumentException( 'Push MD test adapter terms must already exist.' );
+		}
+	}
+}
+
+function push_md_test_apply_metadata( $post_id, $metadata ) {
+	$mapping = array(
+		'collections' => 'push_md_test_collection',
+		'topics'      => 'push_md_test_topic',
+	);
+	foreach ( $mapping as $field => $taxonomy ) {
+		if ( ! array_key_exists( $field, $metadata ) ) {
+			continue;
+		}
+		$result = wp_set_object_terms( $post_id, $metadata[ $field ], $taxonomy, false );
+		if ( is_wp_error( $result ) ) {
+			throw new RuntimeException( $result->get_error_message() );
+		}
+	}
+}
+
+add_action(
+	'rest_api_init',
+	static function () {
+		$permission = static function () {
+			return current_user_can( 'manage_options' );
+		};
+		register_rest_route(
+			'push-md-test/v1',
+			'/adapter-fixture',
+			array(
+				'methods'             => 'POST',
+				'permission_callback' => $permission,
+				'callback'            => 'push_md_test_create_adapter_fixture',
+			)
+		);
+		register_rest_route(
+			'push-md-test/v1',
+			'/adapter-document/(?P<id>[\d]+)',
+			array(
+				'methods'             => 'GET',
+				'permission_callback' => $permission,
+				'callback'            => static function ( WP_REST_Request $request ) {
+					$post = get_post( intval( $request->get_param( 'id' ) ) );
+					if ( ! $post || 'push_md_test_doc' !== $post->post_type ) {
+						return new WP_Error( 'not_found', 'Adapter document not found.', array( 'status' => 404 ) );
+					}
+					return rest_ensure_response(
+						array(
+							'id'          => $post->ID,
+							'content'     => $post->post_content,
+							'collections' => push_md_test_term_slugs( $post->ID, 'push_md_test_collection' ),
+							'topics'      => push_md_test_term_slugs( $post->ID, 'push_md_test_topic' ),
+						)
+					);
+				},
+			)
+		);
+	}
+);
+
+function push_md_test_create_adapter_fixture( WP_REST_Request $request ) {
+	$suffix = sanitize_title( $request->get_param( 'suffix' ) );
+	if ( '' === $suffix ) {
+		return new WP_Error( 'missing_suffix', 'A fixture suffix is required.', array( 'status' => 400 ) );
+	}
+
+	$collection_slugs = array( 'guides-' . $suffix, 'reference-' . $suffix );
+	$topic_slugs      = array( 'blocks-' . $suffix, 'wordpress-' . $suffix );
+	$parent_term      = wp_insert_term( 'Guides ' . $suffix, 'push_md_test_collection', array( 'slug' => $collection_slugs[0] ) );
+	if ( is_wp_error( $parent_term ) ) {
+		return $parent_term;
+	}
+	$child_term = wp_insert_term(
+		'Reference ' . $suffix,
+		'push_md_test_collection',
+		array(
+			'slug'   => $collection_slugs[1],
+			'parent' => $parent_term['term_id'],
+		)
+	);
+	if ( is_wp_error( $child_term ) ) {
+		return $child_term;
+	}
+	foreach ( $topic_slugs as $topic_slug ) {
+		$term = wp_insert_term( ucwords( str_replace( '-', ' ', $topic_slug ) ), 'push_md_test_topic', array( 'slug' => $topic_slug ) );
+		if ( is_wp_error( $term ) ) {
+			return $term;
+		}
+	}
+
+	$parent_slug = 'docs-' . $suffix;
+	$child_slug  = 'getting-started-' . $suffix;
+	$parent_id   = wp_insert_post(
+		array(
+			'post_type'    => 'push_md_test_doc',
+			'post_status'  => 'publish',
+			'post_name'    => $parent_slug,
+			'post_title'   => 'Docs ' . $suffix,
+			'post_content' => '<!-- wp:paragraph --><p>Adapter parent ' . esc_html( $suffix ) . '</p><!-- /wp:paragraph -->',
+		),
+		true
+	);
+	if ( is_wp_error( $parent_id ) ) {
+		return $parent_id;
+	}
+	$child_id = wp_insert_post(
+		array(
+			'post_type'    => 'push_md_test_doc',
+			'post_status'  => 'publish',
+			'post_name'    => $child_slug,
+			'post_parent'  => $parent_id,
+			'post_title'   => 'Getting Started ' . $suffix,
+			'post_content' => '<!-- wp:paragraph --><p>Adapter child ' . esc_html( $suffix ) . '</p><!-- /wp:paragraph -->',
+		),
+		true
+	);
+	if ( is_wp_error( $child_id ) ) {
+		return $child_id;
+	}
+	wp_set_object_terms( $child_id, $collection_slugs, 'push_md_test_collection', false );
+	wp_set_object_terms( $child_id, $topic_slugs, 'push_md_test_topic', false );
+
+	return rest_ensure_response(
+		array(
+			'child_id'    => $child_id,
+			'path'        => 'push_md_test_doc/' . $parent_slug . '/' . $child_slug . '.md',
+			'collections' => $collection_slugs,
+			'topics'      => $topic_slugs,
+		)
+	);
+}
+
 add_filter( 'push_md_seed_batch_size', static function () {
 	return 5;
 } );

--- a/plugins/push-md/class-push-md-plugin.php
+++ b/plugins/push-md/class-push-md-plugin.php
@@ -55,8 +55,10 @@ class Push_MD_Plugin {
 	const BRANCH_PREVIEWS_OPTION       = 'push_md_branch_previews';
 	const BRANCH_QUERY_PARAM           = 'branch';
 
-	public static $supported_post_types    = array( 'post', 'page' );
-	public static $supported_post_statuses = array( 'publish', 'draft', 'pending', 'private', 'future' );
+	public static $supported_post_types     = array( 'post', 'page' );
+	public static $supported_post_statuses  = array( 'publish', 'draft', 'pending', 'private', 'future' );
+	private static $content_adapters        = array();
+	private static $content_adapters_frozen = false;
 
 	private static $raw_block_post_types = array( 'wp_template', 'wp_template_part', 'wp_navigation' );
 
@@ -78,6 +80,7 @@ class Push_MD_Plugin {
 	);
 
 	public static function bootstrap() {
+		add_action( 'init', array( __CLASS__, 'freeze_content_adapters' ), 100 );
 		add_action( 'init', array( __CLASS__, 'install_default_agent_skill' ), 20 );
 		add_action( 'parse_request', array( __CLASS__, 'maybe_enable_branch_preview' ), 1 );
 		add_action( 'admin_bar_menu', array( __CLASS__, 'add_admin_bar_branch_switcher' ), 90 );
@@ -123,7 +126,7 @@ class Push_MD_Plugin {
 
 	public static function get_supported_post_types() {
 		$post_types = array_merge(
-			self::$supported_post_types,
+			self::get_supported_markdown_post_types(),
 			self::get_existing_raw_block_post_types(),
 			self::get_existing_json_post_types()
 		);
@@ -131,7 +134,154 @@ class Push_MD_Plugin {
 			$post_types[] = 'wp_guideline';
 		}
 
-		return $post_types;
+		return array_values( array_unique( $post_types ) );
+	}
+
+	public static function register_content_adapter( $post_type, $args = array() ) {
+		if ( self::$content_adapters_frozen ) {
+			throw new LogicException( 'Push MD content adapters must be registered before the init hook reaches priority 100.' );
+		}
+
+		$requested_post_type = (string) $post_type;
+		$post_type           = sanitize_key( $requested_post_type );
+		$reserved_post_types = array_merge( self::$supported_post_types, self::$raw_block_post_types, self::$json_post_types, array( 'wp_guideline' ) );
+		if ( '' === $post_type || $post_type !== $requested_post_type || in_array( $post_type, $reserved_post_types, true ) || isset( self::$content_adapters[ $post_type ] ) ) {
+			throw new InvalidArgumentException( 'Push MD content adapters require a unique custom post type.' );
+		}
+
+		$args            = wp_parse_args(
+			$args,
+			array(
+				'hierarchical'       => false,
+				'frontmatter_fields' => array(),
+				'export_metadata'    => null,
+				'validate_metadata'  => null,
+				'apply_metadata'     => null,
+			)
+		);
+		$fields          = array();
+		$reserved_fields = array( 'id', 'title', 'date', 'date_gmt', 'modified_gmt', 'status', 'description', 'slug', 'type' );
+		foreach ( (array) $args['frontmatter_fields'] as $field ) {
+			$requested_field = (string) $field;
+			$field           = sanitize_key( $requested_field );
+			if ( '' === $field || $field !== $requested_field || in_array( $field, $reserved_fields, true ) ) {
+				throw new InvalidArgumentException( 'Push MD adapter front matter fields must be unique custom keys.' );
+			}
+			$fields[] = $field;
+		}
+		if ( count( $fields ) !== count( array_unique( $fields ) ) ) {
+			throw new InvalidArgumentException( 'Push MD adapter front matter fields must not contain duplicates.' );
+		}
+		foreach ( array( 'export_metadata', 'validate_metadata', 'apply_metadata' ) as $callback ) {
+			if ( null !== $args[ $callback ] && ! is_callable( $args[ $callback ] ) ) {
+				throw new InvalidArgumentException( 'Push MD adapter callbacks must be callable.' );
+			}
+		}
+
+		$args['post_type']                    = $post_type;
+		$args['hierarchical']                 = (bool) $args['hierarchical'];
+		$args['frontmatter_fields']           = $fields;
+		self::$content_adapters[ $post_type ] = $args;
+	}
+
+	public static function freeze_content_adapters() {
+		foreach ( self::$content_adapters as $post_type => $adapter ) {
+			if ( ! post_type_exists( $post_type ) ) {
+				throw new LogicException( 'Push MD content adapter post type is not registered: ' . esc_html( $post_type ) );
+			}
+		}
+		self::$content_adapters_frozen = true;
+	}
+
+	private static function get_supported_markdown_post_types() {
+		return array_merge( self::$supported_post_types, array_keys( self::$content_adapters ) );
+	}
+
+	private static function get_content_adapter( $post_type ) {
+		return isset( self::$content_adapters[ $post_type ] ) ? self::$content_adapters[ $post_type ] : null;
+	}
+
+	private static function is_hierarchical_markdown_post_type( $post_type ) {
+		if ( 'page' === $post_type ) {
+			return true;
+		}
+
+		$adapter = self::get_content_adapter( $post_type );
+		return $adapter && ! empty( $adapter['hierarchical'] );
+	}
+
+	private static function export_adapter_metadata( WP_Post $post ) {
+		$adapter = self::get_content_adapter( $post->post_type );
+		if ( ! $adapter || ! $adapter['export_metadata'] ) {
+			return array();
+		}
+
+		$exported = call_user_func( $adapter['export_metadata'], $post );
+		if ( ! is_array( $exported ) ) {
+			throw new UnexpectedValueException( 'Push MD adapter export_metadata callbacks must return an array.' );
+		}
+
+		$metadata = array();
+		foreach ( $exported as $field => $values ) {
+			if ( ! in_array( $field, $adapter['frontmatter_fields'], true ) ) {
+				throw new UnexpectedValueException( 'Push MD adapter exported an undeclared front matter field.' );
+			}
+			$values = is_array( $values ) ? $values : array( $values );
+			$values = array_map(
+				function ( $value ) use ( $field ) {
+					if ( ! is_scalar( $value ) || is_bool( $value ) ) {
+						throw new UnexpectedValueException( 'Push MD adapter front matter values must be scalar: ' . esc_html( $field ) );
+					}
+					return (string) $value;
+				},
+				$values
+			);
+			$values = array_values( array_unique( $values ) );
+			sort( $values, SORT_STRING );
+			$metadata[ $field ] = array( $values );
+		}
+
+		return $metadata;
+	}
+
+	private static function extract_adapter_metadata( $post_type, $raw_metadata ) {
+		$adapter = self::get_content_adapter( $post_type );
+		if ( ! $adapter ) {
+			return array();
+		}
+
+		$metadata = array();
+		foreach ( $adapter['frontmatter_fields'] as $field ) {
+			if ( ! array_key_exists( $field, $raw_metadata ) ) {
+				continue;
+			}
+			$values = is_array( $raw_metadata[ $field ] ) ? $raw_metadata[ $field ] : array( $raw_metadata[ $field ] );
+			if ( 1 === count( $values ) && is_array( reset( $values ) ) ) {
+				$values = reset( $values );
+			}
+			foreach ( $values as $value ) {
+				if ( ! is_scalar( $value ) || is_bool( $value ) ) {
+					throw new Exception( 'Push rejected because adapter front matter values must be scalar strings or numbers.' );
+				}
+			}
+			$metadata[ $field ] = array_values( array_map( 'strval', $values ) );
+		}
+
+		return $metadata;
+	}
+
+	private static function validate_adapter_metadata( $post_type, $metadata, $context ) {
+		$adapter = self::get_content_adapter( $post_type );
+		if ( $adapter && $adapter['validate_metadata'] ) {
+			call_user_func( $adapter['validate_metadata'], $metadata, $context );
+		}
+	}
+
+	private static function apply_adapter_metadata( $post_type, $post_id, $metadata, $context ) {
+		$adapter = self::get_content_adapter( $post_type );
+		if ( $adapter && $adapter['apply_metadata'] ) {
+			call_user_func( $adapter['apply_metadata'], $post_id, $metadata, $context );
+		}
 	}
 
 	private static function guidelines_available() {
@@ -998,11 +1148,11 @@ class Push_MD_Plugin {
 			'filter'                => 'raw',
 		);
 
-		if ( 'page' === $post_type ) {
-			$parent_slugs = self::path_to_page_slugs( $path );
+		if ( self::is_hierarchical_markdown_post_type( $post_type ) ) {
+			$parent_slugs = self::path_to_hierarchical_slugs( $path );
 			array_pop( $parent_slugs );
 			if ( ! empty( $parent_slugs ) ) {
-				$post_obj->post_parent = -1 * abs( crc32( 'page/' . implode( '/', $parent_slugs ) . '.md' ) );
+				$post_obj->post_parent = -1 * abs( crc32( $post_type . '/' . implode( '/', $parent_slugs ) . '.md' ) );
 			}
 		}
 
@@ -1774,8 +1924,8 @@ class Push_MD_Plugin {
 					self::get_post_theme_slug( $post_or_type )
 				);
 			}
-			if ( 'page' === $post_or_type->post_type ) {
-				return self::build_page_markdown_path( $post_or_type );
+			if ( self::is_hierarchical_markdown_post_type( $post_or_type->post_type ) ) {
+				return self::build_hierarchical_markdown_path( $post_or_type );
 			}
 
 			return ltrim( $post_or_type->post_type . '/' . self::get_export_post_slug( $post_or_type ) . '.md', '/' );
@@ -1832,9 +1982,9 @@ class Push_MD_Plugin {
 			return false;
 		}
 
-		if ( 'page' === $post_type ) {
-			foreach ( self::path_to_page_slugs( $path ) as $slug ) {
-				if ( self::get_id_from_fallback_slug( 'page', $slug ) ) {
+		if ( self::is_hierarchical_markdown_post_type( $post_type ) ) {
+			foreach ( self::path_to_hierarchical_slugs( $path ) as $slug ) {
+				if ( self::get_id_from_fallback_slug( $post_type, $slug ) ) {
 					return true;
 				}
 			}
@@ -1857,22 +2007,22 @@ class Push_MD_Plugin {
 		throw new Exception( 'Push rejected because this fallback filename is stale after WordPress assigned the post a slug. Pull the latest changes and edit the slug-based file path.' );
 	}
 
-	private static function build_page_markdown_path( WP_Post $post ) {
+	private static function build_hierarchical_markdown_path( WP_Post $post ) {
 		$segments  = array( self::get_export_post_slug( $post ) );
 		$seen      = array( intval( $post->ID ) => true );
 		$parent_id = intval( $post->post_parent );
 
 		while ( $parent_id > 0 ) {
 			if ( ! empty( $seen[ $parent_id ] ) ) {
-				throw new Exception( 'Git export rejected because a WordPress page hierarchy contains a cycle.' );
+				throw new Exception( 'page' === $post->post_type ? 'Git export rejected because a WordPress page hierarchy contains a cycle.' : 'Git export rejected because a hierarchical WordPress content tree contains a cycle.' );
 			}
 
 			$parent = get_post( $parent_id );
-			if ( ! $parent || 'page' !== $parent->post_type ) {
-				throw new Exception( 'Git export rejected because a WordPress page has an invalid parent.' );
+			if ( ! $parent || $post->post_type !== $parent->post_type ) {
+				throw new Exception( 'page' === $post->post_type ? 'Git export rejected because a WordPress page has an invalid parent.' : 'Git export rejected because hierarchical WordPress content has an invalid parent.' );
 			}
 			if ( ! in_array( $parent->post_status, self::$supported_post_statuses, true ) ) {
-				throw new Exception( 'Git export rejected because a WordPress page has a non-exported parent page. Restore, publish, or reparent the child page before cloning.' );
+				throw new Exception( 'page' === $post->post_type ? 'Git export rejected because a WordPress page has a non-exported parent page. Restore, publish, or reparent the child page before cloning.' : 'Git export rejected because hierarchical WordPress content has a non-exported parent. Restore, publish, or reparent the child before cloning.' );
 			}
 
 			array_unshift( $segments, self::get_export_post_slug( $parent ) );
@@ -1880,7 +2030,7 @@ class Push_MD_Plugin {
 			$parent_id          = intval( $parent->post_parent );
 		}
 
-		return 'page/' . implode( '/', $segments ) . '.md';
+		return $post->post_type . '/' . implode( '/', $segments ) . '.md';
 	}
 
 	private static function build_raw_block_path( $post_type, $slug, $theme_slug = '' ) {
@@ -1978,6 +2128,7 @@ class Push_MD_Plugin {
 		if ( '' !== trim( $post->post_excerpt ) ) {
 			$metadata['description'] = array( $post->post_excerpt );
 		}
+		$metadata = array_merge( $metadata, self::export_adapter_metadata( $post ) );
 
 		$producer = new MarkdownProducer(
 			new BlocksWithMetadata(
@@ -2274,7 +2425,7 @@ class Push_MD_Plugin {
 		self::reject_deleted_raw_block_files( $old_files, $new_files );
 		self::reject_deleted_theme_base_files( $old_files, $new_files );
 		self::reject_deleted_global_styles_files( $old_files, $new_files );
-		self::reject_deleted_page_parent_files_with_remaining_children( $old_files, $new_files );
+		self::reject_deleted_hierarchical_parent_files_with_remaining_children( $old_files, $new_files );
 
 		foreach ( $new_files as $path => $entry ) {
 			if ( isset( $old_files[ $path ] ) && self::repository_entries_match( $old_files[ $path ], $entry ) ) {
@@ -2311,7 +2462,7 @@ class Push_MD_Plugin {
 		self::reject_deleted_raw_block_files( $old_files, $new_files );
 		self::reject_deleted_theme_base_files( $old_files, $new_files );
 		self::reject_deleted_global_styles_files( $old_files, $new_files );
-		self::reject_deleted_page_parent_files_with_remaining_children( $old_files, $new_files );
+		self::reject_deleted_hierarchical_parent_files_with_remaining_children( $old_files, $new_files );
 
 		foreach ( $new_files as $path => $entry ) {
 			if ( isset( $old_files[ $path ] ) && self::repository_entries_match( $old_files[ $path ], $entry ) ) {
@@ -2483,16 +2634,16 @@ class Push_MD_Plugin {
 		}
 	}
 
-	private static function reject_deleted_page_parent_files_with_remaining_children( $old_files, $new_files ) {
+	private static function reject_deleted_hierarchical_parent_files_with_remaining_children( $old_files, $new_files ) {
 		foreach ( $old_files as $path => $entry ) {
 			if ( isset( $new_files[ $path ] ) ) {
 				continue;
 			}
-			if ( TreeEntry::FILE_MODE_SYMBOLIC_LINK === $entry['mode'] || ! self::is_page_markdown_path( $path ) ) {
+			if ( TreeEntry::FILE_MODE_SYMBOLIC_LINK === $entry['mode'] || ! self::is_hierarchical_markdown_path( $path ) ) {
 				continue;
 			}
 
-			$descendant_prefix = self::page_descendant_prefix_from_path( $path );
+			$descendant_prefix = self::hierarchical_descendant_prefix_from_path( $path );
 			if ( '' === $descendant_prefix ) {
 				continue;
 			}
@@ -2500,26 +2651,28 @@ class Push_MD_Plugin {
 			foreach ( $new_files as $new_path => $new_entry ) {
 				unset( $new_entry );
 				if ( 0 === strpos( $new_path, $descendant_prefix ) ) {
-					throw new Exception( 'Push rejected because deleting a parent page while keeping nested child page files would move child content. Delete the nested child page files too, or keep the parent page.' );
+					$post_type = self::path_to_post_type( $path );
+					throw new Exception( 'page' === $post_type ? 'Push rejected because deleting a parent page while keeping nested child page files would move child content. Delete the nested child page files too, or keep the parent page.' : 'Push rejected because deleting hierarchical parent content while keeping nested child files would move child content. Delete the nested child files too, or keep the parent.' );
 				}
 			}
 		}
 	}
 
-	private static function is_page_markdown_path( $path ) {
+	private static function is_hierarchical_markdown_path( $path ) {
 		$segments = explode( '/', ltrim( $path, '/' ) );
 		return isset( $segments[0] )
-			&& 'page' === $segments[0]
+			&& self::is_hierarchical_markdown_post_type( $segments[0] )
 			&& 'md' === pathinfo( basename( $path ), PATHINFO_EXTENSION );
 	}
 
-	private static function page_descendant_prefix_from_path( $path ) {
-		$relative_path = substr( ltrim( $path, '/' ), strlen( 'page/' ) );
+	private static function hierarchical_descendant_prefix_from_path( $path ) {
+		$post_type     = self::path_to_post_type( $path );
+		$relative_path = substr( ltrim( $path, '/' ), strlen( $post_type . '/' ) );
 		if ( '.md' !== substr( $relative_path, - strlen( '.md' ) ) ) {
 			return '';
 		}
 
-		return 'page/' . substr( $relative_path, 0, - strlen( '.md' ) ) . '/';
+		return $post_type . '/' . substr( $relative_path, 0, - strlen( '.md' ) ) . '/';
 	}
 
 	private static function reject_symlink_file_changes( $old_files, $new_files ) {
@@ -2571,18 +2724,30 @@ class Push_MD_Plugin {
 		$consumer = new MarkdownConsumer( $markdown );
 		$result   = $consumer->consume();
 		self::assert_block_markup_is_safe( $result->get_block_markup() );
-		$metadata = array();
-		foreach ( $result->get_all_metadata() as $key => $value ) {
+		$raw_metadata     = $result->get_all_metadata();
+		$adapter_metadata = self::extract_adapter_metadata( $post_type, $raw_metadata );
+		$metadata         = array();
+		foreach ( $raw_metadata as $key => $value ) {
+			if ( array_key_exists( $key, $adapter_metadata ) ) {
+				continue;
+			}
 			$metadata[ $key ] = is_array( $value ) ? reset( $value ) : $value;
 		}
 
 		self::reject_path_identity_frontmatter( $metadata );
-		$metadata      = self::normalize_supported_frontmatter(
+		$metadata        = self::normalize_supported_frontmatter(
 			$metadata,
 			array( 'id', 'title', 'date', 'status', 'description' )
 		);
-		$post_id       = self::find_post_id_by_path_metadata( $path, $metadata );
-		$existing_post = $post_id ? get_post( $post_id ) : null;
+		$post_id         = self::find_post_id_by_path_metadata( $path, $metadata );
+		$existing_post   = $post_id ? get_post( $post_id ) : null;
+		$adapter_context = array(
+			'path'          => $path,
+			'post_type'     => $post_type,
+			'existing_post' => $existing_post,
+			'dry_run'       => ! empty( $options['dry_run'] ),
+		);
+		self::validate_adapter_metadata( $post_type, $adapter_metadata, $adapter_context );
 		if ( $existing_post ) {
 			self::assert_id_fallback_path_is_current( $path, $existing_post );
 		}
@@ -2592,7 +2757,7 @@ class Push_MD_Plugin {
 		);
 		self::validate_post_status( $post_status, $post_type );
 		self::assert_can_set_post_status( $post_type, $post_status, $existing_post );
-		$post_parent = 'page' === $post_type ? self::path_to_page_parent_id( $path, false ) : 0;
+		$post_parent = self::is_hierarchical_markdown_post_type( $post_type ) ? self::path_to_hierarchical_parent_id( $path, false ) : 0;
 
 		if (
 			$existing_post &&
@@ -2618,7 +2783,7 @@ class Push_MD_Plugin {
 		if ( ! $existing_post || ! self::is_current_slugless_fallback_path( $path, $existing_post ) ) {
 			$postarr['post_name'] = $slug;
 		}
-		if ( 'page' === $post_type ) {
+		if ( self::is_hierarchical_markdown_post_type( $post_type ) ) {
 			$postarr['post_parent'] = $post_parent;
 		}
 
@@ -2652,7 +2817,10 @@ class Push_MD_Plugin {
 			throw new Exception( esc_html( $post_id->get_error_message() ) );
 		}
 
-		$post = get_post( $post_id );
+		$post                             = get_post( $post_id );
+		$adapter_context['existing_post'] = $post;
+		$adapter_context['dry_run']       = false;
+		self::apply_adapter_metadata( $post_type, $post_id, $adapter_metadata, $adapter_context );
 
 		return array(
 			'post_id' => $post_id,
@@ -3335,7 +3503,7 @@ class Push_MD_Plugin {
 	}
 
 	private static function get_preview_page_permalink_for_path( $path ) {
-		$page_path = implode( '/', self::path_to_page_slugs( $path ) );
+		$page_path = implode( '/', self::path_to_hierarchical_slugs( $path ) );
 		if ( '' === (string) get_option( 'permalink_structure' ) ) {
 			return add_query_arg( 'pagename', $page_path, home_url( '/' ) );
 		}
@@ -3878,12 +4046,12 @@ class Push_MD_Plugin {
 				$include_trash
 			);
 		}
-		if ( 'page' === $post_type ) {
+		if ( self::is_hierarchical_markdown_post_type( $post_type ) ) {
 			if ( isset( $metadata['id'] ) ) {
 				return self::find_post_id_by_frontmatter_id( $path, $metadata, $include_trash );
 			}
 
-			return self::find_page_id_by_path( $path, $include_trash );
+			return self::find_hierarchical_post_id_by_path( $path, $include_trash );
 		}
 
 		if ( isset( $metadata['id'] ) ) {
@@ -3970,16 +4138,17 @@ class Push_MD_Plugin {
 		return intval( $id );
 	}
 
-	private static function find_page_id_by_path( $path, $include_trash = true ) {
-		$slugs     = self::path_to_page_slugs( $path );
+	private static function find_hierarchical_post_id_by_path( $path, $include_trash = true ) {
+		$post_type = self::path_to_post_type( $path );
+		$slugs     = self::path_to_hierarchical_slugs( $path );
 		$slug      = array_pop( $slugs );
-		$parent_id = self::resolve_page_parent_id( $slugs, $include_trash );
+		$parent_id = self::resolve_hierarchical_parent_id( $post_type, $slugs, $include_trash );
 		$statuses  = $include_trash
 			? array_merge( self::$supported_post_statuses, array( 'trash' ) )
 			: self::$supported_post_statuses;
 		$posts     = get_posts(
 			array(
-				'post_type'      => 'page',
+				'post_type'      => $post_type,
 				'name'           => $slug,
 				'post_parent'    => $parent_id,
 				'post_status'    => $statuses,
@@ -3989,19 +4158,19 @@ class Push_MD_Plugin {
 		);
 
 		if ( empty( $posts ) ) {
-			$page_id = self::find_slugless_page_id_by_fallback_slug( $slug, $parent_id, $statuses );
-			if ( $page_id ) {
-				return $page_id;
+			$post_id = self::find_slugless_hierarchical_id_by_fallback_slug( $post_type, $slug, $parent_id, $statuses );
+			if ( $post_id ) {
+				return $post_id;
 			}
 
 			if ( ! $include_trash ) {
-				self::reject_unsupported_status_slug_collision( 'page', $slug, self::$supported_post_statuses, $parent_id );
+				self::reject_unsupported_status_slug_collision( $post_type, $slug, self::$supported_post_statuses, $parent_id );
 				return 0;
 			}
 
 			$posts = get_posts(
 				array(
-					'post_type'      => 'page',
+					'post_type'      => $post_type,
 					'name'           => $slug . '__trashed',
 					'post_parent'    => $parent_id,
 					'post_status'    => array( 'trash' ),
@@ -4010,13 +4179,13 @@ class Push_MD_Plugin {
 				)
 			);
 			if ( empty( $posts ) ) {
-				$page_id = self::find_slugless_page_id_by_fallback_slug( $slug, $parent_id, array( 'trash' ) );
-				if ( $page_id ) {
-					return $page_id;
+				$post_id = self::find_slugless_hierarchical_id_by_fallback_slug( $post_type, $slug, $parent_id, array( 'trash' ) );
+				if ( $post_id ) {
+					return $post_id;
 				}
 
 				self::reject_unsupported_status_slug_collision(
-					'page',
+					$post_type,
 					$slug,
 					array_merge( self::$supported_post_statuses, array( 'trash' ) ),
 					$parent_id
@@ -4028,7 +4197,7 @@ class Push_MD_Plugin {
 		return intval( $posts[0] );
 	}
 
-	private static function resolve_page_parent_id( $parent_slugs, $include_trash = true ) {
+	private static function resolve_hierarchical_parent_id( $post_type, $parent_slugs, $include_trash = true ) {
 		$parent_id = 0;
 		$statuses  = $include_trash
 			? array_merge( self::$supported_post_statuses, array( 'trash' ) )
@@ -4037,7 +4206,7 @@ class Push_MD_Plugin {
 		foreach ( $parent_slugs as $slug ) {
 			$parents = get_posts(
 				array(
-					'post_type'      => 'page',
+					'post_type'      => $post_type,
 					'name'           => $slug,
 					'post_parent'    => $parent_id,
 					'post_status'    => $statuses,
@@ -4046,12 +4215,12 @@ class Push_MD_Plugin {
 				)
 			);
 			if ( empty( $parents ) ) {
-				$page_id = self::find_slugless_page_id_by_fallback_slug( $slug, $parent_id, $statuses );
-				if ( ! $page_id ) {
-					throw new Exception( 'Push rejected because nested page paths must reference existing WordPress parent pages.' );
+				$post_id = self::find_slugless_hierarchical_id_by_fallback_slug( $post_type, $slug, $parent_id, $statuses );
+				if ( ! $post_id ) {
+					throw new Exception( 'page' === $post_type ? 'Push rejected because nested page paths must reference existing WordPress parent pages.' : 'Push rejected because nested paths must reference existing WordPress parent content.' );
 				}
 
-				$parent_id = $page_id;
+				$parent_id = $post_id;
 				continue;
 			}
 
@@ -4061,8 +4230,8 @@ class Push_MD_Plugin {
 		return $parent_id;
 	}
 
-	private static function find_slugless_page_id_by_fallback_slug( $slug, $parent_id, $statuses ) {
-		$id = self::get_id_from_fallback_slug( 'page', $slug );
+	private static function find_slugless_hierarchical_id_by_fallback_slug( $post_type, $slug, $parent_id, $statuses ) {
+		$id = self::get_id_from_fallback_slug( $post_type, $slug );
 		if ( ! $id ) {
 			return 0;
 		}
@@ -4070,7 +4239,7 @@ class Push_MD_Plugin {
 		$post = get_post( $id );
 		if (
 			! $post ||
-			'page' !== $post->post_type ||
+			$post_type !== $post->post_type ||
 			'' !== $post->post_name ||
 			intval( $post->post_parent ) !== intval( $parent_id ) ||
 			! in_array( $post->post_status, $statuses, true )
@@ -4081,11 +4250,12 @@ class Push_MD_Plugin {
 		return intval( $post->ID );
 	}
 
-	private static function path_to_page_parent_id( $path, $include_trash = true ) {
-		$slugs = self::path_to_page_slugs( $path );
+	private static function path_to_hierarchical_parent_id( $path, $include_trash = true ) {
+		$post_type = self::path_to_post_type( $path );
+		$slugs     = self::path_to_hierarchical_slugs( $path );
 		array_pop( $slugs );
 
-		return self::resolve_page_parent_id( $slugs, $include_trash );
+		return self::resolve_hierarchical_parent_id( $post_type, $slugs, $include_trash );
 	}
 
 	private static function reject_unsupported_status_slug_collision( $post_type, $slug, $allowed_statuses, $post_parent = null ) {
@@ -4197,8 +4367,8 @@ class Push_MD_Plugin {
 		if ( 'post' === $segments[0] && 2 !== count( $segments ) ) {
 			throw new Exception( 'Push rejected because post Markdown files must use post/<slug>.md paths.' );
 		}
-		if ( 'page' === $segments[0] ) {
-			$slugs = self::path_to_page_slugs( $path );
+		if ( self::is_hierarchical_markdown_post_type( $segments[0] ) ) {
+			$slugs = self::path_to_hierarchical_slugs( $path );
 
 			return end( $slugs );
 		}
@@ -4214,10 +4384,10 @@ class Push_MD_Plugin {
 		return $slug;
 	}
 
-	private static function path_to_page_slugs( $path ) {
+	private static function path_to_hierarchical_slugs( $path ) {
 		$segments = explode( '/', ltrim( $path, '/' ) );
-		if ( count( $segments ) < 2 || 'page' !== $segments[0] ) {
-			throw new Exception( 'Push rejected because page Markdown files must use page/<slug>.md or page/<parent>/<slug>.md paths.' );
+		if ( count( $segments ) < 2 || ! self::is_hierarchical_markdown_post_type( $segments[0] ) ) {
+			throw new Exception( isset( $segments[0] ) && 'page' === $segments[0] ? 'Push rejected because page Markdown files must use page/<slug>.md or page/<parent>/<slug>.md paths.' : 'Push rejected because hierarchical Markdown files must use <post-type>/<slug>.md or <post-type>/<parent>/<slug>.md paths.' );
 		}
 
 		$basename = array_pop( $segments );

--- a/plugins/push-md/docs/README.md
+++ b/plugins/push-md/docs/README.md
@@ -65,6 +65,8 @@ changes back through WordPress post APIs.
 Supported exported content includes:
 
 - Posts and pages as Markdown files.
+- Custom post types explicitly registered by another plugin through a Push MD
+  content adapter.
 - Block theme templates, template parts, and navigation posts as raw Gutenberg
   block HTML.
 - Active theme `theme.json` files as read-only context.
@@ -73,7 +75,41 @@ Supported exported content includes:
   features are available.
 
 Push MD does not deploy PHP code, plugin code, theme source, uploads, media
-files, arbitrary custom post types, or arbitrary database tables.
+files, unregistered custom post types, or arbitrary database tables.
+
+## Content Adapters
+
+Plugins may register an explicit custom post type mapping on `init` before
+priority 100. The post type must be registered before Push MD freezes the
+adapter registry:
+
+```php
+push_md_register_content_adapter(
+	'book',
+	array(
+		'hierarchical'       => true,
+		'frontmatter_fields' => array( 'genres' ),
+		'export_metadata'    => 'my_exported_book_metadata',
+		'validate_metadata'  => 'my_validate_book_metadata',
+		'apply_metadata'     => 'my_apply_book_metadata',
+	)
+);
+```
+
+`export_metadata( WP_Post $post )` returns declared field values. Push MD
+normalizes each field to a sorted, unique array of scalar strings.
+`validate_metadata( array $metadata, array $context )` runs during the dry-run
+plan before WordPress is changed. `apply_metadata( int $post_id, array
+$metadata, array $context )` applies the already validated values after the
+post write. The context contains `path`, `post_type`, `existing_post`, and
+`dry_run`.
+
+Adapters are fail-closed: post type keys and front matter keys must be
+canonical and unique, callbacks must be callable, Push MD-owned front matter
+keys are reserved, and an adapter whose post type is absent at `init` priority
+100 stops initialization. Hierarchical adapters use nested
+`<post-type>/<parent>/<item>.md` paths and require parent content to exist
+before a nested child is pushed.
 
 ## Privacy And Security Model
 

--- a/plugins/push-md/functions.php
+++ b/plugins/push-md/functions.php
@@ -4,6 +4,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! function_exists( 'push_md_register_content_adapter' ) ) {
+	/**
+	 * Registers an explicit custom post type mapping for Push MD.
+	 *
+	 * Register the post type and adapter on init before priority 100.
+	 *
+	 * @param string $post_type Custom post type key.
+	 * @param array  $args      Adapter configuration and callbacks.
+	 */
+	function push_md_register_content_adapter( $post_type, $args = array() ) {
+		Push_MD_Plugin::register_content_adapter( $post_type, $args );
+	}
+}
+
 if ( ! function_exists( 'push_md_install_skill' ) ) {
 	function push_md_install_skill( string $source_identifier, string $title, string $excerpt, string $content, array $extras = array() ) {
 		if ( '' === $source_identifier ) {


### PR DESCRIPTION
## Summary

- add a fail-closed Push MD content adapter registry for plugin-defined custom post types
- route export, import, hierarchy, permissions, seeding, and branch previews through registered adapters
- preserve JSON array front matter values for deterministic adapter metadata such as taxonomies
- document the public registration contract and cover a hierarchical CPT end to end

Closes #79.

Consumer: https://github.com/chubes4/wp-docs/issues/19

## How to test

1. Run `composer install`.
2. Run `vendor/bin/phpunit components/Markdown/Tests/MarkdownConsumerTest.php`.
3. Run `vendor/bin/phpunit --filter PMD_Export_Path_Test plugins/push-md/Tests`.
4. Run `vendor/bin/phpunit plugins/push-md/Tests/BranchPreviewTest.php`.
5. Run `vendor/bin/phpcs -d memory_limit=1G components/Markdown/class-markdownconsumer.php components/Markdown/Tests/MarkdownConsumerTest.php plugins/push-md/functions.php plugins/push-md/class-push-md-plugin.php plugins/push-md/Tests/BranchPreviewTest.php plugins/push-md/Tests/EndToEndTest.php plugins/push-md/Tests/ExportPathTest.php plugins/push-md/Tests/ci-mu-test-helper.php`.
6. Run `bash bin/test-push-md-git-actions.sh` in the repository-supported Docker environment to exercise clone, push, hierarchy, metadata, stale-state, and trash behavior against WordPress.

## Verification

- Markdown consumer: 26 tests, 26 assertions passed.
- Adapter export/path tests: 15 tests, 17 assertions passed.
- Branch preview tests: 7 tests, 19 assertions passed.
- PHPCS passes for all changed PHP files.
- Repository-wide `composer lint` remains blocked by existing PHP 8.5 `curl_close()` deprecation errors in `components/HttpClient/Transport/class-curltransport.php` and `components/CORSProxy/cors-proxy.php`, outside this diff.

## Compatibility

Existing built-in Push MD paths and behavior remain unchanged. This adds the public `push_md_register_content_adapter()` extension path; adapters register before `init` priority 100 and fail closed on invalid or late registration.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Implementing the adapter registry, tests, documentation, verification, and PR preparation in collaboration with Chris Huber.
